### PR TITLE
fix(forms): ISO date columns everywhere, Date objects for timestamps, global mutation error toasts

### DIFF
--- a/components/assets/AssetsPage.tsx
+++ b/components/assets/AssetsPage.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Server, Pencil, Trash2 } from "lucide-react";
-import { toast } from "sonner";
 
 const OTHER_VALUE = "__other__";
 
@@ -144,10 +143,9 @@ export function AssetsPage({ items, inline, focus, policyData }: AssetsPageProps
   const t = useTranslations("assets");
   const router = useRouter();
   const refresh = () => router.refresh();
-  const onError = (err: { message: string }) => toast.error(err.message);
-  const createMut = trpc.asset.create.useMutation({ onSuccess: refresh, onError });
-  const updateMut = trpc.asset.update.useMutation({ onSuccess: refresh, onError });
-  const deleteMut = trpc.asset.delete.useMutation({ onSuccess: refresh, onError });
+  const createMut = trpc.asset.create.useMutation({ onSuccess: refresh });
+  const updateMut = trpc.asset.update.useMutation({ onSuccess: refresh });
+  const deleteMut = trpc.asset.delete.useMutation({ onSuccess: refresh });
 
   const omit = useMemo(() => {
     if (!focus) return DEFAULT_OMIT;

--- a/lib/forms/field-renderer.tsx
+++ b/lib/forms/field-renderer.tsx
@@ -223,8 +223,11 @@ export function renderFieldInput(
           {...field}
           value={dateValue}
           onChange={(e) => {
-            // null, not "" — nullable date schemas reject the empty string
-            field.onChange(e.target.value || null);
+            // null, not "" — nullable date schemas reject the empty string.
+            // z.date() fields (timestamp columns) need a real Date; the
+            // input's string never passes them.
+            const v = e.target.value;
+            field.onChange(v ? (meta.jsDate ? new Date(v) : v) : null);
           }}
         />
       );

--- a/lib/forms/schema-introspect.ts
+++ b/lib/forms/schema-introspect.ts
@@ -44,6 +44,8 @@ export interface FieldMeta {
   min?: number;
   max?: number;
   isInteger?: boolean;
+  /** True when the schema expects a JS Date (z.date / timestamp column) rather than an ISO string (z.iso.date / pg date column). */
+  jsDate?: boolean;
   label: string;
 }
 
@@ -130,6 +132,7 @@ function resolveType(zodType: any, meta: FieldMeta): void {
 
     case "date":
       meta.type = "date";
+      meta.jsDate = true;
       return;
 
     case "array":

--- a/lib/trpc/provider.tsx
+++ b/lib/trpc/provider.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MutationCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
+import { toast } from "sonner";
 import { trpc } from "./client";
 
 function getBaseUrl() {
@@ -16,6 +17,14 @@ export function TRPCProvider({ children }: { children: React.ReactNode }) {
     () =>
       new QueryClient({
         defaultOptions: { queries: { staleTime: 30_000 } },
+        mutationCache: new MutationCache({
+          // Surface server errors from mutations that don't handle them
+          // locally — an unhandled tRPC failure otherwise looks like
+          // "nothing happened". Local onError handlers take precedence.
+          onError: (error, _variables, _context, mutation) => {
+            if (!mutation.options.onError) toast.error(error.message);
+          },
+        }),
       })
   );
 

--- a/schema/validators.ts
+++ b/schema/validators.ts
@@ -14,6 +14,7 @@
  *   const parsed = companyInsertSchema.parse(req.body);
  */
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { getTableColumns, type Table } from "drizzle-orm";
 import { z } from "zod";
 
 // --- Table imports (alphabetical by file) ---
@@ -62,6 +63,32 @@ const omitAudit = { id: true, createdAt: true } as const;
  * never from request input.
  */
 const omitTenantMeta = { ...omitMeta, companyId: true } as const;
+
+/**
+ * pg `date` columns surface from drizzle-zod as bare strings, which lets ""
+ * and free-text through to Postgres (`invalid input syntax for type date`)
+ * and makes SchemaForm render a text input instead of a date picker. Spread
+ * this into createInsertSchema overrides for every table that has date
+ * columns; derived from table metadata so new date columns are covered
+ * without maintaining a field list. Explicit overrides listed after the
+ * spread still win.
+ */
+function isoDateColumns<T extends Table>(
+  table: T,
+): Partial<Record<keyof T["_"]["columns"], z.ZodType>> {
+  const out: Partial<Record<keyof T["_"]["columns"], z.ZodType>> = {};
+  for (const [name, col] of Object.entries(getTableColumns(table))) {
+    if (col.columnType === "PgDateString") {
+      // nullish, not nullable: drizzle-zod makes nullable columns optional in
+      // insert schemas (callers may omit the key) and an override replaces
+      // that wholesale — .nullable() alone would make absent keys a 400.
+      out[name as keyof T["_"]["columns"]] = col.notNull
+        ? z.iso.date()
+        : z.iso.date().nullish();
+    }
+  }
+  return out;
+}
 
 // ============================================================================
 // Organization
@@ -211,7 +238,9 @@ export const userUpdateSchema = userInsertSchema.partial().omit(omitTenantMeta);
 // Compliance Frameworks
 // ============================================================================
 
-export const frameworkInsertSchema = createInsertSchema(complianceFramework);
+export const frameworkInsertSchema = createInsertSchema(complianceFramework, {
+  ...isoDateColumns(complianceFramework),
+});
 export const frameworkSelectSchema = createSelectSchema(complianceFramework);
 
 export const categoryInsertSchema = createInsertSchema(requirementCategory, {
@@ -237,10 +266,14 @@ export const requirementUpdateSchema = requirementInsertSchema.partial().omit(om
 // Assessments
 // ============================================================================
 
-export const assessmentInsertSchema = createInsertSchema(companyAssessment);
+export const assessmentInsertSchema = createInsertSchema(companyAssessment, {
+  ...isoDateColumns(companyAssessment),
+});
 export const assessmentSelectSchema = createSelectSchema(companyAssessment);
 
-export const requirementStatusInsertSchema = createInsertSchema(companyRequirementStatus);
+export const requirementStatusInsertSchema = createInsertSchema(companyRequirementStatus, {
+  ...isoDateColumns(companyRequirementStatus),
+});
 export const requirementStatusSelectSchema = createSelectSchema(companyRequirementStatus);
 // assessmentId + requirementId are immutable parent FKs — never patchable.
 export const requirementStatusUpdateSchema = requirementStatusInsertSchema
@@ -252,6 +285,7 @@ export const requirementStatusUpdateSchema = requirementStatusInsertSchema
 // ============================================================================
 
 export const evidenceInsertSchema = createInsertSchema(evidence, {
+  ...isoDateColumns(evidence),
   fileName: z.string().min(1).max(500),
   storageKey: z.string().min(1).max(500),
   contentHash: z.string().length(64).nullish(),
@@ -264,6 +298,7 @@ export const evidenceUpdateSchema = evidenceInsertSchema.partial().omit({ id: tr
 // ============================================================================
 
 export const policyInsertSchema = createInsertSchema(policy, {
+  ...isoDateColumns(policy),
   title: z.string().min(1).max(500),
   type: z.string().min(1).max(100),
 });
@@ -286,16 +321,9 @@ export const auditLogSelectSchema = createSelectSchema(auditLog);
 // ============================================================================
 
 export const assetInsertSchema = createInsertSchema(asset, {
+  ...isoDateColumns(asset),
   name: z.string().min(1).max(255),
   type: z.string().min(1).max(100),
-  // pg `date` columns surface from drizzle-zod as bare strings; tighten to
-  // ISO dates so forms render a date input and Postgres never receives a
-  // non-date string. `.nullable()` restated — overrides drop the column's
-  // nullable flag.
-  lastPatchDate: z.iso.date().nullable(),
-  lastVulnScanDate: z.iso.date().nullable(),
-  lastBackupTestDate: z.iso.date().nullable(),
-  endOfLife: z.iso.date().nullable(),
 });
 export const assetSelectSchema = createSelectSchema(asset);
 export const assetUpdateSchema = assetInsertSchema.partial().omit(omitTenantMeta);
@@ -375,6 +403,7 @@ export const assetServiceUpdateSchema = assetInsertSchema
 // ============================================================================
 
 export const riskInsertSchema = createInsertSchema(risk, {
+  ...isoDateColumns(risk),
   title: z.string().min(1).max(500),
   description: z.string().min(1),
   likelihood: z.number().int().min(1).max(6),
@@ -409,6 +438,7 @@ export const incidentUpdateSchema = incidentInsertSchema.partial().omit(omitTena
 // ============================================================================
 
 export const supplierInsertSchema = createInsertSchema(supplier, {
+  ...isoDateColumns(supplier),
   name: z.string().min(1).max(255),
   // Per-customer contract clauses
   subprocessorList: z.string().max(2000).nullish(),
@@ -453,6 +483,7 @@ export const relationshipClausesUpdateSchema = supplierInsertSchema
 // ============================================================================
 
 export const trainingInsertSchema = createInsertSchema(trainingRecord, {
+  ...isoDateColumns(trainingRecord),
   trainingType: z.string().min(1).max(255),
   title: z.string().min(1).max(500),
   participantName: z.string().min(1).max(255),
@@ -488,6 +519,7 @@ export const changeRequestUpdateSchema = changeRequestInsertSchema.partial().omi
 // ============================================================================
 
 export const patchRecordInsertSchema = createInsertSchema(patchRecord, {
+  ...isoDateColumns(patchRecord),
   patchIdentifier: z.string().min(1).max(255),
   severity: z.string().min(1).max(50),
 });
@@ -499,6 +531,7 @@ export const patchRecordUpdateSchema = patchRecordInsertSchema.partial().omit(om
 // ============================================================================
 
 export const vulnerabilityInsertSchema = createInsertSchema(vulnerability, {
+  ...isoDateColumns(vulnerability),
   title: z.string().min(1).max(500),
   severity: z.string().min(1).max(50),
 });
@@ -510,6 +543,7 @@ export const vulnerabilityUpdateSchema = vulnerabilityInsertSchema.partial().omi
 // ============================================================================
 
 export const internalAuditInsertSchema = createInsertSchema(internalAudit, {
+  ...isoDateColumns(internalAudit),
   title: z.string().min(1).max(500),
   auditArea: z.string().min(1).max(255),
 });
@@ -517,6 +551,7 @@ export const internalAuditSelectSchema = createSelectSchema(internalAudit);
 export const internalAuditUpdateSchema = internalAuditInsertSchema.partial().omit(omitTenantMeta);
 
 export const auditFindingInsertSchema = createInsertSchema(auditFinding, {
+  ...isoDateColumns(auditFinding),
   description: z.string().min(1),
   correctiveAction: z.string().min(1),
 });
@@ -531,6 +566,7 @@ export const auditFindingUpdateSchema = auditFindingInsertSchema
 // ============================================================================
 
 export const improvementItemInsertSchema = createInsertSchema(improvementItem, {
+  ...isoDateColumns(improvementItem),
   title: z.string().min(1).max(500),
   description: z.string().min(1),
 });
@@ -551,6 +587,7 @@ export const kpiMeasurementSelectSchema = createSelectSchema(kpiMeasurement);
 // ============================================================================
 
 export const managementReviewInsertSchema = createInsertSchema(managementReview, {
+  ...isoDateColumns(managementReview),
   title: z.string().min(1).max(500),
 });
 export const managementReviewSelectSchema = createSelectSchema(managementReview);
@@ -561,6 +598,7 @@ export const managementReviewUpdateSchema = managementReviewInsertSchema.partial
 // ============================================================================
 
 export const riskTreatmentInsertSchema = createInsertSchema(riskTreatment, {
+  ...isoDateColumns(riskTreatment),
   action: z.string().min(1).max(500),
 });
 export const riskTreatmentSelectSchema = createSelectSchema(riskTreatment);
@@ -574,6 +612,7 @@ export const riskTreatmentUpdateSchema = riskTreatmentInsertSchema
 // ============================================================================
 
 export const exerciseInsertSchema = createInsertSchema(exercise, {
+  ...isoDateColumns(exercise),
   title: z.string().min(1).max(500),
   domain: z.string().min(1).max(100),
 });
@@ -591,7 +630,9 @@ export const policyAcknowledgmentSelectSchema = createSelectSchema(policyAcknowl
 // BSIG Module
 // ============================================================================
 
-export const bsiRegistrationInsertSchema = createInsertSchema(bsiRegistration);
+export const bsiRegistrationInsertSchema = createInsertSchema(bsiRegistration, {
+  ...isoDateColumns(bsiRegistration),
+});
 export const bsiRegistrationSelectSchema = createSelectSchema(bsiRegistration);
 export const bsiRegistrationUpdateSchema = bsiRegistrationInsertSchema.partial().omit(omitTenantMeta);
 
@@ -653,8 +694,11 @@ export const companyCertificationCreateSchema = z.object({
   typeOther: z.string().max(255).optional(),
   scope: z.string().optional(),
   auditor: z.string().max(255).optional(),
-  validFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  validUntil: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  // z.iso.date() over a hand regex: same YYYY-MM-DD contract plus calendar
+  // validity, and the `format` metadata makes SchemaForm render a date picker.
+  // nullish: the date input emits null when cleared.
+  validFrom: z.iso.date().nullish(),
+  validUntil: z.iso.date(),
   storageKey: z.string().min(1).max(500),
   fileName: z.string().min(1).max(500).optional(),
   fileSize: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
Follow-up sweep after #25, hunting the same bug classes across every form.

## Found and fixed

**1. pg `date` columns validated as bare strings (18 insert schemas).** Same bug #25 fixed for assets only: forms rendered text inputs, `""` or `17.07.2026` reached Postgres as `''::date` → silent 500. Now a `isoDateColumns(table)` helper derives `z.iso.date()` overrides from drizzle table metadata (DB-first, no hand-kept field list) and is spread into every insert schema whose table has date columns. Required date columns (`exercise.scheduledDate`, `internalAudit.scheduledDate`, `managementReview.reviewDate`) are now genuinely required with visible errors.

**2. #25 regression (caught by this sweep's verification):** overriding a nullable column with `.nullable()` drops drizzle-zod's implicit optionality, so `asset.create` 400d server-side when the form omitted `lastVulnScanDate`/`lastBackupTestDate` keys. `.nullish()` restores absent-key semantics. Asset creation is genuinely fixed only with this PR.

**3. Timestamp fields could never validate.** `z.date()` columns rendered by forms (e.g. required `incident.discoveredAt`) got strings from the date input, which `z.date()` always rejects — incident creation was impossible. The renderer now emits real `Date` objects for these fields (`FieldMeta.jsDate`).

**4. Silent mutation failures platform-wide.** All 12 remaining CrudPage consumers (and ~89 other mutations) had no `onError`. A global `MutationCache` handler now toasts any tRPC mutation failure that has no local handler; local handlers keep precedence. The AssetsPage-local handler from #25 is superseded and removed.

**5. `companyCertificationCreateSchema`** date regexes → `z.iso.date()` (same contract plus calendar validity, and the fields get date pickers).

## Verified

- Exact DRK asset payload passes the server-shaped schema (with omitted keys absent)
- `exercise`/`managementReview` required dates: ISO passes, null/free-text fails on the right field
- `incident.discoveredAt`: introspects as jsDate, `Date` passes, string fails
- Sweep assertion: no date-named field on any insert schema accepts free text
- Typecheck error set identical to main baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)