### PR TITLE
fix(training): let users edit the name printed on their certificate

### DIFF
--- a/components/training-portal/CertificateDownload.tsx
+++ b/components/training-portal/CertificateDownload.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
+import { trpc } from "@/lib/trpc/client";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Download, CheckCircle2, Lock } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Download, CheckCircle2, Lock, Pencil } from "lucide-react";
 
 interface CertificateDownloadProps {
   courseId: string;
@@ -21,7 +27,14 @@ export function CertificateDownload({
   totalCount,
   userName,
 }: CertificateDownloadProps) {
+  const t = useTranslations("trainingPortal.certificate");
   const remaining = totalCount - completedCount;
+  const router = useRouter();
+  const [name, setName] = useState(userName ?? "");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const updateName = trpc.user.updateName.useMutation();
 
   if (!allCompleted) {
     return (
@@ -29,14 +42,12 @@ export function CertificateDownload({
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <Lock className="size-4 text-muted-foreground" />
-            {locale === "de" ? "Teilnahmebescheinigung" : "Certificate of Completion"}
+            {t("lockedTitle")}
           </CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            {locale === "de"
-              ? `Schließen Sie alle Lektionen ab, um Ihre Bescheinigung herunterzuladen. Noch ${remaining} von ${totalCount} Lektionen offen.`
-              : `Complete all lessons to download your certificate. ${remaining} of ${totalCount} lessons remaining.`}
+            {t("lockedText", { remaining, total: totalCount })}
           </p>
           <div className="mt-3 h-2 w-full rounded-full bg-muted">
             <div
@@ -56,30 +67,104 @@ export function CertificateDownload({
     );
   }
 
+  function startEditing() {
+    setDraft(name);
+    setEditing(true);
+  }
+
+  function handleSave() {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+
+    startTransition(async () => {
+      try {
+        await updateName.mutateAsync({ name: trimmed });
+        setName(trimmed);
+        setEditing(false);
+        toast.success(t("nameSaved"));
+        router.refresh();
+      } catch {
+        toast.error(t("nameSaveError"));
+      }
+    });
+  }
+
   return (
     <Card className="border-primary/30 bg-primary/5">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <CheckCircle2 className="size-4 text-primary" />
-          {locale === "de" ? "Kurs abgeschlossen" : "Course Complete"}
+          {t("completeTitle")}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-sm text-muted-foreground">
-          {locale === "de"
-            ? `${userName ?? "Sie haben"} alle ${totalCount} Lektionen abgeschlossen. Laden Sie Ihre Teilnahmebescheinigung herunter.`
-            : `${userName ?? "You"} completed all ${totalCount} lessons. Download your certificate below.`}
+          {t("completeText", { total: totalCount })}
         </p>
-        <Button onClick={handleDownload} className="gap-2">
+        <div className="rounded-md border bg-background p-3">
+          <label
+            htmlFor="certificate-name"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            {t("nameLabel")}
+          </label>
+          {editing ? (
+            <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+              <Input
+                id="certificate-name"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSave();
+                  if (e.key === "Escape") setEditing(false);
+                }}
+                maxLength={255}
+                autoFocus
+                placeholder={t("namePlaceholder")}
+                disabled={isPending}
+              />
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={isPending || draft.trim().length === 0}
+                >
+                  {t("save")}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setEditing(false)}
+                  disabled={isPending}
+                >
+                  {t("cancel")}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-1 flex items-center justify-between gap-2">
+              <span className="text-sm font-medium">
+                {name || t("noNameSet")}
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1.5"
+                onClick={startEditing}
+              >
+                <Pencil className="size-3.5" />
+                {t("edit")}
+              </Button>
+            </div>
+          )}
+          <p className="mt-2 text-xs text-muted-foreground">{t("nameHint")}</p>
+        </div>
+        <Button onClick={handleDownload} className="gap-2" disabled={editing}>
           <Download className="size-4" />
-          {locale === "de"
-            ? "Bescheinigung herunterladen"
-            : "Download Certificate"}
+          {t("download")}
         </Button>
         <p className="text-xs text-muted-foreground">
-          {locale === "de"
-            ? "Wird als PDF heruntergeladen. Sie können die Datei speichern oder ausdrucken."
-            : "Downloads as a PDF you can save or print."}
+          {editing ? t("finishEditingHint") : t("downloadHint")}
         </p>
       </CardContent>
     </Card>

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -311,6 +311,7 @@ export const getSession = cache(async (): Promise<Session | null> => {
     where: eq(user.email, session.user.email),
     columns: {
       id: true,
+      name: true,
       companyId: true,
       role: true,
       jobTitle: true,
@@ -329,6 +330,9 @@ export const getSession = cache(async (): Promise<Session | null> => {
   }
 
   session.user.id = dbUser.id;
+  // DB name wins over the JWT snapshot so an in-app name change (e.g. fixing
+  // the name printed on a training certificate) shows up without re-login.
+  session.user.name = dbUser.name;
   session.companyId = dbUser.companyId;
   session.role = dbUser.role;
   session.jobTitle = dbUser.jobTitle ?? null;

--- a/messages/trainingPortal/cs.json
+++ b/messages/trainingPortal/cs.json
@@ -40,6 +40,24 @@
       "incorrect": "Nesprávně"
     },
     "progressLabel": "Dokončeno {completed} z {total} lekcí",
-    "estimatedTime": "{minutes} min čtení"
+    "estimatedTime": "{minutes} min čtení",
+    "certificate": {
+      "lockedTitle": "Osvědčení o absolvování",
+      "lockedText": "Dokončete všechny lekce a stáhněte si osvědčení. Zbývá {remaining} z {total} lekcí.",
+      "completeTitle": "Kurz dokončen",
+      "completeText": "Dokončili jste všech {total} lekcí. Níže si můžete stáhnout osvědčení.",
+      "nameLabel": "Jméno na osvědčení",
+      "namePlaceholder": "Celé jméno",
+      "noNameSet": "Jméno není vyplněno",
+      "nameHint": "Toto jméno bude vytištěno na osvědčení.",
+      "edit": "Upravit",
+      "save": "Uložit",
+      "cancel": "Zrušit",
+      "nameSaved": "Jméno uloženo",
+      "nameSaveError": "Jméno se nepodařilo uložit",
+      "download": "Stáhnout osvědčení",
+      "downloadHint": "Stáhne se jako PDF, které můžete uložit nebo vytisknout.",
+      "finishEditingHint": "Nejprve uložte nebo zrušte změnu jména."
+    }
   }
 }

--- a/messages/trainingPortal/de.json
+++ b/messages/trainingPortal/de.json
@@ -40,6 +40,24 @@
       "incorrect": "Falsch"
     },
     "progressLabel": "{completed} von {total} Lektionen abgeschlossen",
-    "estimatedTime": "{minutes} Min. Lesezeit"
+    "estimatedTime": "{minutes} Min. Lesezeit",
+    "certificate": {
+      "lockedTitle": "Teilnahmebescheinigung",
+      "lockedText": "Schließen Sie alle Lektionen ab, um Ihre Bescheinigung herunterzuladen. Noch {remaining} von {total} Lektionen offen.",
+      "completeTitle": "Kurs abgeschlossen",
+      "completeText": "Sie haben alle {total} Lektionen abgeschlossen. Laden Sie Ihre Teilnahmebescheinigung herunter.",
+      "nameLabel": "Name auf der Bescheinigung",
+      "namePlaceholder": "Vollständiger Name",
+      "noNameSet": "Kein Name hinterlegt",
+      "nameHint": "Dieser Name wird auf die Bescheinigung gedruckt.",
+      "edit": "Ändern",
+      "save": "Speichern",
+      "cancel": "Abbrechen",
+      "nameSaved": "Name gespeichert",
+      "nameSaveError": "Name konnte nicht gespeichert werden",
+      "download": "Bescheinigung herunterladen",
+      "downloadHint": "Wird als PDF heruntergeladen. Sie können die Datei speichern oder ausdrucken.",
+      "finishEditingHint": "Speichern oder verwerfen Sie zuerst die Namensänderung."
+    }
   }
 }

--- a/messages/trainingPortal/en.json
+++ b/messages/trainingPortal/en.json
@@ -40,6 +40,24 @@
       "incorrect": "Incorrect"
     },
     "progressLabel": "{completed} of {total} lessons completed",
-    "estimatedTime": "{minutes} min read"
+    "estimatedTime": "{minutes} min read",
+    "certificate": {
+      "lockedTitle": "Certificate of Completion",
+      "lockedText": "Complete all lessons to download your certificate. {remaining} of {total} lessons remaining.",
+      "completeTitle": "Course Complete",
+      "completeText": "You completed all {total} lessons. Download your certificate below.",
+      "nameLabel": "Name on the certificate",
+      "namePlaceholder": "Full name",
+      "noNameSet": "No name set",
+      "nameHint": "This name is printed on the certificate.",
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel",
+      "nameSaved": "Name saved",
+      "nameSaveError": "Could not save your name",
+      "download": "Download Certificate",
+      "downloadHint": "Downloads as a PDF you can save or print.",
+      "finishEditingHint": "Save or cancel the name change first."
+    }
   }
 }

