### PR TITLE
feat(landing): link Open Source in the hero subtitle to the GitHub repo

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -70,7 +70,18 @@ export default async function LandingPage() {
           <div className="mt-12 grid gap-12 lg:grid-cols-[minmax(0,25rem)_1fr] lg:items-center">
             <div>
               <p className="max-w-sm text-base leading-relaxed text-muted-foreground">
-                {t("subtitle")}
+                {t.rich("subtitle", {
+                  os: (chunks) => (
+                    <a
+                      href="https://github.com/NISD2/open-isms"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline decoration-muted-foreground/40 underline-offset-2 transition-colors hover:text-foreground"
+                    >
+                      {chunks}
+                    </a>
+                  ),
+                })}
               </p>
 
               {/* CTAs stacked for the narrow column */}

--- a/messages/landing/cs.json
+++ b/messages/landing/cs.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Snižte účet Evropy za <blue>NIS2</blue> na polovinu.",
     "eyebrow": "Open source · Zdarma · Bez vendor lock-inu",
-    "subtitle": "Bezplatná platforma pro regulované firmy a jejich dodavatele k zavedení NIS2: sebehodnocení, šablony a školení vedení. Open source, bez vendor lock-inu.",
+    "subtitle": "Bezplatná platforma pro regulované firmy a jejich dodavatele k zavedení NIS2: sebehodnocení, šablony a školení vedení. <os>Open source</os>, bez vendor lock-inu.",
     "productLine": "Bezplatná shoda s NIS2 a informace pro regulované firmy a jejich dodavatele.",
     "regLine": "Směrnice NIS2 (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Dostali jste od zákazníka dotazník k NIS2? Přejděte do portálu pro dodavatele.",

--- a/messages/landing/de.json
+++ b/messages/landing/de.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Halbiert Europas <blue>NIS2</blue>-Rechnung.",
     "eyebrow": "Open Source · Kostenlos · Kein Lock-in",
-    "subtitle": "Die kostenlose Plattform, mit der regulierte Unternehmen und ihre Lieferanten NIS2 umsetzen: mit Selbsteinschätzung, Vorlagen und Schulung für die Geschäftsführung. Open Source, kein Lock-in.",
+    "subtitle": "Die kostenlose Plattform, mit der regulierte Unternehmen und ihre Lieferanten NIS2 umsetzen: mit Selbsteinschätzung, Vorlagen und Schulung für die Geschäftsführung. <os>Open Source</os>, kein Lock-in.",
     "productLine": "Kostenlose NIS2-Compliance und Informationen für regulierte Unternehmen und ihre Lieferanten.",
     "regLine": "NIS2-Richtlinie (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Haben Sie einen NIS2-Fragebogen von einem Kunden erhalten? Zum Lieferantenportal.",

--- a/messages/landing/en.json
+++ b/messages/landing/en.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Halve Europe's <blue>NIS2</blue> bill.",
     "eyebrow": "Open source · Free · No lock-in",
-    "subtitle": "The free platform for regulated companies and their suppliers to implement NIS2: self-assessment, templates, and management training. Open source, no lock-in.",
+    "subtitle": "The free platform for regulated companies and their suppliers to implement NIS2: self-assessment, templates, and management training. <os>Open source</os>, no lock-in.",
     "productLine": "Free NIS2 compliance and information for regulated companies and their suppliers.",
     "regLine": "NIS2 Directive (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Received a NIS2 questionnaire from a customer? Go to the supplier portal.",

--- a/messages/landing/es.json
+++ b/messages/landing/es.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Reduzca a la mitad la factura de <blue>NIS2</blue> en Europa.",
     "eyebrow": "Open source · Gratis · Sin lock-in",
-    "subtitle": "La plataforma gratuita para que las empresas reguladas y sus proveedores implementen NIS2: autoevaluación, plantillas y formación para la dirección. Open source, sin lock-in.",
+    "subtitle": "La plataforma gratuita para que las empresas reguladas y sus proveedores implementen NIS2: autoevaluación, plantillas y formación para la dirección. <os>Open source</os>, sin lock-in.",
     "productLine": "Cumplimiento e información sobre NIS2 gratuitos para empresas reguladas y sus proveedores.",
     "regLine": "Directiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "¿Ha recibido un cuestionario NIS2 de un cliente? Vaya al portal de proveedores.",

--- a/messages/landing/fr.json
+++ b/messages/landing/fr.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Réduisez de moitié la facture <blue>NIS2</blue> de l'Europe.",
     "eyebrow": "Open source · Gratuit · Sans lock-in",
-    "subtitle": "La plateforme gratuite permettant aux entreprises réglementées et à leurs fournisseurs de mettre en œuvre NIS2 : auto-évaluation, modèles et formation de la direction. Open source, sans lock-in.",
+    "subtitle": "La plateforme gratuite permettant aux entreprises réglementées et à leurs fournisseurs de mettre en œuvre NIS2 : auto-évaluation, modèles et formation de la direction. <os>Open source</os>, sans lock-in.",
     "productLine": "Conformité et information NIS2 gratuites pour les entreprises réglementées et leurs fournisseurs.",
     "regLine": "Directive NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Vous avez reçu un questionnaire NIS2 de la part d'un client ? Accédez au portail fournisseur.",

--- a/messages/landing/it.json
+++ b/messages/landing/it.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Dimezza il conto <blue>NIS2</blue> dell'Europa.",
     "eyebrow": "Open source · Gratuita · Nessun lock-in",
-    "subtitle": "La piattaforma gratuita con cui le aziende regolamentate e i loro fornitori implementano NIS2: autovalutazione, modelli e formazione per la direzione. Open source, nessun lock-in.",
+    "subtitle": "La piattaforma gratuita con cui le aziende regolamentate e i loro fornitori implementano NIS2: autovalutazione, modelli e formazione per la direzione. <os>Open source</os>, nessun lock-in.",
     "productLine": "Conformità NIS2 e informazioni gratuite per le aziende regolamentate e i loro fornitori.",
     "regLine": "Direttiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Hai ricevuto un questionario NIS2 da un cliente? Vai al portale fornitori.",

--- a/messages/landing/nl.json
+++ b/messages/landing/nl.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Halveer Europa's <blue>NIS2</blue>-rekening.",
     "eyebrow": "Open source · Gratis · Geen lock-in",
-    "subtitle": "Het gratis platform waarmee gereguleerde bedrijven en hun leveranciers NIS2 implementeren: met zelfbeoordeling, sjablonen en bestuurstraining. Open source, geen lock-in.",
+    "subtitle": "Het gratis platform waarmee gereguleerde bedrijven en hun leveranciers NIS2 implementeren: met zelfbeoordeling, sjablonen en bestuurstraining. <os>Open source</os>, geen lock-in.",
     "productLine": "Gratis NIS2-compliance en informatie voor gereguleerde bedrijven en hun leveranciers.",
     "regLine": "NIS2-richtlijn (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Hebt u een NIS2-vragenlijst van een klant ontvangen? Naar het leveranciersportaal.",

--- a/messages/landing/pl.json
+++ b/messages/landing/pl.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Zmniejsz o połowę rachunek Europy za <blue>NIS2</blue>.",
     "eyebrow": "Open source · Darmowe · Kein Lock-in",
-    "subtitle": "Darmowa platforma dla regulowanych firm i ich dostawców do wdrożenia NIS2: samoocena, szablony i szkolenia dla kierownictwa. Open source, kein Lock-in.",
+    "subtitle": "Darmowa platforma dla regulowanych firm i ich dostawców do wdrożenia NIS2: samoocena, szablony i szkolenia dla kierownictwa. <os>Open source</os>, bez lock-inu.",
     "productLine": "Darmowa zgodność z NIS2 i informacje dla regulowanych firm oraz ich dostawców.",
     "regLine": "Dyrektywa NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Otrzymałeś kwestionariusz NIS2 od klienta? Przejdź do portalu dostawców.",

--- a/messages/landing/pt.json
+++ b/messages/landing/pt.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Reduza para metade a fatura <blue>NIS2</blue> da Europa.",
     "eyebrow": "Open source · Gratuito · Sem lock-in",
-    "subtitle": "A plataforma gratuita para empresas reguladas e os seus fornecedores implementarem a NIS2: autoavaliação, modelos e formação para a direção. Open source, sem lock-in.",
+    "subtitle": "A plataforma gratuita para empresas reguladas e os seus fornecedores implementarem a NIS2: autoavaliação, modelos e formação para a direção. <os>Open source</os>, sem lock-in.",
     "productLine": "Conformidade NIS2 e informação gratuitas para empresas reguladas e os seus fornecedores.",
     "regLine": "Diretiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Recebeu um questionário NIS2 de um cliente? Aceda ao portal de fornecedores.",

--- a/messages/landing/ro.json
+++ b/messages/landing/ro.json
@@ -2,7 +2,7 @@
   "landing": {
     "title": "Înjumătățiți factura <blue>NIS2</blue> a Europei.",
     "eyebrow": "Open Source · Gratuit · Kein Lock-in",
-    "subtitle": "Platforma gratuită prin care companiile reglementate și furnizorii lor implementează NIS2: autoevaluare, șabloane și instruire pentru conducere. Open Source, kein Lock-in.",
+    "subtitle": "Platforma gratuită prin care companiile reglementate și furnizorii lor implementează NIS2: autoevaluare, șabloane și instruire pentru conducere. <os>Open Source</os>, fără lock-in.",
     "productLine": "Conformitate NIS2 gratuită și informații pentru companiile reglementate și furnizorii lor.",
     "regLine": "Directiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Ați primit un chestionar NIS2 de la un client? Mergeți la portalul furnizorilor.",


### PR DESCRIPTION
Underlines the "Open Source" phrase in the hero subtitle and links it to the public repo (github.com/NISD2/open-isms) via `t.rich` across all 10 locales. Also fixes a leftover German "kein Lock-in" in the Polish and Romanian subtitles.