### PR TITLE
feat(pricing): self-host licence becomes pay what you can, from 1 euro

### DIFF
--- a/messages/pricing/cs.json
+++ b/messages/pricing/cs.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Ceník - Platforma pro shodu s NIS2",
-      "description": "Dva způsoby provozu platformy. Hostováno na nis2.eu, navždy zdarma. Vlastní hosting pod licencí AGPL-3.0, jednorázová doživotní licence za 10 000 €."
+      "description": "Dva způsoby provozu platformy. Hostováno na nis2.eu, navždy zdarma. Vlastní hosting pod licencí AGPL-3.0: zaplaťte, kolik můžete, od 1 € jako jednorázová doživotní licence."
     },
     "title": "Ceník",
     "subtitle": "Dva způsoby provozu platformy. Vyberte si jeden.",
-
     "free": {
       "name": "Hostováno na nis2.eu",
       "description": "Celá platforma, kterou provozujeme my na infrastruktuře v EU.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Datový model je Open Source. Export kdykoli."
       }
     },
-
     "selfHost": {
       "name": "Vlastní hosting",
       "description": "Celý zdrojový kód. Provozujte ji na vlastní infrastruktuře, navždy.",
-      "price": "10 000 €",
-      "priceSub": "jednorázově, doživotní licence",
+      "price": "od 1 €",
+      "priceSub": "zaplaťte, kolik můžete, jednorázově, doživotní licence",
       "cta": "Spojte se s námi",
       "features": {
         "h1": "Celý zdrojový kód platformy pod licencí AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Jmenovaný kontakt pro podporu přes e-mail a Signal"
       }
     },
-
     "consultantFootnote": "Potřebujete konzultanta pro NIS2? Spojíme vás s prověřenými specialisty, a to pro vás zdarma.",
     "consultantCta": "Vyžádat konzultanta"
   }

--- a/messages/pricing/de.json
+++ b/messages/pricing/de.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Preise - NIS2-Compliance-Plattform",
-      "description": "Zwei Wege, die Plattform zu nutzen. Gehostet auf nis2.eu, kostenlos für immer. Self-Hosting unter AGPL-3.0, einmalig 10.000 € als lebenslange Lizenz."
+      "description": "Zwei Wege, die Plattform zu nutzen. Gehostet auf nis2.eu, kostenlos für immer. Self-Hosting unter AGPL-3.0: Zahlen Sie, was Sie können, ab 1 € als einmalige, lebenslange Lizenz."
     },
     "title": "Preise",
     "subtitle": "Zwei Wege, die Plattform zu nutzen. Wählen Sie einen.",
-
     "free": {
       "name": "Gehostet auf nis2.eu",
       "description": "Die vollständige Plattform, von uns auf EU-Infrastruktur betrieben.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Open Source Datenmodell. Jederzeit exportierbar."
       }
     },
-
     "selfHost": {
       "name": "Self-Hosting",
       "description": "Vollständiger Quellcode. Auf eigener Infrastruktur betreiben, dauerhaft.",
-      "price": "10.000 €",
-      "priceSub": "einmalig, lebenslange Lizenz",
+      "price": "ab 1 €",
+      "priceSub": "Zahlen Sie, was Sie können. Einmalig, lebenslange Lizenz",
       "cta": "Kontakt aufnehmen",
       "features": {
         "h1": "Vollständiger Plattform-Quellcode unter AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Persönlicher Ansprechpartner per E-Mail und Signal"
       }
     },
-
     "consultantFootnote": "Brauchen Sie einen NIS2-Berater? Wir vermitteln geprüfte Fachleute, kostenlos für Sie.",
     "consultantCta": "Berater anfragen"
   }

--- a/messages/pricing/en.json
+++ b/messages/pricing/en.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Pricing - NIS2 Compliance Platform",
-      "description": "Two ways to run the platform. Hosted at nis2.eu, free forever. Self-host under AGPL-3.0, one-time €10,000 lifetime licence."
+      "description": "Two ways to run the platform. Hosted at nis2.eu, free forever. Self-host under AGPL-3.0: pay what you can, from €1, as a one-time lifetime licence."
     },
     "title": "Pricing",
     "subtitle": "Two ways to run the platform. Pick one.",
-
     "free": {
       "name": "Hosted at nis2.eu",
       "description": "The full platform, operated by us on EU infrastructure.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Open Source data model. Export anytime."
       }
     },
