### PR TITLE
data(grc-vergleich): add Kopexa to the vendor pricing audit

### DIFF
--- a/data/grc-vendors.json
+++ b/data/grc-vendors.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-17",
+  "lastUpdated": "2026-07-20",
   "methodology": {
     "de": "Wir haben am 17. Mai 2026 die Preisseiten von ~150 GRC/ISMS/NIS2-Anbietern besucht. Preise wurden wörtlich von der eigenen Website jedes Anbieters übernommen. Wo Preise hinter einem Demo-Formular versteckt sind, steht 'Demo-Termin erforderlich'. Keine Extrapolation aus G2, Capterra oder Drittquellen.",
     "en": "On 17 May 2026 we visited the pricing pages of ~150 GRC/ISMS/NIS2 vendors. Prices are quoted verbatim from each vendor's own website. Where pricing is hidden behind a demo form we record 'Demo call required'. No extrapolation from G2, Capterra or third-party sources."
@@ -595,6 +595,28 @@
         "en": "Open-source Vanta alternative"
       },
       "lastVerified": "2026-05-17"
+    },
+    {
+      "id": "kopexa",
+      "name": "Kopexa",
+      "country": "DE",
+      "tier": "transparent",
+      "category": "grc",
+      "entryPriceEur": 249,
+      "priceModel": {
+        "de": "€249/Monat pro Space (Lite, 12 Monate Laufzeit); Pro €599/Monat; Enterprise auf Anfrage",
+        "en": "€249/month per Space (Lite, 12-month term); Pro €599/month; Enterprise on request"
+      },
+      "nis2Listed": true,
+      "frameworks": ["NIS2", "ISO 27001", "TISAX", "GDPR", "DORA"],
+      "freeTier": "trial",
+      "formLikeness": "medium",
+      "sourceUrl": "https://kopexa.com/pricing",
+      "notes": {
+        "de": "Auf Hinweis des Anbieters im Juli 2026 aufgenommen. Preise vollständig öffentlich, 14 Tage Test ohne Kreditkarte.",
+        "en": "Added in July 2026 after the vendor pointed out the omission. Pricing fully public, 14-day trial without credit card."
+      },
+      "lastVerified": "2026-07-20"
     },
     {
       "id": "strike-graph",

--- a/messages/grcComparison/de.json
+++ b/messages/grcComparison/de.json
@@ -1,12 +1,12 @@
 {
   "grcComparison": {
     "meta": {
-      "title": "GRC / ISMS / NIS2 Preisvergleich: 136 kommerzielle Anbieter geprüft",
-      "description": "Wir haben am 17. Mai 2026 die Preisseiten von 136 kommerziellen GRC-, ISMS- und NIS2-Plattformen besucht. 103 davon verlangen einen Demo-Termin, um den Preis überhaupt zu erfahren. Hier ist die ganze Liste, sortiert und filterbar. Neun Open-Source-Alternativen sind bewusst ausgenommen."
+      "title": "GRC / ISMS / NIS2 Preisvergleich: 137 kommerzielle Anbieter geprüft",
+      "description": "Wir haben seit dem 17. Mai 2026 die Preisseiten von 137 kommerziellen GRC-, ISMS- und NIS2-Plattformen besucht. 103 davon verlangen einen Demo-Termin, um den Preis überhaupt zu erfahren. Hier ist die ganze Liste, sortiert und filterbar. Neun Open-Source-Alternativen sind bewusst ausgenommen."
     },
     "hero": {
-      "eyebrow": "Markt-Audit · 17. Mai 2026",
-      "title": "Wir haben 136 kommerzielle GRC/ISMS-Plattformen geprüft. 103 sagen dir nicht, was sie kosten.",
+      "eyebrow": "Marktaudit · Stand 20. Juli 2026",
+      "title": "Wir haben 137 kommerzielle GRC/ISMS-Plattformen geprüft. 103 sagen dir nicht, was sie kosten.",
       "subtitle": "Wir haben die Preisseite jedes Anbieters wörtlich erfasst. Wo Preise hinter einem Demo-Formular versteckt sind, steht 'Demo-Termin erforderlich'. Keine Schätzungen, keine Drittquellen. Neun Open-Source-Alternativen (verinice, CISO Assistant, Deming, ISMS Builder, Unicis CE, wir selbst und weitere) sind nicht in dieser Liste, weil sie dir kein Abo verkaufen.",
       "ctaPlatform": "Kostenlos starten",
       "ctaMethodology": "Methodik"
@@ -23,7 +23,7 @@
     },
     "thesis": {
       "title": "Warum dieser Markt reif für Disruption ist",
-      "body": "76 % dieser 136 kommerziellen GRC/ISMS-Anbieter verstecken ihre Preise. Die Produkte sind im Kern Formulare, Vorlagen und Checklisten, auf eine Datenbank gesetzt. Die Grenzkosten für einen weiteren Kunden gehen gegen null. Die Preise nicht. Hier sind die Beweise.",
+      "body": "75 % dieser 137 kommerziellen GRC/ISMS-Anbieter verstecken ihre Preise. Die Produkte sind im Kern Formulare, Vorlagen und Checklisten, auf eine Datenbank gesetzt. Die Grenzkosten für einen weiteren Kunden gehen gegen null. Die Preise nicht. Hier sind die Beweise.",
       "points": [
         {
           "title": "Verträge mit 5-stelligen Jahresgebühren für ein Formular",

--- a/messages/grcComparison/en.json
+++ b/messages/grcComparison/en.json
@@ -1,12 +1,12 @@
 {
   "grcComparison": {
     "meta": {
-      "title": "GRC / ISMS / NIS2 pricing audit: 136 commercial vendors verified",
-      "description": "On 17 May 2026 we visited the pricing pages of 136 commercial GRC, ISMS and NIS2 platforms. 103 of them won't tell you what they cost without a demo call. Here's the full list, sortable and filterable. Nine open-source alternatives are excluded by design."
+      "title": "GRC / ISMS / NIS2 pricing audit: 137 commercial vendors verified",
+      "description": "Since 17 May 2026 we have visited the pricing pages of 137 commercial GRC, ISMS and NIS2 platforms. 103 of them won't tell you what they cost without a demo call. Here's the full list, sortable and filterable. Nine open-source alternatives are excluded by design."
     },
     "hero": {
-      "eyebrow": "Market audit · 17 May 2026",
-      "title": "We audited 136 commercial GRC/ISMS platforms. 103 won't tell you what they cost.",
+      "eyebrow": "Market audit · updated 20 July 2026",
+      "title": "We audited 137 commercial GRC/ISMS platforms. 103 won't tell you what they cost.",
       "subtitle": "We captured every vendor's pricing page verbatim. Where pricing is hidden behind a demo form we record 'Demo call required'. No estimates, no third-party sources. Nine open-source alternatives (verinice, CISO Assistant, Deming, ISMS Builder, Unicis CE, ourselves and others) are excluded from this list because they don't sell you a subscription.",
       "ctaPlatform": "Start free",
       "ctaMethodology": "Methodology"
@@ -23,7 +23,7 @@
     },
     "thesis": {
       "title": "Why this market is ripe for disruption",
-      "body": "76% of these 136 commercial GRC/ISMS vendors hide their prices. The products are forms, templates and checklists on top of a database. The marginal cost of one more customer is near zero. The price is not. Here are the receipts.",
+      "body": "75% of these 137 commercial GRC/ISMS vendors hide their prices. The products are forms, templates and checklists on top of a database. The marginal cost of one more customer is near zero. The price is not. Here are the receipts.",
       "points": [
         {
           "title": "Five-figure annual contracts for a form",

--- a/messages/grcComparison/nl.json
+++ b/messages/grcComparison/nl.json
@@ -1,12 +1,12 @@
 {
   "grcComparison": {
     "meta": {
-      "title": "GRC / ISMS / NIS2 prijsvergelijking: 136 commerciële leveranciers gecontroleerd",
-      "description": "Op 17 mei 2026 hebben we de prijspagina's van 136 commerciële GRC-, ISMS- en NIS2-platforms bezocht. 103 daarvan vertellen je niet wat ze kosten zonder een demo-call. Hier is de hele lijst, sorteerbaar en filterbaar. Negen open-source alternatieven zijn bewust niet opgenomen."
+      "title": "GRC / ISMS / NIS2 prijsvergelijking: 137 commerciële leveranciers gecontroleerd",
+      "description": "Sinds 17 mei 2026 hebben we de prijspagina's van 137 commerciële GRC-, ISMS- en NIS2-platforms bezocht. 103 daarvan vertellen je niet wat ze kosten zonder een demo-call. Hier is de hele lijst, sorteerbaar en filterbaar. Negen open-source alternatieven zijn bewust niet opgenomen."
     },
     "hero": {
-      "eyebrow": "Marktonderzoek · 17 mei 2026",
-      "title": "We hebben 136 commerciële GRC/ISMS-platforms onderzocht. 103 vertellen je niet wat ze kosten.",
+      "eyebrow": "Marktonderzoek · bijgewerkt 20 juli 2026",
+      "title": "We hebben 137 commerciële GRC/ISMS-platforms onderzocht. 103 vertellen je niet wat ze kosten.",
       "subtitle": "We hebben elke prijspagina woordelijk vastgelegd. Waar prijzen achter een demo-formulier verborgen zijn, schrijven we 'Demo-call vereist'. Geen schattingen, geen derde bronnen. Negen open-source alternatieven (verinice, CISO Assistant, Deming, ISMS Builder, Unicis CE, wijzelf en anderen) staan niet in deze lijst omdat ze je geen abonnement verkopen.",
       "ctaPlatform": "Gratis starten",
       "ctaMethodology": "Methodologie"
@@ -23,7 +23,7 @@
     },
     "thesis": {
       "title": "Waarom deze markt klaar is voor disruptie",
-      "body": "76% van deze 136 commerciële GRC/ISMS-leveranciers verbergt hun prijzen. De producten zijn formulieren, sjablonen en checklists bovenop een database. De marginale kosten per extra klant zijn bijna nul. De prijs niet. Hier zijn de bewijzen.",
+      "body": "75% van deze 137 commerciële GRC/ISMS-leveranciers verbergt hun prijzen. De producten zijn formulieren, sjablonen en checklists bovenop een database. De marginale kosten per extra klant zijn bijna nul. De prijs niet. Hier zijn de bewijzen.",
       "points": [
         {
           "title": "Vijfcijferige jaarcontracten voor een formulier",


### PR DESCRIPTION
Kopexa (Nikolai Shulgin) pointed out via LinkedIn that they are missing from the /wiki/vergleich/grc-vergleich pricing audit. Verified their pricing page on 2026-07-20.

## Entry
- Kopexa GmbH, DE, GRC/ISMS for SMEs
- Transparent tier: Lite EUR 249/month per Space (12-month term), Pro EUR 599/month, Enterprise on request
- 14-day trial without credit card
- Frameworks: NIS2, ISO 27001, TISAX, GDPR, DORA
- Source: https://kopexa.com/pricing

## Derived numbers updated in de/en/nl copy
- Commercial vendors: 136 -> 137
- Demo-gated count stays 103 (102 gated + 1 unverifiable)
- Hidden-pricing share: 76% -> 75% (103/137)
- Audit date phrasing changed from 'On 17 May 2026' to 'Since 17 May 2026'; hero eyebrow now says updated 20 July 2026
- dataset lastUpdated bumped to 2026-07-20

Validated with the Zod schema (loadVendorDataset + summarise): 137 commercial, 22 transparent, 102 gated, 1 unverifiable.