### PR TITLE
fix(pricing): show the pay-what-you-can phrase as the price

### DIFF
--- a/messages/pricing/cs.json
+++ b/messages/pricing/cs.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Ceník - Platforma pro shodu s NIS2",
-      "description": "Dva způsoby provozu platformy. Hostováno na nis2.eu, navždy zdarma. Vlastní hosting pod licencí AGPL-3.0: zaplaťte, kolik můžete, od 1 € jako jednorázová doživotní licence."
+      "description": "Dva způsoby provozu platformy. Hostováno na nis2.eu, navždy zdarma. Vlastní hosting pod licencí AGPL-3.0: zaplaťte, kolik můžete, jako jednorázová doživotní licence."
     },
     "title": "Ceník",
     "subtitle": "Dva způsoby provozu platformy. Vyberte si jeden.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Vlastní hosting",
       "description": "Celý zdrojový kód. Provozujte ji na vlastní infrastruktuře, navždy.",
-      "price": "od 1 €",
-      "priceSub": "zaplaťte, kolik můžete, jednorázově, doživotní licence",
+      "price": "Zaplaťte, kolik můžete",
+      "priceSub": "jednorázově, doživotní licence",
       "cta": "Spojte se s námi",
       "features": {
         "h1": "Celý zdrojový kód platformy pod licencí AGPL-3.0",

--- a/messages/pricing/de.json
+++ b/messages/pricing/de.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Preise - NIS2-Compliance-Plattform",
-      "description": "Zwei Wege, die Plattform zu nutzen. Gehostet auf nis2.eu, kostenlos für immer. Self-Hosting unter AGPL-3.0: Zahlen Sie, was Sie können, ab 1 € als einmalige, lebenslange Lizenz."
+      "description": "Zwei Wege, die Plattform zu nutzen. Gehostet auf nis2.eu, kostenlos für immer. Self-Hosting unter AGPL-3.0: Zahlen Sie, was Sie können, als einmalige, lebenslange Lizenz."
     },
     "title": "Preise",
     "subtitle": "Zwei Wege, die Plattform zu nutzen. Wählen Sie einen.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Self-Hosting",
       "description": "Vollständiger Quellcode. Auf eigener Infrastruktur betreiben, dauerhaft.",
-      "price": "ab 1 €",
-      "priceSub": "Zahlen Sie, was Sie können. Einmalig, lebenslange Lizenz",
+      "price": "Zahlen Sie, was Sie können",
+      "priceSub": "einmalig, lebenslange Lizenz",
       "cta": "Kontakt aufnehmen",
       "features": {
         "h1": "Vollständiger Plattform-Quellcode unter AGPL-3.0",

--- a/messages/pricing/en.json
+++ b/messages/pricing/en.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Pricing - NIS2 Compliance Platform",
-      "description": "Two ways to run the platform. Hosted at nis2.eu, free forever. Self-host under AGPL-3.0: pay what you can, from €1, as a one-time lifetime licence."
+      "description": "Two ways to run the platform. Hosted at nis2.eu, free forever. Self-host under AGPL-3.0: pay what you can, one-time, lifetime licence."
     },
     "title": "Pricing",
     "subtitle": "Two ways to run the platform. Pick one.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Self-host",
       "description": "Full source code. Run it on your own infrastructure, forever.",
-      "price": "€1+",
-      "priceSub": "pay what you can, one-time, lifetime licence",
+      "price": "Pay what you can",
+      "priceSub": "one-time, lifetime licence",
       "cta": "Talk to us",
       "features": {
         "h1": "Full platform source under AGPL-3.0",

--- a/messages/pricing/es.json
+++ b/messages/pricing/es.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Precios - Plataforma de cumplimiento NIS2",
-      "description": "Dos formas de utilizar la plataforma. Alojada en nis2.eu, gratis para siempre. Autoalojamiento bajo AGPL-3.0: pague lo que pueda, desde 1 €, como licencia perpetua de pago único."
+      "description": "Dos formas de utilizar la plataforma. Alojada en nis2.eu, gratis para siempre. Autoalojamiento bajo AGPL-3.0: pague lo que pueda, como licencia perpetua de pago único."
     },
     "title": "Precios",
     "subtitle": "Dos formas de utilizar la plataforma. Elija una.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Autoalojamiento",
       "description": "Código fuente completo. Ejecútelo en su propia infraestructura, para siempre.",