--- a/messages/trainingPortal/es.json
+++ b/messages/trainingPortal/es.json
@@ -40,6 +40,24 @@
       "incorrect": "Incorrecto"
     },
     "progressLabel": "{completed} de {total} lecciones completadas",
-    "estimatedTime": "{minutes} min de lectura"
+    "estimatedTime": "{minutes} min de lectura",
+    "certificate": {
+      "lockedTitle": "Certificado de finalización",
+      "lockedText": "Complete todas las lecciones para descargar su certificado. Le quedan {remaining} de {total} lecciones.",
+      "completeTitle": "Curso completado",
+      "completeText": "Ha completado las {total} lecciones. Descargue su certificado a continuación.",
+      "nameLabel": "Nombre en el certificado",
+      "namePlaceholder": "Nombre completo",
+      "noNameSet": "Sin nombre indicado",
+      "nameHint": "Este nombre se imprime en el certificado.",
+      "edit": "Editar",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "nameSaved": "Nombre guardado",
+      "nameSaveError": "No se pudo guardar el nombre",
+      "download": "Descargar certificado",
+      "downloadHint": "Se descarga como PDF que puede guardar o imprimir.",
+      "finishEditingHint": "Guarde o cancele primero el cambio de nombre."
+    }
   }
 }

--- a/messages/trainingPortal/fr.json
+++ b/messages/trainingPortal/fr.json
@@ -40,6 +40,24 @@
       "incorrect": "Incorrect"
     },
     "progressLabel": "{completed} sur {total} leçons terminées",
