### PR TITLE
feat(platform-admin): CEO course completion stat in the overview KPI row

### DIFF
--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -40,6 +40,8 @@ interface Overview {
   draftCompanies: number;
   usersWithActivatedCompany: number;
   totalAssessments: number;
+  ceoCourseFinished: number;
+  ceoCourseStarted: number;
 }
 
 interface UserRow {
@@ -223,10 +225,11 @@ export function PlatformAdminPage({
       </div>
 
       {/* KPI cards */}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
         <StatCard label="Total Users" value={overview.totalUsers} sub={`${overview.recentUsers} this week`} />
         <StatCard label="Activated Users" value={overview.usersWithActivatedCompany} sub={`of ${overview.totalUsers}`} />
         <StatCard label="Activated Orgs" value={overview.activatedCompanies} sub={`${overview.draftCompanies} draft`} />
+        <StatCard label="CEO Course Done" value={overview.ceoCourseFinished} sub={`of ${overview.ceoCourseStarted} started`} />
         <StatCard label="Assessments" value={overview.totalAssessments} />
         <StatCard label="Not Activated" value={overview.totalUsers - overview.usersWithActivatedCompany} sub="draft shell only" />
       </div>

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -6,7 +6,7 @@
  * (which is company-scoped). This is a platform-level view across
  * ALL companies and users.
  */
-import { desc, count, eq, sql, and, isNotNull, gte } from "drizzle-orm";
+import { desc, count, eq, sql, and, isNotNull, gte, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { randomUUID, randomBytes } from "node:crypto";
 import bcrypt from "bcryptjs";
@@ -61,6 +61,12 @@ export const platformAdminRouter = router({
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
+    // "Finished" = same definition as certificate eligibility
+    // (trainingCertificate.getCourseCompletion): every lesson of the CURRENT
+    // course definition completed — hence the lessonId membership filter, so
+    // progress on since-removed lessons cannot inflate the count.
+    const ceoLessonIds = (await loadCourse("nis2-ceo")).modules.flatMap((m) => m.lessonIds);
+
     const [
       totalUsersRow,
       recentUsersRow,
@@ -68,6 +74,8 @@ export const platformAdminRouter = router({
       activatedCompaniesRow,
       usersWithActivatedCompanyRow,
       totalAssessmentsRow,
+      ceoFinishedRows,
+      ceoStartedRow,
     ] = await Promise.all([
       ctx.db.select({ count: count() }).from(user),
       ctx.db.select({ count: count() }).from(user).where(gte(user.createdAt, sevenDaysAgo)),
@@ -82,6 +90,22 @@ export const platformAdminRouter = router({
         .innerJoin(company, eq(user.companyId, company.id))
         .where(isNotNull(company.activatedAt)),
       ctx.db.select({ count: count() }).from(companyAssessment),
+      ctx.db
+        .select({ userId: trainingLessonProgress.userId })
+        .from(trainingLessonProgress)
+        .where(
+          and(
+            eq(trainingLessonProgress.courseId, "nis2-ceo"),
+            eq(trainingLessonProgress.completed, true),
+            inArray(trainingLessonProgress.lessonId, ceoLessonIds),
+          ),
+        )
+        .groupBy(trainingLessonProgress.userId)
+        .having(sql`count(distinct ${trainingLessonProgress.lessonId}) = ${ceoLessonIds.length}`),
+      ctx.db
+        .select({ count: sql<number>`count(distinct ${trainingLessonProgress.userId})::int` })
+        .from(trainingLessonProgress)
+        .where(eq(trainingLessonProgress.courseId, "nis2-ceo")),
     ]);
 
     const totalCompanies = totalCompaniesRow[0]?.count ?? 0;
@@ -97,6 +121,8 @@ export const platformAdminRouter = router({
       draftCompanies: Math.max(0, totalCompanies - activatedCompanies),
       usersWithActivatedCompany: usersWithActivatedCompanyRow[0]?.count ?? 0,
       totalAssessments: totalAssessmentsRow[0]?.count ?? 0,
+      ceoCourseFinished: ceoFinishedRows.length,
+      ceoCourseStarted: ceoStartedRow[0]?.count ?? 0,
     };
   }),
 


### PR DESCRIPTION
Adds the number Simon checks most — CEO course completions — to the platform-admin top stats.

## What
- New KPI card **CEO Course Done** (value: users who finished, sub: 'of X started'), inserted after Activated Orgs; grid goes lg:grid-cols-5 -> 6. All existing cards stay.
- overview query gains two cheap aggregates on training_lesson_progress: finished users (grouped, having count(distinct lesson_id) = 47) and started users (distinct users with any nis2-ceo row).

## Definition of 'finished'
Same as certificate eligibility (trainingCertificate.getCourseCompletion allCompleted): every lesson of the CURRENT course definition completed. The lessonId membership filter (inArray) prevents progress on since-removed lessons from inflating the count. Verified: loadCourse('nis2-ceo') = 6 modules / 47 unique lessons; generated SQL checked via QueryBuilder.toSQL().

## Typecheck note
tsc shows 26 pre-existing errors on clean origin/main in my environment (stale cross-worktree node_modules resolution of @nisd2/isms-schema, which has no tsconfig path mapping, plus the 3 known package devDep errors). Verified identical error set with and without this diff — this change adds zero errors. Prod build is unaffected (next.config ignoreBuildErrors + fresh install on Coolify).