### PR TITLE
fix(docker): pin webpack build to stop Turbopack OOM on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,12 @@ ENV NODE_OPTIONS=--max-old-space-size=4096
 # --add-host. They run at container startup instead, via
 # scripts/runtime-migrate.mjs, which the runner stage's ENTRYPOINT
 # chains before exec'ing node server.js.
-RUN node node_modules/next/dist/bin/next build
+#
+# --webpack pins the webpack builder. Next 16 runs `next build` on
+# Turbopack by default, whose compile peaks well past the 4GB heap set
+# above and gets OOM-killed (exit 137) on the Coolify builder. The 4GB
+# tuning and this app's Tailwind v4 setup target webpack; keep it there.
+RUN node node_modules/next/dist/bin/next build --webpack
 
 # -----------------------------------------------------------------------------
 # Stage 3: runner


### PR DESCRIPTION
## Problem
The Coolify production deploy has failed since ~2026-07-05 with an OOM kill (`exit code: 137`, `Killed`) during `next build`. The build log shows `Next.js 16.2.7 (Turbopack)` — Next 16 runs `next build` on Turbopack by default. Turbopack's compile peaks past the 4GB heap the builder stage is tuned for, so the OOM killer terminates it. As a result none of the recent merges (bsig-38, timeline sweep, dependency bumps) are live; the site is still serving the last build that succeeded before then.

## Fix
Pin the build to webpack with `next build --webpack`. The Dockerfile's own comment ("Webpack + Next 16 + ~200 routes needs 4GB heap"), the `build:webpack` script, and this app's Tailwind v4 setup all target webpack — Turbopack build was an unintended default from the Next 16 upgrade.

## Fallback
If the deploy still OOMs after this, the cause is builder RAM (the Coolify host / build resource limit is under ~5GB); the next step there is more build memory, not a code change.