-    "estimatedTime": "{minutes} min de lecture"
+    "estimatedTime": "{minutes} min de lecture",
+    "certificate": {
+      "lockedTitle": "Attestation de réussite",
+      "lockedText": "Terminez toutes les leçons pour télécharger votre attestation. Encore {remaining} leçons sur {total}.",
+      "completeTitle": "Cours terminé",
+      "completeText": "Vous avez terminé les {total} leçons. Téléchargez votre attestation ci-dessous.",
+      "nameLabel": "Nom sur l'attestation",
+      "namePlaceholder": "Nom complet",
+      "noNameSet": "Aucun nom renseigné",
+      "nameHint": "Ce nom sera imprimé sur l'attestation.",
+      "edit": "Modifier",
+      "save": "Enregistrer",
+      "cancel": "Annuler",
+      "nameSaved": "Nom enregistré",
+      "nameSaveError": "Le nom n'a pas pu être enregistré",
+      "download": "Télécharger l'attestation",
+      "downloadHint": "Téléchargée au format PDF, à enregistrer ou à imprimer.",
+      "finishEditingHint": "Enregistrez ou annulez d'abord la modification du nom."
+    }
   }
 }

--- a/messages/trainingPortal/it.json
+++ b/messages/trainingPortal/it.json
@@ -40,6 +40,24 @@
       "incorrect": "Errato"
     },
     "progressLabel": "{completed} di {total} lezioni completate",
-    "estimatedTime": "{minutes} min di lettura"
+    "estimatedTime": "{minutes} min di lettura",
+    "certificate": {
+      "lockedTitle": "Attestato di completamento",
+      "lockedText": "Completa tutte le lezioni per scaricare il tuo attestato. Mancano {remaining} lezioni su {total}.",
+      "completeTitle": "Corso completato",
+      "completeText": "Hai completato tutte le {total} lezioni. Scarica il tuo attestato qui sotto.",
+      "nameLabel": "Nome sull'attestato",
+      "namePlaceholder": "Nome e cognome",
+      "noNameSet": "Nessun nome indicato",
+      "nameHint": "Questo nome viene stampato sull'attestato.",
+      "edit": "Modifica",
+      "save": "Salva",
+      "cancel": "Annulla",
+      "nameSaved": "Nome salvato",
+      "nameSaveError": "Impossibile salvare il nome",
+      "download": "Scarica l'attestato",
+      "downloadHint": "Viene scaricato come PDF che puoi salvare o stampare.",
+      "finishEditingHint": "Prima salva o annulla la modifica del nome."
+    }
   }
 }

--- a/messages/trainingPortal/nl.json
+++ b/messages/trainingPortal/nl.json
@@ -40,6 +40,24 @@
       "incorrect": "Onjuist"
     },
     "progressLabel": "{completed} van {total} lessen voltooid",
