### PR TITLE
feat(admin): mark a training course complete for a user

### DIFF
--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -3,14 +3,20 @@
 import { useState } from "react";
 import {
   Activity,
+  BadgeCheck,
   Building2,
   GraduationCap,
+  Loader2,
   Mail,
   Shield,
   Trash2,
   Truck,
   Users,
 } from "lucide-react";
+import { trpc, type RouterInputs } from "@/lib/trpc/client";
+import { toast } from "sonner";
+
+type CourseId = RouterInputs["platformAdmin"]["trainingMarkCourseComplete"]["courseId"];
 import {
   Card,
   CardContent,
@@ -18,7 +24,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { PageHeader } from "@/components/shared/PageHeader";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { EraseUserButton, ErasuresPanel } from "./GdprErasure";
 
@@ -93,11 +99,15 @@ interface TrainingRow {
   lastActivity: string;
 }
 
-/** Lesson count per course (sum of module.lessonIds across each course definition). */
-const COURSE_TOTALS = {
-  ceo: 47,
-  cra: 9,
-  tabletop: 8,
+/**
+ * Course id + lesson count per table column (count = sum of
+ * module.lessonIds in each course definition). One map so the id and
+ * the total shown next to it cannot drift apart.
+ */
+const COURSES = {
+  ceo: { id: "nis2-ceo", total: 47 },
+  cra: { id: "cra-sbom", total: 9 },
+  tabletop: { id: "nis2-tabletop", total: 8 },
 } as const;
 
 interface SupplierRow {
@@ -483,13 +493,13 @@ function TrainingTable({ rows }: { rows: TrainingRow[] }) {
                   <td className="py-2 pr-4 text-muted-foreground">{r.userEmail}</td>
                   <td className="py-2 pr-4">{r.companyName ?? <span className="text-muted-foreground italic">none</span>}</td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.ceoCompleted} total={COURSE_TOTALS.ceo} touched={r.ceoTouched} />
+                    <CourseCell completed={r.ceoCompleted} total={COURSES.ceo.total} touched={r.ceoTouched} courseId={COURSES.ceo.id} userId={r.userId} userEmail={r.userEmail} />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.craCompleted} total={COURSE_TOTALS.cra} touched={r.craTouched} />
+                    <CourseCell completed={r.craCompleted} total={COURSES.cra.total} touched={r.craTouched} courseId={COURSES.cra.id} userId={r.userId} userEmail={r.userEmail} />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.tabletopCompleted} total={COURSE_TOTALS.tabletop} touched={r.tabletopTouched} />
+                    <CourseCell completed={r.tabletopCompleted} total={COURSES.tabletop.total} touched={r.tabletopTouched} courseId={COURSES.tabletop.id} userId={r.userId} userEmail={r.userEmail} />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">{r.quizzesPassed}</td>
                   <td className="py-2 text-muted-foreground">{r.lastActivity ? timeAgo(r.lastActivity) : "-"}</td>
@@ -506,15 +516,75 @@ function TrainingTable({ rows }: { rows: TrainingRow[] }) {
   );
 }
 
