### PR TITLE
feat(nav): GitHub icon in the public navbar

### DIFF
--- a/components/PublicNav.tsx
+++ b/components/PublicNav.tsx
@@ -7,6 +7,25 @@ import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { auth } from "@/lib/auth/config";
 import { getInitials } from "@/lib/utils";
 
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+}
+
 export async function PublicNav() {
   const t = await getTranslations("landing");
   const session = await auth();
@@ -32,6 +51,16 @@ export async function PublicNav() {
             {t("nav.about")}
           </Link>
           <div className="flex items-center gap-2">
+            <a
+              href="https://github.com/NISD2/open-isms"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open ISMS on GitHub"
+              title="Open ISMS on GitHub"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <GithubIcon className="size-5" />
+            </a>
             <LocaleSwitcher />
             {user ? (
               <Button size="sm" variant="outline" asChild>


### PR DESCRIPTION
Adds a GitHub icon to the top-right of the marketing navbar, to the left of the language switcher, linking to https://github.com/NISD2/open-isms. Reuses the outline GitHub mark already used on the About page (matches the navbar's stroke icons) with the same muted-foreground hover as the other nav items. Opens in a new tab (rel=noopener), aria-label + title for accessibility. Typecheck clean.