### PR TITLE
wiki: HowTo schema on the missed-registration page

### DIFF
--- a/app/[locale]/wiki/troubleshooting/nis2-registrierung-verpasst/page.tsx
+++ b/app/[locale]/wiki/troubleshooting/nis2-registrierung-verpasst/page.tsx
@@ -48,6 +48,13 @@ export default async function MissedRegistrationPage({ params }: { params: Promi
     },
   }));
 
+  const howToSteps = stepKeys.map((key, index) => ({
+    "@type": "HowToStep" as const,
+    position: index + 1,
+    name: t(`missedRegistration.steps.items.${key}.title`),
+    text: t(`missedRegistration.steps.items.${key}.description`),
+  }));
+
   return (
     <GlossedProse locale={locale}>
     <div className="space-y-10">
@@ -67,6 +74,15 @@ export default async function MissedRegistrationPage({ params }: { params: Promi
           "@context": "https://schema.org",
           "@type": "FAQPage",
           mainEntity: faqs,
+        }}
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "HowTo",
+          name: t("missedRegistration.steps.heading"),
+          description: t("missedRegistration.steps.description"),
+          step: howToSteps,
         }}
       />
 


### PR DESCRIPTION
Adds HowTo structured data to `/wiki/troubleshooting/nis2-registrierung-verpasst` for the five recovery steps, making the procedural query eligible for how-to rich results. Reads the existing translated step content, so no content or translation changes. Closes the one SEO gap the SERP research flagged for this otherwise-mature page (it already had FAQPage schema, §33/§65/§30/§38 coverage, and the no-fear framing). Typecheck: no new errors.