### PR TITLE
feat(open-source): add the open-isms platform repo to the open-source page

### DIFF
--- a/app/[locale]/(info)/open-source/page.tsx
+++ b/app/[locale]/(info)/open-source/page.tsx
@@ -27,6 +27,12 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 
 const repos = [
   {
+    name: "open-isms",
+    href: "https://github.com/NISD2/open-isms",
+    titleKey: "platform.title",
+    descKey: "platform.description",
+  },
+  {
     name: "nis2-gap-assessment-schema",
     href: "https://github.com/NISD2/nis2-gap-assessment-schema",
     titleKey: "gapAssessment.title",

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -342,9 +342,18 @@
         "heading": "Tři fáze oznamování",
         "description": "Článek 23(4) NIS 2, § 32 odstavec 1 BSIG.",
         "items": {
-          "s1": { "title": "Včasné varování do 24 hodin", "text": "První včasné varování pro BSI do 24 hodin od zjištění významného incidentu s uvedením, zda se předpokládá, že byl způsoben protiprávním nebo zlovolným jednáním, a zda by mohl mít přeshraniční dopad." },
-          "s2": { "title": "Oznámení do 72 hodin", "text": "Úplnější oznámení do 72 hodin, které doplňuje včasné varování o první posouzení incidentu, jeho závažnosti a dopadu, jakož i o indikátory kompromitace, jsou-li k dispozici." },
-          "s3": { "title": "Závěrečná zpráva po jednom měsíci", "text": "Závěrečná zpráva nejpozději jeden měsíc po oznámení: podrobný popis, druh hrozby nebo příčinu, přijatá nápravná opatření a případný přeshraniční dopad." }
+          "s1": {
+            "title": "Včasné varování do 24 hodin",
+            "text": "První včasné varování pro BSI do 24 hodin od zjištění významného incidentu s uvedením, zda se předpokládá, že byl způsoben protiprávním nebo zlovolným jednáním, a zda by mohl mít přeshraniční dopad."
+          },
+          "s2": {
+            "title": "Oznámení do 72 hodin",
+            "text": "Úplnější oznámení do 72 hodin, které doplňuje včasné varování o první posouzení incidentu, jeho závažnosti a dopadu, jakož i o indikátory kompromitace, jsou-li k dispozici."
+          },
+          "s3": {
+            "title": "Závěrečná zpráva po jednom měsíci",
+            "text": "Závěrečná zpráva nejpozději jeden měsíc po oznámení: podrobný popis, druh hrozby nebo příčinu, přijatá nápravná opatření a případný přeshraniční dopad."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Časté dotazy",
-        "q1": { "q": "Kdy začíná běžet 24hodinová lhůta?", "a": "Jakmile se subjekt o významném incidentu dozví, nikoli kdy začal." },
-        "q2": { "q": "Existují pevné prahové hodnoty v eurech pro významný incident?", "a": "Pouze pro poskytovatele digitálních služeb uvedené v PN (EU) 2024/2690. Pro všechny ostatní subjekty platí kvalitativní kritéria podle článku 23(3) NIS 2." },
-        "q3": { "q": "Co když si nejsem jistý, zda je incident významný?", "a": "Doložte své posouzení a důvody. Odůvodněné rozhodnutí je to, co auditor očekává; absence jakéhokoli posouzení je tím skutečným pochybením." },
-        "q4": { "q": "Musím oznamovat i podle GDPR?", "a": "Jsou-li dotčeny osobní údaje, posuďte samostatně článek 33 GDPR. Má vlastní 72hodinovou lhůtu a jiného adresáta." },
-        "q5": { "q": "Co se děje po oznámení?", "a": "BSI si může vyžádat další informace a závěrečná zpráva následuje nejpozději jeden měsíc po oznámení." }
+        "q1": {
+          "q": "Kdy začíná běžet 24hodinová lhůta?",
+          "a": "Jakmile se subjekt o významném incidentu dozví, nikoli kdy začal."
+        },
+        "q2": {
+          "q": "Existují pevné prahové hodnoty v eurech pro významný incident?",
+          "a": "Pouze pro poskytovatele digitálních služeb uvedené v PN (EU) 2024/2690. Pro všechny ostatní subjekty platí kvalitativní kritéria podle článku 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "Co když si nejsem jistý, zda je incident významný?",
+          "a": "Doložte své posouzení a důvody. Odůvodněné rozhodnutí je to, co auditor očekává; absence jakéhokoli posouzení je tím skutečným pochybením."
+        },
+        "q4": {
+          "q": "Musím oznamovat i podle GDPR?",
+          "a": "Jsou-li dotčeny osobní údaje, posuďte samostatně článek 33 GDPR. Má vlastní 72hodinovou lhůtu a jiného adresáta."
+        },
+        "q5": {
+          "q": "Co se děje po oznámení?",
+          "a": "BSI si může vyžádat další informace a závěrečná zpráva následuje nejpozději jeden měsíc po oznámení."
+        }
       },
       "ctaCard": {
         "heading": "Strukturujte svůj oznamovací proces dříve, než ho budete potřebovat",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Přispívání",
         "p1": "Pull requesty vítány: zejména opravy právních citací (s odkazem na primární zdroj), další jazykové překlady, sektorová rozšíření (KRITIS, energetika, zdravotnictví) a rozdíly ve vnitrostátní transpozici. U podstatných změn nejprve prosím otevřete issue."
+      },
+      "platform": {
+        "title": "Platforma nisd2.eu: portál, průvodce, kurzy",
+        "description": "Kompletní aplikace, která pohání tento web. Portál pro compliance, řízený průvodce podle NIS 2, školení pro vedení a veškerá data rámců v jedné kódové základně postavené na Next.js a Drizzle. Lze ji hostovat na vlastní infrastruktuře a je licencována pod AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -6244,6 +6244,10 @@
       "contribute": {
         "heading": "Mitwirken",
         "p1": "Pull Requests willkommen - besonders Korrekturen an Rechtsquellen (mit Primärquellen-Zitat), zusätzliche Sprachübersetzungen, sektorspezifische Erweiterungen (KRITIS, Energie, Gesundheitswesen) und nationale Umsetzungs-Deltas. Für größere Änderungen bitte zuerst ein Issue eröffnen."
+      },
+      "platform": {
+        "title": "Die nisd2.eu-Plattform: Portal, Pfad, Kurse",
+        "description": "Die vollständige Anwendung, die diese Seite betreibt. Das Compliance-Portal, der geführte NIS-2-Pfad, die Geschäftsführer-Schulung und alle Framework-Daten in einer Next.js- und Drizzle-Codebasis. Selbst hostbar und unter AGPL-3.0 lizenziert."
       }
     },
     "partners": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -6251,6 +6251,10 @@
       "contribute": {
         "heading": "Contributing",
         "p1": "Pull requests welcome: particularly corrections to legal citations (with a primary-source reference), additional language translations, sector-specific extensions (KRITIS, energy, healthcare), and national transposition deltas. For substantial changes please open an issue first."
+      },
+      "platform": {
+        "title": "The nisd2.eu platform: portal, journey, courses",
+        "description": "The complete application that runs this site. The compliance portal, the guided NIS 2 journey, the management course and all framework data, in one Next.js and Drizzle codebase. Self-hostable and licensed under AGPL-3.0."
       }
     },
     "partners": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -342,9 +342,18 @@
         "heading": "Las tres fases de notificación",
         "description": "Artículo 23(4) NIS 2, § 32 apartado 1 BSIG.",
         "items": {
-          "s1": { "title": "Alerta temprana en 24 horas", "text": "Una primera alerta temprana al BSI en las 24 horas siguientes al conocimiento del incidente significativo, indicando si se sospecha que está causado por actos ilícitos o malintencionados y si podría tener un impacto transfronterizo." },
-          "s2": { "title": "Notificación en 72 horas", "text": "Una notificación más completa en 72 horas, que complementa la alerta temprana con una primera evaluación del incidente, su gravedad e impacto, así como indicadores de compromiso cuando estén disponibles." },
-          "s3": { "title": "Informe final tras un mes", "text": "Un informe final a más tardar un mes después de la notificación: una descripción detallada, el tipo de amenaza o la causa, las medidas correctoras aplicadas y cualquier impacto transfronterizo." }
+          "s1": {
+            "title": "Alerta temprana en 24 horas",
+            "text": "Una primera alerta temprana al BSI en las 24 horas siguientes al conocimiento del incidente significativo, indicando si se sospecha que está causado por actos ilícitos o malintencionados y si podría tener un impacto transfronterizo."
+          },
+          "s2": {
+            "title": "Notificación en 72 horas",
+            "text": "Una notificación más completa en 72 horas, que complementa la alerta temprana con una primera evaluación del incidente, su gravedad e impacto, así como indicadores de compromiso cuando estén disponibles."
+          },
+          "s3": {
+            "title": "Informe final tras un mes",
+            "text": "Un informe final a más tardar un mes después de la notificación: una descripción detallada, el tipo de amenaza o la causa, las medidas correctoras aplicadas y cualquier impacto transfronterizo."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Preguntas frecuentes",
-        "q1": { "q": "¿Cuándo empieza el plazo de 24 horas?", "a": "Cuando la entidad tiene conocimiento del incidente significativo, no cuando comenzó." },
-        "q2": { "q": "¿Existen umbrales fijos en euros para un incidente significativo?", "a": "Solo para los proveedores de servicios digitales designados en el RE (UE) 2024/2690. Para todas las demás entidades se aplican los criterios cualitativos del artículo 23(3) NIS 2." },
-        "q3": { "q": "¿Qué hago si no estoy seguro de si un incidente es significativo?", "a": "Documente su valoración y los motivos. La decisión motivada es lo que un auditor espera ver; la ausencia de toda valoración es el verdadero fallo." },
-        "q4": { "q": "¿Tengo que notificar también conforme al RGPD?", "a": "Si hay datos personales afectados, compruebe por separado el artículo 33 RGPD. Tiene su propio plazo de 72 horas y un destinatario diferente." },
-        "q5": { "q": "¿Qué ocurre tras la notificación?", "a": "El BSI puede solicitar más información, y el informe final sigue a más tardar un mes después de la notificación." }
+        "q1": {
+          "q": "¿Cuándo empieza el plazo de 24 horas?",
+          "a": "Cuando la entidad tiene conocimiento del incidente significativo, no cuando comenzó."
+        },
+        "q2": {
+          "q": "¿Existen umbrales fijos en euros para un incidente significativo?",
+          "a": "Solo para los proveedores de servicios digitales designados en el RE (UE) 2024/2690. Para todas las demás entidades se aplican los criterios cualitativos del artículo 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "¿Qué hago si no estoy seguro de si un incidente es significativo?",
+          "a": "Documente su valoración y los motivos. La decisión motivada es lo que un auditor espera ver; la ausencia de toda valoración es el verdadero fallo."
+        },
+        "q4": {
+          "q": "¿Tengo que notificar también conforme al RGPD?",
+          "a": "Si hay datos personales afectados, compruebe por separado el artículo 33 RGPD. Tiene su propio plazo de 72 horas y un destinatario diferente."
+        },
+        "q5": {
+          "q": "¿Qué ocurre tras la notificación?",
+          "a": "El BSI puede solicitar más información, y el informe final sigue a más tardar un mes después de la notificación."
+        }
       },
       "ctaCard": {
         "heading": "Estructure su proceso de notificación antes de necesitarlo",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Contribuir",
         "p1": "Pull requests bienvenidas: en particular correcciones a las citas legales (con una referencia a la fuente primaria), traducciones a otros idiomas, extensiones sectoriales (KRITIS, energía, sanidad) y deltas de transposición nacional. Para cambios sustanciales, abra primero una issue."
+      },
+      "platform": {
+        "title": "La plataforma nisd2.eu: portal, ruta, cursos",
+        "description": "La aplicación completa que hace funcionar este sitio. El portal de cumplimiento, la ruta guiada de NIS 2, la formación para la dirección y todos los datos de los marcos, en una única base de código Next.js y Drizzle. Autoalojable y con licencia AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -342,9 +342,18 @@
         "heading": "Les trois étapes de notification",
         "description": "Article 23(4) NIS 2, § 32 alinéa 1 BSIG.",
         "items": {
-          "s1": { "title": "Alerte précoce sous 24 heures", "text": "Une première alerte précoce au BSI dans les 24 heures suivant la connaissance de l'incident significatif, indiquant s'il est soupçonné d'être causé par des actes illégaux ou malveillants et s'il pourrait avoir un impact transfrontalier." },
-          "s2": { "title": "Notification sous 72 heures", "text": "Une notification plus complète dans les 72 heures, complétant l'alerte précoce par une première évaluation de l'incident, de sa gravité et de son impact, ainsi que des indicateurs de compromission lorsqu'ils sont disponibles." },
-          "s3": { "title": "Rapport final après un mois", "text": "Un rapport final au plus tard un mois après la notification : une description détaillée, le type de menace ou la cause, les mesures correctives appliquées et tout impact transfrontalier." }
+          "s1": {
+            "title": "Alerte précoce sous 24 heures",
+            "text": "Une première alerte précoce au BSI dans les 24 heures suivant la connaissance de l'incident significatif, indiquant s'il est soupçonné d'être causé par des actes illégaux ou malveillants et s'il pourrait avoir un impact transfrontalier."
+          },
+          "s2": {
+            "title": "Notification sous 72 heures",
+            "text": "Une notification plus complète dans les 72 heures, complétant l'alerte précoce par une première évaluation de l'incident, de sa gravité et de son impact, ainsi que des indicateurs de compromission lorsqu'ils sont disponibles."
+          },
+          "s3": {
+            "title": "Rapport final après un mois",
+            "text": "Un rapport final au plus tard un mois après la notification : une description détaillée, le type de menace ou la cause, les mesures correctives appliquées et tout impact transfrontalier."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Questions fréquentes",
-        "q1": { "q": "Quand commence le délai de 24 heures ?", "a": "Lorsque l'entité a connaissance de l'incident significatif, et non lorsqu'il a débuté." },
-        "q2": { "q": "Existe-t-il des seuils fixes en euros pour un incident significatif ?", "a": "Uniquement pour les fournisseurs de services numériques désignés par le RE (UE) 2024/2690. Pour toutes les autres entités, ce sont les critères qualitatifs de l'article 23(3) NIS 2 qui s'appliquent." },
-        "q3": { "q": "Que faire si je ne suis pas sûr qu'un incident soit significatif ?", "a": "Documentez votre appréciation et ses motifs. La décision motivée est ce qu'un auditeur s'attend à voir ; l'absence de toute appréciation est la véritable défaillance." },
-        "q4": { "q": "Dois-je aussi notifier au titre du RGPD ?", "a": "Si des données à caractère personnel sont concernées, vérifiez séparément l'article 33 RGPD. Il a son propre délai de 72 heures et un destinataire différent." },
-        "q5": { "q": "Que se passe-t-il après la notification ?", "a": "Le BSI peut demander des informations complémentaires, et le rapport final suit au plus tard un mois après la notification." }
+        "q1": {
+          "q": "Quand commence le délai de 24 heures ?",
+          "a": "Lorsque l'entité a connaissance de l'incident significatif, et non lorsqu'il a débuté."
+        },
+        "q2": {
+          "q": "Existe-t-il des seuils fixes en euros pour un incident significatif ?",
+          "a": "Uniquement pour les fournisseurs de services numériques désignés par le RE (UE) 2024/2690. Pour toutes les autres entités, ce sont les critères qualitatifs de l'article 23(3) NIS 2 qui s'appliquent."
+        },
+        "q3": {
+          "q": "Que faire si je ne suis pas sûr qu'un incident soit significatif ?",
+          "a": "Documentez votre appréciation et ses motifs. La décision motivée est ce qu'un auditeur s'attend à voir ; l'absence de toute appréciation est la véritable défaillance."
+        },
+        "q4": {
+          "q": "Dois-je aussi notifier au titre du RGPD ?",
+          "a": "Si des données à caractère personnel sont concernées, vérifiez séparément l'article 33 RGPD. Il a son propre délai de 72 heures et un destinataire différent."
+        },
+        "q5": {
+          "q": "Que se passe-t-il après la notification ?",
+          "a": "Le BSI peut demander des informations complémentaires, et le rapport final suit au plus tard un mois après la notification."
+        }
       },
       "ctaCard": {
         "heading": "Structurez votre processus de notification avant d'en avoir besoin",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Contribuer",
         "p1": "Les pull requests sont les bienvenues : en particulier les corrections de citations juridiques (avec une référence à une source primaire), des traductions supplémentaires, des extensions sectorielles (KRITIS, énergie, santé) et les écarts de transposition nationale. Pour les modifications importantes, veuillez d'abord ouvrir une issue."
+      },
+      "platform": {
+        "title": "La plateforme nisd2.eu : portail, parcours, cours",
+        "description": "L'application complète qui fait tourner ce site. Le portail de conformité, le parcours NIS 2 guidé, la formation destinée aux dirigeants et toutes les données des référentiels, réunis dans une seule base de code Next.js et Drizzle. Auto-hébergeable et sous licence AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -342,9 +342,18 @@
         "heading": "Le tre fasi di notifica",
         "description": "Articolo 23(4) NIS 2, § 32 comma 1 BSIG.",
         "items": {
-          "s1": { "title": "Preallarme entro 24 ore", "text": "Un primo preallarme al BSI entro 24 ore dalla conoscenza dell'incidente significativo, indicando se si sospetta che sia causato da atti illeciti o dolosi e se possa avere un impatto transfrontaliero." },
-          "s2": { "title": "Notifica entro 72 ore", "text": "Una notifica più completa entro 72 ore, che integra il preallarme con una prima valutazione dell'incidente, della sua gravità e del suo impatto, nonché degli indicatori di compromissione se disponibili." },
-          "s3": { "title": "Relazione finale dopo un mese", "text": "Una relazione finale entro un mese dalla notifica: una descrizione dettagliata, il tipo di minaccia o la causa, le misure correttive applicate ed eventuali impatti transfrontalieri." }
+          "s1": {
+            "title": "Preallarme entro 24 ore",
+            "text": "Un primo preallarme al BSI entro 24 ore dalla conoscenza dell'incidente significativo, indicando se si sospetta che sia causato da atti illeciti o dolosi e se possa avere un impatto transfrontaliero."
+          },
+          "s2": {
+            "title": "Notifica entro 72 ore",
+            "text": "Una notifica più completa entro 72 ore, che integra il preallarme con una prima valutazione dell'incidente, della sua gravità e del suo impatto, nonché degli indicatori di compromissione se disponibili."
+          },
+          "s3": {
+            "title": "Relazione finale dopo un mese",
+            "text": "Una relazione finale entro un mese dalla notifica: una descrizione dettagliata, il tipo di minaccia o la causa, le misure correttive applicate ed eventuali impatti transfrontalieri."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Domande frequenti",
-        "q1": { "q": "Quando inizia il termine di 24 ore?", "a": "Quando l'entità viene a conoscenza dell'incidente significativo, non quando è iniziato." },
-        "q2": { "q": "Esistono soglie fisse in euro per un incidente significativo?", "a": "Solo per i fornitori di servizi digitali indicati nel RE (UE) 2024/2690. Per tutte le altre entità si applicano i criteri qualitativi dell'articolo 23(3) NIS 2." },
-        "q3": { "q": "Cosa faccio se non sono sicuro che un incidente sia significativo?", "a": "Documentate la vostra valutazione e le ragioni. La decisione motivata è ciò che un auditor si aspetta di vedere; l'assenza di qualsiasi valutazione è la vera mancanza." },
-        "q4": { "q": "Devo notificare anche ai sensi del GDPR?", "a": "Se sono coinvolti dati personali, verificate separatamente l'articolo 33 GDPR. Ha un proprio termine di 72 ore e un destinatario diverso." },
-        "q5": { "q": "Cosa succede dopo la notifica?", "a": "Il BSI può richiedere ulteriori informazioni e la relazione finale segue entro un mese dalla notifica." }
+        "q1": {
+          "q": "Quando inizia il termine di 24 ore?",
+          "a": "Quando l'entità viene a conoscenza dell'incidente significativo, non quando è iniziato."
+        },
+        "q2": {
+          "q": "Esistono soglie fisse in euro per un incidente significativo?",
+          "a": "Solo per i fornitori di servizi digitali indicati nel RE (UE) 2024/2690. Per tutte le altre entità si applicano i criteri qualitativi dell'articolo 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "Cosa faccio se non sono sicuro che un incidente sia significativo?",
+          "a": "Documentate la vostra valutazione e le ragioni. La decisione motivata è ciò che un auditor si aspetta di vedere; l'assenza di qualsiasi valutazione è la vera mancanza."
+        },
+        "q4": {
+          "q": "Devo notificare anche ai sensi del GDPR?",
+          "a": "Se sono coinvolti dati personali, verificate separatamente l'articolo 33 GDPR. Ha un proprio termine di 72 ore e un destinatario diverso."
+        },
+        "q5": {
+          "q": "Cosa succede dopo la notifica?",
+          "a": "Il BSI può richiedere ulteriori informazioni e la relazione finale segue entro un mese dalla notifica."
+        }
       },
       "ctaCard": {
         "heading": "Strutturate il vostro processo di notifica prima di averne bisogno",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Contribuire",
         "p1": "Pull request benvenute: in particolare correzioni alle citazioni giuridiche (con riferimento a una fonte primaria), traduzioni in altre lingue, estensioni settoriali (KRITIS, energia, sanità) e delta di recepimento nazionale. Per modifiche sostanziali, apri prima una issue."
+      },
+      "platform": {
+        "title": "La piattaforma nisd2.eu: portale, percorso, corsi",
+        "description": "L'applicazione completa che alimenta questo sito. Il portale di conformità, il percorso guidato NIS 2, la formazione per la direzione e tutti i dati dei framework in un'unica codebase Next.js e Drizzle. Autoospitabile e rilasciata sotto licenza AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -342,9 +342,18 @@
         "heading": "De drie meldfasen",
         "description": "Artikel 23 lid 4 NIS 2, § 32 lid 1 BSIG.",
         "items": {
-          "s1": { "title": "Vroegtijdige waarschuwing binnen 24 uur", "text": "Een eerste vroegtijdige waarschuwing aan het BSI binnen 24 uur na kennisname van het significante incident, met vermelding of een onrechtmatige of kwaadwillige oorzaak wordt vermoed en of grensoverschrijdende gevolgen mogelijk zijn." },
-          "s2": { "title": "Melding binnen 72 uur", "text": "Een uitgebreidere melding binnen 72 uur, die de vroegtijdige waarschuwing aanvult met een eerste beoordeling van het incident, de ernst en de gevolgen, en beschikbare compromittatie-indicatoren." },
-          "s3": { "title": "Eindrapport na één maand", "text": "Een eindrapport uiterlijk één maand na de melding: een gedetailleerde beschrijving, het type dreiging of de oorzaak, de getroffen maatregelen en eventuele grensoverschrijdende gevolgen." }
+          "s1": {
+            "title": "Vroegtijdige waarschuwing binnen 24 uur",
+            "text": "Een eerste vroegtijdige waarschuwing aan het BSI binnen 24 uur na kennisname van het significante incident, met vermelding of een onrechtmatige of kwaadwillige oorzaak wordt vermoed en of grensoverschrijdende gevolgen mogelijk zijn."
+          },
+          "s2": {
+            "title": "Melding binnen 72 uur",
+            "text": "Een uitgebreidere melding binnen 72 uur, die de vroegtijdige waarschuwing aanvult met een eerste beoordeling van het incident, de ernst en de gevolgen, en beschikbare compromittatie-indicatoren."
+          },
+          "s3": {
+            "title": "Eindrapport na één maand",
+            "text": "Een eindrapport uiterlijk één maand na de melding: een gedetailleerde beschrijving, het type dreiging of de oorzaak, de getroffen maatregelen en eventuele grensoverschrijdende gevolgen."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Veelgestelde vragen",
-        "q1": { "q": "Wanneer begint de klok van 24 uur?", "a": "Zodra de entiteit kennis krijgt van het significante incident, niet wanneer het begon." },
-        "q2": { "q": "Zijn er vaste eurodrempels voor een significant incident?", "a": "Alleen voor de in CIR (EU) 2024/2690 genoemde aanbieders van digitale diensten. Voor alle andere entiteiten gelden de kwalitatieve criteria uit artikel 23 lid 3 NIS 2." },
-        "q3": { "q": "Wat als ik niet zeker weet of een incident significant is?", "a": "Documenteer uw beoordeling en de redenen. De onderbouwde beslissing is wat een auditor wil zien; het ontbreken van elke beoordeling is de echte tekortkoming." },
-        "q4": { "q": "Moet ik ook onder de AVG melden?", "a": "Als persoonsgegevens betrokken zijn, controleer artikel 33 AVG apart. Het heeft een eigen termijn van 72 uur en een andere adressaat." },
-        "q5": { "q": "Wat gebeurt er na de melding?", "a": "Het BSI kan nadere informatie opvragen, en het eindrapport volgt uiterlijk één maand na de melding." }
+        "q1": {
+          "q": "Wanneer begint de klok van 24 uur?",
+          "a": "Zodra de entiteit kennis krijgt van het significante incident, niet wanneer het begon."
+        },
+        "q2": {
+          "q": "Zijn er vaste eurodrempels voor een significant incident?",
+          "a": "Alleen voor de in CIR (EU) 2024/2690 genoemde aanbieders van digitale diensten. Voor alle andere entiteiten gelden de kwalitatieve criteria uit artikel 23 lid 3 NIS 2."
+        },
+        "q3": {
+          "q": "Wat als ik niet zeker weet of een incident significant is?",
+          "a": "Documenteer uw beoordeling en de redenen. De onderbouwde beslissing is wat een auditor wil zien; het ontbreken van elke beoordeling is de echte tekortkoming."
+        },
+        "q4": {
+          "q": "Moet ik ook onder de AVG melden?",
+          "a": "Als persoonsgegevens betrokken zijn, controleer artikel 33 AVG apart. Het heeft een eigen termijn van 72 uur en een andere adressaat."
+        },
+        "q5": {
+          "q": "Wat gebeurt er na de melding?",
+          "a": "Het BSI kan nadere informatie opvragen, en het eindrapport volgt uiterlijk één maand na de melding."
+        }
       },
       "ctaCard": {
         "heading": "Structureer uw meldproces voordat u het nodig heeft",
@@ -6640,6 +6664,10 @@
       "contribute": {
         "heading": "Contributing",
         "p1": "Pull requests welcome: particularly corrections to legal citations (with a primary-source reference), additional language translations, sector-specific extensions (KRITIS, energy, healthcare), and national transposition deltas. For substantial changes please open an issue first."
+      },
+      "platform": {
+        "title": "Het nisd2.eu-platform: portaal, traject, cursussen",
+        "description": "De volledige applicatie die deze site aandrijft. Het Compliance-portaal, het begeleide NIS 2-traject, de bestuurderscursus en alle frameworkgegevens in een Next.js- en Drizzle-codebase. Zelf te hosten en gelicentieerd onder AGPL-3.0."
       }
     },
     "partners": {

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -342,9 +342,18 @@
         "heading": "Trzy etapy zgłaszania",
         "description": "Artykuł 23(4) NIS 2, § 32 ustęp 1 BSIG.",
         "items": {
-          "s1": { "title": "Wczesne ostrzeżenie w ciągu 24 godzin", "text": "Pierwsze wczesne ostrzeżenie do BSI w ciągu 24 godzin od powzięcia wiadomości o poważnym incydencie, ze wskazaniem, czy istnieje podejrzenie, że został spowodowany działaniami bezprawnymi lub złośliwymi, oraz czy może mieć skutki transgraniczne." },
-          "s2": { "title": "Zgłoszenie w ciągu 72 godzin", "text": "Pełniejsze zgłoszenie w ciągu 72 godzin, uzupełniające wczesne ostrzeżenie o pierwszą ocenę incydentu, jego powagi i skutków, a także o wskaźniki naruszenia, jeśli są dostępne." },
-          "s3": { "title": "Raport końcowy po miesiącu", "text": "Raport końcowy najpóźniej miesiąc po zgłoszeniu: szczegółowy opis, rodzaj zagrożenia lub przyczynę, zastosowane środki zaradcze oraz wszelkie skutki transgraniczne." }
+          "s1": {
+            "title": "Wczesne ostrzeżenie w ciągu 24 godzin",
+            "text": "Pierwsze wczesne ostrzeżenie do BSI w ciągu 24 godzin od powzięcia wiadomości o poważnym incydencie, ze wskazaniem, czy istnieje podejrzenie, że został spowodowany działaniami bezprawnymi lub złośliwymi, oraz czy może mieć skutki transgraniczne."
+          },
+          "s2": {
+            "title": "Zgłoszenie w ciągu 72 godzin",
+            "text": "Pełniejsze zgłoszenie w ciągu 72 godzin, uzupełniające wczesne ostrzeżenie o pierwszą ocenę incydentu, jego powagi i skutków, a także o wskaźniki naruszenia, jeśli są dostępne."
+          },
+          "s3": {
+            "title": "Raport końcowy po miesiącu",
+            "text": "Raport końcowy najpóźniej miesiąc po zgłoszeniu: szczegółowy opis, rodzaj zagrożenia lub przyczynę, zastosowane środki zaradcze oraz wszelkie skutki transgraniczne."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Najczęstsze pytania",
-        "q1": { "q": "Kiedy zaczyna biec termin 24 godzin?", "a": "Gdy podmiot dowiaduje się o poważnym incydencie, a nie gdy się on rozpoczął." },
-        "q2": { "q": "Czy istnieją stałe progi w euro dla poważnego incydentu?", "a": "Tylko dla dostawców usług cyfrowych wskazanych w RW (UE) 2024/2690. Dla wszystkich innych podmiotów stosuje się kryteria jakościowe z artykułu 23(3) NIS 2." },
-        "q3": { "q": "Co zrobić, jeśli nie jestem pewien, czy incydent jest poważny?", "a": "Udokumentujcie swoją ocenę i jej powody. Uzasadniona decyzja jest tym, czego oczekuje audytor; brak jakiejkolwiek oceny jest właściwym uchybieniem." },
-        "q4": { "q": "Czy muszę zgłaszać także na podstawie RODO?", "a": "Jeśli dotyczy to danych osobowych, sprawdźcie odrębnie artykuł 33 RODO. Ma własny 72-godzinny termin i innego adresata." },
-        "q5": { "q": "Co dzieje się po zgłoszeniu?", "a": "BSI może zażądać dalszych informacji, a raport końcowy następuje najpóźniej miesiąc po zgłoszeniu." }
+        "q1": {
+          "q": "Kiedy zaczyna biec termin 24 godzin?",
+          "a": "Gdy podmiot dowiaduje się o poważnym incydencie, a nie gdy się on rozpoczął."
+        },
+        "q2": {
+          "q": "Czy istnieją stałe progi w euro dla poważnego incydentu?",
+          "a": "Tylko dla dostawców usług cyfrowych wskazanych w RW (UE) 2024/2690. Dla wszystkich innych podmiotów stosuje się kryteria jakościowe z artykułu 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "Co zrobić, jeśli nie jestem pewien, czy incydent jest poważny?",
+          "a": "Udokumentujcie swoją ocenę i jej powody. Uzasadniona decyzja jest tym, czego oczekuje audytor; brak jakiejkolwiek oceny jest właściwym uchybieniem."
+        },
+        "q4": {
+          "q": "Czy muszę zgłaszać także na podstawie RODO?",
+          "a": "Jeśli dotyczy to danych osobowych, sprawdźcie odrębnie artykuł 33 RODO. Ma własny 72-godzinny termin i innego adresata."
+        },
+        "q5": {
+          "q": "Co dzieje się po zgłoszeniu?",
+          "a": "BSI może zażądać dalszych informacji, a raport końcowy następuje najpóźniej miesiąc po zgłoszeniu."
+        }
       },
       "ctaCard": {
         "heading": "Uporządkujcie proces zgłaszania, zanim będzie potrzebny",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Współtworzenie",
         "p1": "Pull requesty mile widziane: w szczególności poprawki cytatów prawnych (z odniesieniem do źródła pierwotnego), dodatkowe tłumaczenia językowe, rozszerzenia sektorowe (KRITIS, energetyka, ochrona zdrowia) oraz różnice w transpozycjach krajowych. W przypadku istotnych zmian prosimy najpierw o otwarcie zgłoszenia."
+      },
+      "platform": {
+        "title": "Platforma nisd2.eu: portal, ścieżka, kursy",
+        "description": "Kompletna aplikacja, która obsługuje tę stronę. Portal zgodności, prowadzona ścieżka NIS 2, szkolenie dla kadry zarządzającej oraz wszystkie dane frameworków w jednej bazie kodu opartej na Next.js i Drizzle. Możliwość samodzielnego hostowania, licencja AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -342,9 +342,18 @@
         "heading": "As três fases de notificação",
         "description": "Artigo 23(4) NIS 2, § 32 n.º 1 BSIG.",
         "items": {
-          "s1": { "title": "Alerta precoce em 24 horas", "text": "Um primeiro alerta precoce ao BSI no prazo de 24 horas após o conhecimento do incidente significativo, indicando se se suspeita ter sido causado por atos ilícitos ou maliciosos e se poderá ter um impacto transfronteiriço." },
-          "s2": { "title": "Notificação em 72 horas", "text": "Uma notificação mais completa em 72 horas, que complementa o alerta precoce com uma primeira avaliação do incidente, da sua gravidade e impacto, bem como indicadores de comprometimento, quando disponíveis." },
-          "s3": { "title": "Relatório final após um mês", "text": "Um relatório final o mais tardar um mês após a notificação: uma descrição detalhada, o tipo de ameaça ou a causa, as medidas corretivas aplicadas e qualquer impacto transfronteiriço." }
+          "s1": {
+            "title": "Alerta precoce em 24 horas",
+            "text": "Um primeiro alerta precoce ao BSI no prazo de 24 horas após o conhecimento do incidente significativo, indicando se se suspeita ter sido causado por atos ilícitos ou maliciosos e se poderá ter um impacto transfronteiriço."
+          },
+          "s2": {
+            "title": "Notificação em 72 horas",
+            "text": "Uma notificação mais completa em 72 horas, que complementa o alerta precoce com uma primeira avaliação do incidente, da sua gravidade e impacto, bem como indicadores de comprometimento, quando disponíveis."
+          },
+          "s3": {
+            "title": "Relatório final após um mês",
+            "text": "Um relatório final o mais tardar um mês após a notificação: uma descrição detalhada, o tipo de ameaça ou a causa, as medidas corretivas aplicadas e qualquer impacto transfronteiriço."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Perguntas frequentes",
-        "q1": { "q": "Quando começa o prazo de 24 horas?", "a": "Quando a entidade toma conhecimento do incidente significativo, não quando este começou." },
-        "q2": { "q": "Existem limiares fixos em euros para um incidente significativo?", "a": "Apenas para os prestadores de serviços digitais designados no RE (UE) 2024/2690. Para todas as outras entidades aplicam-se os critérios qualitativos do artigo 23(3) NIS 2." },
-        "q3": { "q": "E se eu não tiver a certeza de que um incidente é significativo?", "a": "Documente a sua apreciação e os motivos. A decisão fundamentada é o que um auditor espera ver; a ausência de qualquer apreciação é a verdadeira falha." },
-        "q4": { "q": "Também tenho de notificar ao abrigo do RGPD?", "a": "Se houver dados pessoais envolvidos, verifique separadamente o artigo 33 RGPD. Tem o seu próprio prazo de 72 horas e um destinatário diferente." },
-        "q5": { "q": "O que acontece após a notificação?", "a": "O BSI pode solicitar mais informações, e o relatório final segue o mais tardar um mês após a notificação." }
+        "q1": {
+          "q": "Quando começa o prazo de 24 horas?",
+          "a": "Quando a entidade toma conhecimento do incidente significativo, não quando este começou."
+        },
+        "q2": {
+          "q": "Existem limiares fixos em euros para um incidente significativo?",
+          "a": "Apenas para os prestadores de serviços digitais designados no RE (UE) 2024/2690. Para todas as outras entidades aplicam-se os critérios qualitativos do artigo 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "E se eu não tiver a certeza de que um incidente é significativo?",
+          "a": "Documente a sua apreciação e os motivos. A decisão fundamentada é o que um auditor espera ver; a ausência de qualquer apreciação é a verdadeira falha."
+        },
+        "q4": {
+          "q": "Também tenho de notificar ao abrigo do RGPD?",
+          "a": "Se houver dados pessoais envolvidos, verifique separadamente o artigo 33 RGPD. Tem o seu próprio prazo de 72 horas e um destinatário diferente."
+        },
+        "q5": {
+          "q": "O que acontece após a notificação?",
+          "a": "O BSI pode solicitar mais informações, e o relatório final segue o mais tardar um mês após a notificação."
+        }
       },
       "ctaCard": {
         "heading": "Estruture o seu processo de notificação antes de precisar dele",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Contribuir",
         "p1": "Pull requests bem-vindos: em particular correções a citações legais (com referência à fonte primária), traduções para línguas adicionais, extensões específicas por setor (KRITIS, energia, saúde) e diferenças de transposição nacional. Para alterações substanciais, abra primeiro um issue."
+      },
+      "platform": {
+        "title": "A plataforma nisd2.eu: portal, percurso, cursos",
+        "description": "A aplicação completa que faz funcionar este site. O portal de conformidade, o percurso guiado de NIS 2, a formação para gestão e todos os dados dos frameworks, numa única base de código Next.js e Drizzle. Alojável de forma autónoma e licenciada sob AGPL-3.0."
       }
     },
     "status": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -342,9 +342,18 @@
         "heading": "Cele trei etape de notificare",
         "description": "Articolul 23(4) NIS 2, Articolul 32 alineatul 1 BSIG.",
         "items": {
-          "s1": { "title": "Avertizare timpurie in 24 de ore", "text": "O prima avertizare timpurie catre BSI in termen de 24 de ore de la luarea la cunostinta a incidentului semnificativ, indicand daca se suspecteaza ca a fost cauzat de acte ilicite sau rau intentionate si daca ar putea avea un impact transfrontalier." },
-          "s2": { "title": "Notificare in 72 de ore", "text": "O notificare mai completa in 72 de ore, care completeaza avertizarea timpurie cu o prima evaluare a incidentului, a gravitatii si impactului acestuia, precum si cu indicatori de compromitere, atunci cand sunt disponibili." },
-          "s3": { "title": "Raport final dupa o luna", "text": "Un raport final cel tarziu la o luna dupa notificare: o descriere detaliata, tipul de amenintare sau cauza, masurile corective aplicate si orice impact transfrontalier." }
+          "s1": {
+            "title": "Avertizare timpurie in 24 de ore",
+            "text": "O prima avertizare timpurie catre BSI in termen de 24 de ore de la luarea la cunostinta a incidentului semnificativ, indicand daca se suspecteaza ca a fost cauzat de acte ilicite sau rau intentionate si daca ar putea avea un impact transfrontalier."
+          },
+          "s2": {
+            "title": "Notificare in 72 de ore",
+            "text": "O notificare mai completa in 72 de ore, care completeaza avertizarea timpurie cu o prima evaluare a incidentului, a gravitatii si impactului acestuia, precum si cu indicatori de compromitere, atunci cand sunt disponibili."
+          },
+          "s3": {
+            "title": "Raport final dupa o luna",
+            "text": "Un raport final cel tarziu la o luna dupa notificare: o descriere detaliata, tipul de amenintare sau cauza, masurile corective aplicate si orice impact transfrontalier."
+          }
         }
       },
       "significant": {
@@ -364,11 +373,26 @@
       },
       "faq": {
         "heading": "Intrebari frecvente",
-        "q1": { "q": "Cand incepe termenul de 24 de ore?", "a": "Cand entitatea ia cunostinta de incidentul semnificativ, nu cand a inceput." },
-        "q2": { "q": "Exista praguri fixe in euro pentru un incident semnificativ?", "a": "Doar pentru furnizorii de servicii digitale desemnati in RPA (UE) 2024/2690. Pentru toate celelalte entitati se aplica criteriile calitative din articolul 23(3) NIS 2." },
-        "q3": { "q": "Ce fac daca nu sunt sigur ca un incident este semnificativ?", "a": "Documentati evaluarea si motivele. Decizia motivata este ceea ce asteapta un auditor; absenta oricarei evaluari este adevarata deficienta." },
-        "q4": { "q": "Trebuie sa notific si in temeiul RGPD?", "a": "Daca sunt implicate date cu caracter personal, verificati separat articolul 33 RGPD. Are propriul termen de 72 de ore si un destinatar diferit." },
-        "q5": { "q": "Ce se intampla dupa notificare?", "a": "BSI poate solicita informatii suplimentare, iar raportul final urmeaza cel tarziu la o luna dupa notificare." }
+        "q1": {
+          "q": "Cand incepe termenul de 24 de ore?",
+          "a": "Cand entitatea ia cunostinta de incidentul semnificativ, nu cand a inceput."
+        },
+        "q2": {
+          "q": "Exista praguri fixe in euro pentru un incident semnificativ?",
+          "a": "Doar pentru furnizorii de servicii digitale desemnati in RPA (UE) 2024/2690. Pentru toate celelalte entitati se aplica criteriile calitative din articolul 23(3) NIS 2."
+        },
+        "q3": {
+          "q": "Ce fac daca nu sunt sigur ca un incident este semnificativ?",
+          "a": "Documentati evaluarea si motivele. Decizia motivata este ceea ce asteapta un auditor; absenta oricarei evaluari este adevarata deficienta."
+        },
+        "q4": {
+          "q": "Trebuie sa notific si in temeiul RGPD?",
+          "a": "Daca sunt implicate date cu caracter personal, verificati separat articolul 33 RGPD. Are propriul termen de 72 de ore si un destinatar diferit."
+        },
+        "q5": {
+          "q": "Ce se intampla dupa notificare?",
+          "a": "BSI poate solicita informatii suplimentare, iar raportul final urmeaza cel tarziu la o luna dupa notificare."
+        }
       },
       "ctaCard": {
         "heading": "Structurati-va procesul de notificare inainte sa aveti nevoie de el",
@@ -6217,6 +6241,10 @@
       "contribute": {
         "heading": "Contribuții",
         "p1": "Pull request-urile sunt binevenite: în special corecturi la citatele juridice (cu o referință la sursa primară), traduceri suplimentare în alte limbi, extensii specifice sectorului (KRITIS, energie, sănătate) și diferențe de transpunere națională. Pentru modificări substanțiale, vă rugăm să deschideți mai întâi o problemă."
+      },
+      "platform": {
+        "title": "Platforma nisd2.eu: portal, parcurs, cursuri",
+        "description": "Aplicația completă care rulează acest site. Portalul de conformitate, parcursul ghidat NIS 2, cursul pentru conducere și toate datele privind cadrele de reglementare, într-o singură bază de cod Next.js și Drizzle. Poate fi găzduită independent și este licențiată sub AGPL-3.0."
       }
     },
     "status": {


### PR DESCRIPTION
Adds NISD2/open-isms (the AGPL-3.0 platform that runs the site) as the first entry on /open-source, above the schema and data repos. Title and description translated across all 10 locales.