-
     "selfHost": {
       "name": "Self-host",
       "description": "Full source code. Run it on your own infrastructure, forever.",
-      "price": "€10,000",
-      "priceSub": "one-time, lifetime licence",
+      "price": "€1+",
+      "priceSub": "pay what you can, one-time, lifetime licence",
       "cta": "Talk to us",
       "features": {
         "h1": "Full platform source under AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Named contact for email and Signal support"
       }
     },
-
     "consultantFootnote": "Need a NIS2 consultant? We connect you with vetted specialists at no cost to you.",
     "consultantCta": "Request a consultant"
   }

--- a/messages/pricing/es.json
+++ b/messages/pricing/es.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Precios - Plataforma de cumplimiento NIS2",
-      "description": "Dos formas de utilizar la plataforma. Alojada en nis2.eu, gratis para siempre. Autoalojamiento bajo AGPL-3.0, licencia perpetua de pago único de 10.000 €."
+      "description": "Dos formas de utilizar la plataforma. Alojada en nis2.eu, gratis para siempre. Autoalojamiento bajo AGPL-3.0: pague lo que pueda, desde 1 €, como licencia perpetua de pago único."
     },
     "title": "Precios",
     "subtitle": "Dos formas de utilizar la plataforma. Elija una.",
-
     "free": {
       "name": "Alojada en nis2.eu",
       "description": "La plataforma completa, operada por nosotros en infraestructura de la UE.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Modelo de datos Open Source. Exporte cuando quiera."
       }
     },
-
     "selfHost": {
       "name": "Autoalojamiento",
       "description": "Código fuente completo. Ejecútelo en su propia infraestructura, para siempre.",
-      "price": "10.000 €",
-      "priceSub": "pago único, licencia perpetua",
+      "price": "desde 1 €",
+      "priceSub": "pague lo que pueda, pago único, licencia perpetua",
       "cta": "Hable con nosotros",
       "features": {
         "h1": "Código fuente completo de la plataforma bajo AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Contacto designado para soporte por correo electrónico y Signal"
       }
     },
-
     "consultantFootnote": "¿Necesita un consultor de NIS2? Le ponemos en contacto con especialistas verificados sin coste alguno para usted.",
     "consultantCta": "Solicitar un consultor"
   }

--- a/messages/pricing/fr.json
+++ b/messages/pricing/fr.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Tarifs - Plateforme de conformité NIS2",
-      "description": "Deux façons d'utiliser la plateforme. Hébergée sur nis2.eu, gratuite pour toujours. Auto-hébergement sous AGPL-3.0, licence à vie en un paiement unique de 10 000 €."
+      "description": "Deux façons d'utiliser la plateforme. Hébergée sur nis2.eu, gratuite pour toujours. Auto-hébergement sous AGPL-3.0 : payez ce que vous pouvez, dès 1 €, en un paiement unique pour une licence à vie."
     },
     "title": "Tarifs",
     "subtitle": "Deux façons d'utiliser la plateforme. Choisissez-en une.",
-
     "free": {
       "name": "Hébergée sur nis2.eu",
       "description": "La plateforme complète, exploitée par nos soins sur une infrastructure de l'UE.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Modèle de données Open Source. Export à tout moment."
       }
     },
-
     "selfHost": {
       "name": "Auto-hébergement",
       "description": "Code source complet. Exécutez-la sur votre propre infrastructure, pour toujours.",
-      "price": "10 000 €",
-      "priceSub": "paiement unique, licence à vie",
+      "price": "dès 1 €",
+      "priceSub": "payez ce que vous pouvez, en un paiement unique, licence à vie",
       "cta": "Parlons-en",
       "features": {
         "h1": "Code source complet de la plateforme sous AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Contact nommé pour le support par e-mail et Signal"
       }
     },
-
     "consultantFootnote": "Besoin d'un consultant NIS2 ? Nous vous mettons en relation avec des spécialistes vérifiés, sans frais pour vous.",
     "consultantCta": "Demander un consultant"
   }

--- a/messages/pricing/it.json
+++ b/messages/pricing/it.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Prezzi - Piattaforma di conformità NIS2",
-      "description": "Due modi per utilizzare la piattaforma. In hosting su nis2.eu, gratuita per sempre. Self-hosting con licenza AGPL-3.0, licenza a vita una tantum da €10.000."
+      "description": "Due modi per utilizzare la piattaforma. In hosting su nis2.eu, gratuita per sempre. Self-hosting con licenza AGPL-3.0: paga quanto puoi, a partire da €1, come licenza a vita una tantum."
     },
     "title": "Prezzi",
     "subtitle": "Due modi per utilizzare la piattaforma. Scegline uno.",