-      "price": "desde 1 €",
-      "priceSub": "pague lo que pueda, pago único, licencia perpetua",
+      "price": "Pague lo que pueda",
+      "priceSub": "pago único, licencia perpetua",
       "cta": "Hable con nosotros",
       "features": {
         "h1": "Código fuente completo de la plataforma bajo AGPL-3.0",

--- a/messages/pricing/fr.json
+++ b/messages/pricing/fr.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Tarifs - Plateforme de conformité NIS2",
-      "description": "Deux façons d'utiliser la plateforme. Hébergée sur nis2.eu, gratuite pour toujours. Auto-hébergement sous AGPL-3.0 : payez ce que vous pouvez, dès 1 €, en un paiement unique pour une licence à vie."
+      "description": "Deux façons d'utiliser la plateforme. Hébergée sur nis2.eu, gratuite pour toujours. Auto-hébergement sous AGPL-3.0 : payez ce que vous pouvez, en un paiement unique pour une licence à vie."
     },
     "title": "Tarifs",
     "subtitle": "Deux façons d'utiliser la plateforme. Choisissez-en une.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Auto-hébergement",
       "description": "Code source complet. Exécutez-la sur votre propre infrastructure, pour toujours.",
-      "price": "dès 1 €",
-      "priceSub": "payez ce que vous pouvez, en un paiement unique, licence à vie",
+      "price": "Payez ce que vous pouvez",
+      "priceSub": "paiement unique, licence à vie",
       "cta": "Parlons-en",
       "features": {
         "h1": "Code source complet de la plateforme sous AGPL-3.0",

--- a/messages/pricing/it.json
+++ b/messages/pricing/it.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prezzi - Piattaforma di conformità NIS2",
-      "description": "Due modi per utilizzare la piattaforma. In hosting su nis2.eu, gratuita per sempre. Self-hosting con licenza AGPL-3.0: paga quanto puoi, a partire da €1, come licenza a vita una tantum."
+      "description": "Due modi per utilizzare la piattaforma. In hosting su nis2.eu, gratuita per sempre. Self-hosting con licenza AGPL-3.0: paga quanto puoi, come licenza a vita una tantum."
     },
     "title": "Prezzi",
     "subtitle": "Due modi per utilizzare la piattaforma. Scegline uno.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Self-hosting",
       "description": "Codice sorgente completo. Eseguila sulla tua infrastruttura, per sempre.",
-      "price": "da €1",
-      "priceSub": "paga quanto puoi, una tantum, licenza a vita",
+      "price": "Paga quanto puoi",
+      "priceSub": "una tantum, licenza a vita",
       "cta": "Contattaci",
       "features": {
         "h1": "Codice sorgente completo della piattaforma con licenza AGPL-3.0",

--- a/messages/pricing/nl.json
+++ b/messages/pricing/nl.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prijzen - NIS2-complianceplatform",
-      "description": "Twee manieren om het platform te gebruiken. Gehost op nis2.eu, voor altijd gratis. Self-hosting onder AGPL-3.0: betaal wat u kunt, vanaf € 1, als eenmalige, levenslange licentie."
+      "description": "Twee manieren om het platform te gebruiken. Gehost op nis2.eu, voor altijd gratis. Self-hosting onder AGPL-3.0: betaal wat u kunt, als eenmalige, levenslange licentie."
     },
     "title": "Prijzen",
     "subtitle": "Twee manieren om het platform te gebruiken. Kies er één.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Self-hosting",
       "description": "Volledige broncode. Op uw eigen infrastructuur draaien, voor altijd.",