-    "estimatedTime": "{minutes} min leestijd"
+    "estimatedTime": "{minutes} min leestijd",
+    "certificate": {
+      "lockedTitle": "Deelnamecertificaat",
+      "lockedText": "Voltooi alle lessen om uw certificaat te downloaden. Nog {remaining} van {total} lessen te gaan.",
+      "completeTitle": "Cursus afgerond",
+      "completeText": "U heeft alle {total} lessen voltooid. Download hieronder uw certificaat.",
+      "nameLabel": "Naam op het certificaat",
+      "namePlaceholder": "Volledige naam",
+      "noNameSet": "Geen naam ingesteld",
+      "nameHint": "Deze naam wordt op het certificaat afgedrukt.",
+      "edit": "Wijzigen",
+      "save": "Opslaan",
+      "cancel": "Annuleren",
+      "nameSaved": "Naam opgeslagen",
+      "nameSaveError": "Naam kon niet worden opgeslagen",
+      "download": "Certificaat downloaden",
+      "downloadHint": "Wordt gedownload als PDF die u kunt opslaan of afdrukken.",
+      "finishEditingHint": "Sla de naamswijziging eerst op of annuleer deze."
+    }
   }
 }

--- a/messages/trainingPortal/pl.json
+++ b/messages/trainingPortal/pl.json
@@ -40,6 +40,24 @@
       "incorrect": "Niepoprawne"
     },
     "progressLabel": "Ukończono {completed} z {total} lekcji",
-    "estimatedTime": "{minutes} min czytania"
+    "estimatedTime": "{minutes} min czytania",
+    "certificate": {
+      "lockedTitle": "Certyfikat ukończenia",
+      "lockedText": "Ukończ wszystkie lekcje, aby pobrać certyfikat. Pozostało {remaining} z {total} lekcji.",
+      "completeTitle": "Kurs ukończony",
+      "completeText": "Ukończyłeś wszystkie {total} lekcje. Pobierz swój certyfikat poniżej.",
+      "nameLabel": "Imię i nazwisko na certyfikacie",
+      "namePlaceholder": "Imię i nazwisko",
+      "noNameSet": "Nie podano imienia i nazwiska",
+      "nameHint": "To imię i nazwisko zostanie wydrukowane na certyfikacie.",
+      "edit": "Edytuj",
+      "save": "Zapisz",
+      "cancel": "Anuluj",
+      "nameSaved": "Zapisano imię i nazwisko",
+      "nameSaveError": "Nie udało się zapisać imienia i nazwiska",
+      "download": "Pobierz certyfikat",
+      "downloadHint": "Plik zostanie pobrany jako PDF, który możesz zapisać lub wydrukować.",
+      "finishEditingHint": "Najpierw zapisz lub anuluj zmianę imienia i nazwiska."
+    }
   }
 }

--- a/messages/trainingPortal/pt.json
+++ b/messages/trainingPortal/pt.json
@@ -40,6 +40,24 @@
       "incorrect": "Incorreto"
     },
     "progressLabel": "{completed} de {total} lições concluídas",
-    "estimatedTime": "{minutes} min de leitura"
+    "estimatedTime": "{minutes} min de leitura",
+    "certificate": {
+      "lockedTitle": "Certificado de Conclusão",
+      "lockedText": "Conclua todas as lições para descarregar o seu certificado. Faltam {remaining} de {total} lições.",
+      "completeTitle": "Curso Concluído",
+      "completeText": "Concluiu todas as {total} lições. Descarregue o seu certificado abaixo.",
+      "nameLabel": "Nome no certificado",
+      "namePlaceholder": "Nome completo",
+      "noNameSet": "Nenhum nome definido",
+      "nameHint": "Este nome é impresso no certificado.",
+      "edit": "Editar",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "nameSaved": "Nome guardado",
+      "nameSaveError": "Não foi possível guardar o nome",
+      "download": "Descarregar Certificado",
+      "downloadHint": "É descarregado como PDF, que pode guardar ou imprimir.",
+      "finishEditingHint": "Guarde ou cancele primeiro a alteração do nome."
+    }
   }
 }

--- a/messages/trainingPortal/ro.json
+++ b/messages/trainingPortal/ro.json
@@ -40,6 +40,24 @@
       "incorrect": "Incorect"
     },
     "progressLabel": "{completed} din {total} lecții finalizate",