-
     "free": {
       "name": "In hosting su nis2.eu",
       "description": "La piattaforma completa, gestita da noi su infrastruttura UE.",
@@ -26,12 +25,11 @@
         "f10": "Nessun lock-in. Modello dati Open Source. Esporta in qualsiasi momento."
       }
     },
-
     "selfHost": {
       "name": "Self-hosting",
       "description": "Codice sorgente completo. Eseguila sulla tua infrastruttura, per sempre.",
-      "price": "€10.000",
-      "priceSub": "una tantum, licenza a vita",
+      "price": "da €1",
+      "priceSub": "paga quanto puoi, una tantum, licenza a vita",
       "cta": "Contattaci",
       "features": {
         "h1": "Codice sorgente completo della piattaforma con licenza AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Contatto dedicato per il supporto via email e Signal"
       }
     },
-
     "consultantFootnote": "Hai bisogno di un consulente NIS2? Ti mettiamo in contatto con specialisti selezionati senza alcun costo per te.",
     "consultantCta": "Richiedi un consulente"
   }

--- a/messages/pricing/nl.json
+++ b/messages/pricing/nl.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Prijzen - NIS2-complianceplatform",
-      "description": "Twee manieren om het platform te gebruiken. Gehost op nis2.eu, voor altijd gratis. Self-hosting onder AGPL-3.0, eenmalig € 10.000 voor een levenslange licentie."
+      "description": "Twee manieren om het platform te gebruiken. Gehost op nis2.eu, voor altijd gratis. Self-hosting onder AGPL-3.0: betaal wat u kunt, vanaf € 1, als eenmalige, levenslange licentie."
     },
     "title": "Prijzen",
     "subtitle": "Twee manieren om het platform te gebruiken. Kies er één.",
-
     "free": {
       "name": "Gehost op nis2.eu",
       "description": "Het volledige platform, door ons beheerd op EU-infrastructuur.",
@@ -26,12 +25,11 @@
         "f10": "Geen lock-in. Open Source datamodel. Altijd exporteerbaar."
       }
     },
-
     "selfHost": {
       "name": "Self-hosting",
       "description": "Volledige broncode. Op uw eigen infrastructuur draaien, voor altijd.",
-      "price": "€ 10.000",
-      "priceSub": "eenmalig, levenslange licentie",
+      "price": "vanaf € 1",
+      "priceSub": "betaal wat u kunt, eenmalig, levenslange licentie",
       "cta": "Neem contact op",
       "features": {
         "h1": "Volledige platformbroncode onder AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Vaste contactpersoon voor e-mail- en Signal-support"
       }
     },
-
     "consultantFootnote": "Heeft u een NIS2-adviseur nodig? Wij verbinden u kosteloos met getoetste specialisten.",
     "consultantCta": "Adviseur aanvragen"
   }

--- a/messages/pricing/pl.json
+++ b/messages/pricing/pl.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Cennik - Platforma zgodności z NIS2",
-      "description": "Dwa sposoby uruchomienia platformy. Hostowana na nis2.eu, darmowa na zawsze. Hosting własny na licencji AGPL-3.0, jednorazowa licencja dożywotnia za 10 000 €."
+      "description": "Dwa sposoby uruchomienia platformy. Hostowana na nis2.eu, darmowa na zawsze. Hosting własny na licencji AGPL-3.0: zapłać, ile możesz, od 1 € jako jednorazowa licencja dożywotnia."
     },
     "title": "Cennik",
     "subtitle": "Dwa sposoby uruchomienia platformy. Wybierz jeden.",
-
     "free": {
       "name": "Hostowana na nis2.eu",
       "description": "Pełna platforma, obsługiwana przez nas na infrastrukturze w UE.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Model danych Open Source. Eksport w dowolnym momencie."
       }
     },
-
     "selfHost": {
       "name": "Hosting własny",
       "description": "Pełny kod źródłowy. Uruchom go na własnej infrastrukturze, na zawsze.",
-      "price": "10 000 €",
-      "priceSub": "jednorazowo, licencja dożywotnia",
+      "price": "od 1 €",
+      "priceSub": "zapłać, ile możesz, jednorazowo, licencja dożywotnia",
       "cta": "Skontaktuj się z nami",
       "features": {
         "h1": "Pełny kod źródłowy platformy na licencji AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Wyznaczona osoba kontaktowa do wsparcia przez e-mail i Signal"
       }
     },
-
     "consultantFootnote": "Potrzebujesz konsultanta NIS2? Łączymy Cię ze zweryfikowanymi specjalistami bez żadnych kosztów dla Ciebie.",
     "consultantCta": "Poproś o konsultanta"
   }