-      "price": "vanaf € 1",
-      "priceSub": "betaal wat u kunt, eenmalig, levenslange licentie",
+      "price": "Betaal wat u kunt",
+      "priceSub": "eenmalig, levenslange licentie",
       "cta": "Neem contact op",
       "features": {
         "h1": "Volledige platformbroncode onder AGPL-3.0",

--- a/messages/pricing/pl.json
+++ b/messages/pricing/pl.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Cennik - Platforma zgodności z NIS2",
-      "description": "Dwa sposoby uruchomienia platformy. Hostowana na nis2.eu, darmowa na zawsze. Hosting własny na licencji AGPL-3.0: zapłać, ile możesz, od 1 € jako jednorazowa licencja dożywotnia."
+      "description": "Dwa sposoby uruchomienia platformy. Hostowana na nis2.eu, darmowa na zawsze. Hosting własny na licencji AGPL-3.0: zapłać, ile możesz, jako jednorazowa licencja dożywotnia."
     },
     "title": "Cennik",
     "subtitle": "Dwa sposoby uruchomienia platformy. Wybierz jeden.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Hosting własny",
       "description": "Pełny kod źródłowy. Uruchom go na własnej infrastrukturze, na zawsze.",
-      "price": "od 1 €",
-      "priceSub": "zapłać, ile możesz, jednorazowo, licencja dożywotnia",
+      "price": "Zapłać, ile możesz",
+      "priceSub": "jednorazowo, licencja dożywotnia",
       "cta": "Skontaktuj się z nami",
       "features": {
         "h1": "Pełny kod źródłowy platformy na licencji AGPL-3.0",

--- a/messages/pricing/pt.json
+++ b/messages/pricing/pt.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Preços - Plataforma de Conformidade NIS2",
-      "description": "Duas formas de utilizar a plataforma. Alojada em nis2.eu, gratuita para sempre. Autoalojamento sob AGPL-3.0: pague o que puder, a partir de 1 €, como pagamento único com licença vitalícia."
+      "description": "Duas formas de utilizar a plataforma. Alojada em nis2.eu, gratuita para sempre. Autoalojamento sob AGPL-3.0: pague o que puder, como pagamento único com licença vitalícia."
     },
     "title": "Preços",
     "subtitle": "Duas formas de utilizar a plataforma. Escolha uma.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Autoalojamento",
       "description": "Código-fonte completo. Execute-o na sua própria infraestrutura, para sempre.",
-      "price": "a partir de 1 €",
-      "priceSub": "pague o que puder, pagamento único, licença vitalícia",
+      "price": "Pague o que puder",
+      "priceSub": "pagamento único, licença vitalícia",
       "cta": "Fale connosco",
       "features": {
         "h1": "Código-fonte completo da plataforma sob AGPL-3.0",

--- a/messages/pricing/ro.json
+++ b/messages/pricing/ro.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prețuri - Platformă de conformitate NIS2",
-      "description": "Două moduri de a rula platforma. Găzduită la nis2.eu, gratuit pentru totdeauna. Auto-găzduire sub AGPL-3.0: plătiți cât puteți, de la 1 €, ca licență pe viață cu plată unică."
+      "description": "Două moduri de a rula platforma. Găzduită la nis2.eu, gratuit pentru totdeauna. Auto-găzduire sub AGPL-3.0: plătiți cât puteți, ca licență pe viață cu plată unică."
     },
     "title": "Prețuri",
     "subtitle": "Două moduri de a rula platforma. Alegeți unul.",
@@ -28,8 +28,8 @@
     "selfHost": {
       "name": "Auto-găzduire",
       "description": "Cod sursă complet. Rulați-l pe propria infrastructură, pentru totdeauna.",
-      "price": "de la 1 €",
-      "priceSub": "plătiți cât puteți, plată unică, licență pe viață",
+      "price": "Plătiți cât puteți",
+      "priceSub": "plată unică, licență pe viață",
       "cta": "Contactați-ne",
       "features": {
         "h1": "Cod sursă complet al platformei sub AGPL-3.0",


### PR DESCRIPTION
Follow-up to #12 after review: the big price slot reads the phrase ("Pay what you can" / "Zahlen Sie, was Sie können" / per-locale register from the same translation pass) instead of a €1+ figure, and the subline reverts to each locale's original "one-time, lifetime licence" wording. Meta descriptions drop the €1 floor accordingly. All 10 locales.