-function CourseCell({ completed, total, touched }: { completed: number; total: number; touched: number }) {
-  if (touched === 0) {
-    return <span className="text-muted-foreground/50">—</span>;
-  }
+function CourseCell({
+  completed,
+  total,
+  touched,
+  courseId,
+  userId,
+  userEmail,
+}: {
+  completed: number;
+  total: number;
+  touched: number;
+  courseId: CourseId;
+  userId: string;
+  userEmail: string;
+}) {
   return (
-    <span title={`${touched} lesson${touched === 1 ? "" : "s"} touched`}>
-      <span className="text-green-600">{completed}</span>
-      <span className="text-muted-foreground">/{total}</span>
+    <span className="inline-flex items-center gap-1">
+      {touched === 0 ? (
+        <span className="text-muted-foreground/50">—</span>
+      ) : (
+        <span title={`${touched} lesson${touched === 1 ? "" : "s"} touched`}>
+          <span className="text-green-600">{completed}</span>
+          <span className="text-muted-foreground">/{total}</span>
+        </span>
+      )}
+      {completed < total && (
+        <MarkCourseCompleteButton courseId={courseId} userId={userId} userEmail={userEmail} />
+      )}
     </span>
+  );
+}
+
+function MarkCourseCompleteButton({
+  courseId,
+  userId,
+  userEmail,
+}: {
+  courseId: CourseId;
+  userId: string;
+  userEmail: string;
+}) {
+  const router = useRouter();
+  const mark = trpc.platformAdmin.trainingMarkCourseComplete.useMutation({
+    onSuccess: (res) => {
+      toast.success(`Marked ${res.courseId} complete (${res.lessonCount} lessons) for ${userEmail}`);
+      router.refresh();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="h-6 px-1.5 text-muted-foreground hover:text-green-600"
+      title={`Mark ${courseId} fully complete for ${userEmail}`}
+      disabled={mark.isPending}
+      onClick={() => {
+        if (window.confirm(`Mark ${courseId} fully complete for ${userEmail}?`)) {
+          mark.mutate({ userId, courseId });
+        }
+      }}
+    >
+      {mark.isPending ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <BadgeCheck className="h-3.5 w-3.5" />
+      )}
+    </Button>
   );
 }
 

--- a/lib/training/course-loader.ts
+++ b/lib/training/course-loader.ts
@@ -12,7 +12,8 @@ const COURSES_DIR = join(process.cwd(), "courses");
  * caller can't pass arbitrary tokens (e.g. with `..`) and fish for module
  * resolution errors as a side-channel.
  */
-const KNOWN_COURSES = new Set(["nis2-ceo", "nis2-tabletop", "cra-sbom"]);
+export const COURSE_IDS = ["nis2-ceo", "nis2-tabletop", "cra-sbom"] as const;
+const KNOWN_COURSES = new Set<string>(COURSE_IDS);
 
 function assertKnownCourse(courseId: string): void {
   if (!KNOWN_COURSES.has(courseId)) {

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -26,6 +26,7 @@ import {
 } from "@/schema";
 import { computeScores } from "@/lib/gap-assessment/scoring";
 import { getGapAssessmentData, answerMapSchema } from "@/lib/gap-assessment";
+import { loadCourse, COURSE_IDS } from "@/lib/training/course-loader";
 import { logAudit } from "@/lib/audit";
 import { eraseUser, previewUserErasure } from "@/lib/gdpr/erase-user";
 import { buildErasureCertificate, erasureCertificateFilename } from "@/lib/gdpr/certificate";
@@ -211,6 +212,69 @@ export const platformAdminRouter = router({
 
     return rows;
   }),
+
+  /**
+   * Support tool: mark every lesson of a course complete for a user.
+   * Grant-only by design — it never un-completes or deletes progress, and
+   * existing completedAt timestamps are preserved so a genuine completion
+   * date is not overwritten by a later admin action. Caveat: quizzes stay
+   * unpassed, and a learner who later FAILS a quiz retake flips that
+   * lesson back to incomplete (submitQuiz behavior), which re-locks the
+   * certificate until the quiz is passed or the course is re-granted.
+   */
+  trainingMarkCourseComplete: platformAdminProcedure
+    .input(z.object({ userId: z.string().uuid(), courseId: z.enum(COURSE_IDS) }))
+    .mutation(async ({ ctx, input }) => {
+      const course = await loadCourse(input.courseId);
+      const lessonIds = course.modules.flatMap((m) => m.lessonIds);
+
+      const target = await ctx.db.query.user.findFirst({
+        where: eq(user.id, input.userId),
+        columns: { id: true, companyId: true, email: true },
+      });
+      if (!target) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+      }
+
+      const now = new Date();
+      await ctx.db
+        .insert(trainingLessonProgress)
+        .values(
+          lessonIds.map((lessonId) => ({
+            userId: target.id,
+            companyId: target.companyId,
+            courseId: course.id,
+            lessonId,
+            completed: true,
+            completedAt: now,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            trainingLessonProgress.userId,
+            trainingLessonProgress.courseId,
+            trainingLessonProgress.lessonId,
+          ],
+          set: {
+            completed: true,
+            completedAt: sql`COALESCE(${trainingLessonProgress.completedAt}, excluded.completed_at)`,
+            updatedAt: now,
+          },
+        });
+
+      await logAudit({
+        companyId: target.companyId,
+        userId: ctx.userId,
+        action: "training.admin_complete_course",
+        entityType: "user",
+        entityId: target.id,
+        description: `Admin marked course ${course.id} (${lessonIds.length} lessons) complete for ${target.email}`,
+        ipAddress: ctx.ip,
+        userAgent: ctx.userAgent,
+      });
+
+      return { courseId: course.id, lessonCount: lessonIds.length };
+    }),
 
   /**
    * Outbound email activity + subscription state.


### PR DESCRIPTION
## Summary
- Platform-admin support tool: mark every lesson of a course complete for any user, from the existing Training tab. Covers support cases (progress fixes) and offline/in-person completions.
- Grant-only by design: never un-completes, never deletes, preserves existing `completedAt` timestamps (`COALESCE` with the excluded row), so a genuine completion date is not overwritten.
- `platformAdminProcedure` gated (env-var email allowlist), audit-logged against the target user (`entityType: user`, uuid `entityId`), `courseId` enum-validated from the course loader's exported allowlist.
- UI: a small confirm button in each course cell when completed < total, same mutation/toast/refresh idiom as the sibling gap-assessment admin components.

## Review notes (adversarial multi-lens review, all confirmed findings addressed or documented)
- Fixed during review: audit-log insert silently failed (course slug passed into the uuid `entity_id` column); unbounded `z.string()` courseId now `z.enum(COURSE_IDS)`; duplicate import; `COURSE_TOTALS` consolidated into one `COURSES` map so id and total cannot drift.
- Documented, deliberately unchanged: a learner who later fails a quiz retake flips that lesson back to incomplete (pre-existing `submitQuiz` behavior, noted in the mutation doc comment); users with zero training rows have no table row to click (the mutation handles them, the UI entry point does not); course totals are still hand-maintained constants (follow-up if courses ever change).

## Test plan
- `bun run typecheck` clean (only the 3 known pre-existing package devDep errors).