--- a/messages/pricing/pt.json
+++ b/messages/pricing/pt.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Preços - Plataforma de Conformidade NIS2",
-      "description": "Duas formas de utilizar a plataforma. Alojada em nis2.eu, gratuita para sempre. Autoalojamento sob AGPL-3.0, licença vitalícia única de 10 000 €."
+      "description": "Duas formas de utilizar a plataforma. Alojada em nis2.eu, gratuita para sempre. Autoalojamento sob AGPL-3.0: pague o que puder, a partir de 1 €, como pagamento único com licença vitalícia."
     },
     "title": "Preços",
     "subtitle": "Duas formas de utilizar a plataforma. Escolha uma.",
-
     "free": {
       "name": "Alojada em nis2.eu",
       "description": "A plataforma completa, operada por nós em infraestrutura da UE.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Modelo de dados Open Source. Exportação a qualquer momento."
       }
     },
-
     "selfHost": {
       "name": "Autoalojamento",
       "description": "Código-fonte completo. Execute-o na sua própria infraestrutura, para sempre.",
-      "price": "10 000 €",
-      "priceSub": "pagamento único, licença vitalícia",
+      "price": "a partir de 1 €",
+      "priceSub": "pague o que puder, pagamento único, licença vitalícia",
       "cta": "Fale connosco",
       "features": {
         "h1": "Código-fonte completo da plataforma sob AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Contacto designado para apoio por email e Signal"
       }
     },
-
     "consultantFootnote": "Precisa de um consultor NIS2? Colocamo-lo em contacto com especialistas verificados, sem qualquer custo para si.",
     "consultantCta": "Pedir um consultor"
   }

--- a/messages/pricing/ro.json
+++ b/messages/pricing/ro.json
@@ -2,11 +2,10 @@
   "pricing": {
     "meta": {
       "title": "Prețuri - Platformă de conformitate NIS2",
-      "description": "Două moduri de a rula platforma. Găzduită la nis2.eu, gratuit pentru totdeauna. Auto-găzduire sub AGPL-3.0, licență pe viață cu plată unică de 10.000 €."
+      "description": "Două moduri de a rula platforma. Găzduită la nis2.eu, gratuit pentru totdeauna. Auto-găzduire sub AGPL-3.0: plătiți cât puteți, de la 1 €, ca licență pe viață cu plată unică."
     },
     "title": "Prețuri",
     "subtitle": "Două moduri de a rula platforma. Alegeți unul.",
-
     "free": {
       "name": "Găzduită la nis2.eu",
       "description": "Platforma completă, operată de noi pe infrastructură din UE.",
@@ -26,12 +25,11 @@
         "f10": "Kein Lock-in. Model de date Open Source. Exportați oricând."
       }
     },
-
     "selfHost": {
       "name": "Auto-găzduire",
       "description": "Cod sursă complet. Rulați-l pe propria infrastructură, pentru totdeauna.",
-      "price": "10.000 €",
-      "priceSub": "plată unică, licență pe viață",
+      "price": "de la 1 €",
+      "priceSub": "plătiți cât puteți, plată unică, licență pe viață",
       "cta": "Contactați-ne",
       "features": {
         "h1": "Cod sursă complet al platformei sub AGPL-3.0",
@@ -40,7 +38,6 @@
         "h4": "Persoană de contact dedicată pentru suport prin e-mail și Signal"
       }
     },
-
     "consultantFootnote": "Aveți nevoie de un consultant NIS2? Vă punem în legătură cu specialiști verificați, fără niciun cost pentru dvs.",
     "consultantCta": "Solicită un consultant"
   }


### PR DESCRIPTION
## Summary
- The self-host tier's fixed one-time €10,000 lifetime licence becomes pay what you can, from €1, in all 10 locales: `selfHost.price`, `selfHost.priceSub`, and `meta.description` in `messages/pricing/*.json`.
- Hosted tier (€0) untouched. No other page references the old price (scanned all message namespaces; the remaining €10,000 hits are NIS 2 fine amounts and competitor cost comparisons).
- Locale price formats follow each file's existing euro convention (`€1+`, `ab 1 €`, `vanaf € 1`, `dès 1 €`, ...), registers matched to existing copy (NL u-form, ES usted, IT tu). French colon spacing corrected (`AGPL-3.0 :`).

## Follow-up in a separate PR
- `public/og/pricing-*.png` are live-site screenshots and still show €10,000; og-shot regeneration needs this deployed first.

## Test plan
- `grep -rn "10.000|10,000|10 000" messages/pricing/` returns nothing.
- JSON round-trip validated (python json load/dump per file).