-    "estimatedTime": "{minutes} min de citit"
+    "estimatedTime": "{minutes} min de citit",
+    "certificate": {
+      "lockedTitle": "Certificat de absolvire",
+      "lockedText": "Finalizează toate lecțiile pentru a descărca certificatul. Mai ai {remaining} din {total} lecții.",
+      "completeTitle": "Curs finalizat",
+      "completeText": "Ai finalizat toate cele {total} lecții. Descarcă certificatul mai jos.",
+      "nameLabel": "Numele de pe certificat",
+      "namePlaceholder": "Nume complet",
+      "noNameSet": "Niciun nume setat",
+      "nameHint": "Acest nume va fi tipărit pe certificat.",
+      "edit": "Modifică",
+      "save": "Salvează",
+      "cancel": "Anulează",
+      "nameSaved": "Nume salvat",
+      "nameSaveError": "Numele nu a putut fi salvat",
+      "download": "Descarcă certificatul",
+      "downloadHint": "Se descarcă ca PDF, pe care îl poți salva sau tipări.",
+      "finishEditingHint": "Salvează sau anulează mai întâi modificarea numelui."
+    }
   }
 }

--- a/server/trpc/router.ts
+++ b/server/trpc/router.ts
@@ -35,6 +35,7 @@ import { platformAdminRouter } from "./routers/platform-admin";
 import { gapAssessmentRouter } from "./routers/gap-assessment";
 import { journeyRouter } from "./routers/journey";
 import { newsletterRouter, newsletterPublicRouter } from "./routers/newsletter";
+import { userRouter } from "./routers/user";
 
 // Build-time gated: dev router is excluded from production bundles
 const isDev = process.env.NODE_ENV === "development";
@@ -77,6 +78,7 @@ export const appRouter = router({
   journey: journeyRouter,
   newsletter: newsletterRouter,
   newsletterPublic: newsletterPublicRouter,
+  user: userRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/trpc/routers/user.ts
+++ b/server/trpc/routers/user.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { router, protectedProcedure } from "../init";
+import { user } from "@/schema";
+import { userUpdateSchema } from "@/schema/validators";
+
+export const userRouter = router({
+  /**
+   * Self-service display-name update. Signup only seeds `user.name` (email
+   * local part for credentials signups, OAuth profile snapshot for Google)
+   * and nothing ever syncs it afterwards, so this mutation is the one place
+   * a user can correct the name that prints on their training certificate.
+   */
+  updateName: protectedProcedure
+    .input(userUpdateSchema.pick({ name: true }).required())
+    .mutation(async ({ ctx, input }) => {
+      const name = input.name.trim();
+      if (!name) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Name cannot be empty",
+        });
+      }
+
+      await ctx.db
+        .update(user)
+        .set({ name, updatedAt: new Date() })
+        .where(eq(user.id, ctx.userId));
+
+      return { name };
+    }),
+});


### PR DESCRIPTION
## Summary
- A course participant reported his full name never appeared on the certificate of completion and there was no way to change it.
- Root cause: `user.name` is seeded once at signup (email local part for credentials signups, Google profile snapshot for OAuth) and nothing ever updates it. The certificate PDF reads `user.name` live, and the identity-anchor logic from #65 falls back to the verified email when the name looks like an email local part. Changing the name at the mail provider can never reach the platform.

## Changes
- New `user.updateName` tRPC mutation: protectedProcedure, self-scoped (`WHERE id = ctx.userId`), input derived from `userUpdateSchema.pick({ name: true })`.
- Certificate card shows "Name on the certificate" with an inline editor, so users see exactly what will print before downloading. Download is disabled mid-edit with a hint explaining why; the input is label-associated for assistive tech.
- Card strings migrated from de/en ternaries to `trainingPortal.certificate` next-intl messages and translated in all 10 locales (previously 8 locales saw English on this card).
- `getSession` now overwrites `session.user.name` from the DB, so a rename shows up everywhere that uses getSession without re-login.

## Accepted exceptions (reviewed, deliberately unchanged)
- `PublicNav` decodes the raw JWT via `auth()` to avoid DB reads on public pages, so avatar initials can stay stale until re-login. Cosmetic.
- Sign-off history resolves signer display names live from `user`, so a rename retroactively changes displayed attribution on historical sign-offs (checksum chain and userId/email anchors are unaffected). Pre-existing design that only becomes reachable now that names are editable; follow-up issue to snapshot the signer name into `SignOffSnapshotData`.

## Test plan
- `bun run typecheck` clean (only the 3 known pre-existing package devDep errors).
- Adversarial multi-lens review over the diff (correctness, security, UX/i18n, code principles); every confirmed finding is either fixed in this PR or documented above.