### PR TITLE
feat(e2e): L0 layer — value factory, Stadtwerk persona, drift + coverage tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,10 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # L0 schema-drift and coverage unit tests: seconds, no browser, no
+      # docker — fail fast before the expensive browser suite.
+      - run: bun run test:l0
+
       - run: bunx playwright install --with-deps chromium
 
       # e2e/start-server.sh brings up the docker stack (postgres + MinIO),

--- a/e2e/l0/coverage.test.ts
+++ b/e2e/l0/coverage.test.ts
@@ -1,0 +1,33 @@
+/**
+ * L0 coverage: every NIS2 requirement code in grc-data-model resolves to a
+ * walker interaction kind. A new requirement fails CI here until someone
+ * classifies it (usually free: the product's own registries classify it).
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  nis2Categories,
+  getNis2RequirementsForCategory,
+} from "@nisd2/grc-data-model/frameworks";
+import { classifyRequirement } from "../lib/walker-classification";
+
+const allRequirements = nis2Categories.flatMap((cat) =>
+  getNis2RequirementsForCategory(cat.slug).map((r) => ({
+    code: r.code,
+    moduleRef: r.moduleRef ?? null,
+  })),
+);
+
+test("grc-data-model still defines exactly 49 NIS2 requirements", () => {
+  expect(allRequirements.length).toBe(49);
+});
+
+describe("every requirement code has a walker classification", () => {
+  for (const req of allRequirements) {
+    test(req.code, () => {
+      expect(
+        classifyRequirement(req.code, req.moduleRef),
+        `requirement ${req.code} is unclassified — add it to EXTRA_MODULE_BACKED or the product registries`,
+      ).not.toBe("unclassified");
+    });
+  }
+});

--- a/e2e/l0/schema-drift.test.ts
+++ b/e2e/l0/schema-drift.test.ts
@@ -1,0 +1,72 @@
+/**
+ * L0 drift tests (bun test, no browser, seconds). Fails the PR that lets
+ * the intake schemas and the test data drift apart:
+ *
+ *  1. The value factory must produce a parse-clean value set for EVERY
+ *     current category schema (a new field the factory cannot satisfy
+ *     fails here).
+ *  2. Every Stadtwerk persona field must still exist in its schema
+ *     (a renamed or removed field fails here).
+ *  3. Factory defaults + persona overrides must parse together (a
+ *     retyped field or tightened constraint fails here).
+ */
+import { describe, test, expect } from "bun:test";
+import { CATEGORY_SCHEMAS } from "@/lib/compliance/category-schemas";
+import { REQUIREMENT_FIELD_MAP } from "@/lib/compliance/requirement-fields";
+import { generateFormValues } from "../lib/value-factory";
+import { STADTWERK_INTAKE } from "../personas/stadtwerk-musterstadt";
+
+const categories = Object.keys(CATEGORY_SCHEMAS);
+
+/** Persona fields grouped per category via the product's own mapping. */
+function personaFieldsForCategory(cat: string): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  for (const [code, fields] of Object.entries(STADTWERK_INTAKE)) {
+    if (REQUIREMENT_FIELD_MAP[code]?.categoryCode !== cat) continue;
+    Object.assign(merged, fields);
+  }
+  return merged;
+}
+
+describe("value factory satisfies every category schema", () => {
+  for (const cat of categories) {
+    test(cat, () => {
+      const schema = CATEGORY_SCHEMAS[cat];
+      const result = schema.safeParse(generateFormValues(schema));
+      expect(
+        result.success,
+        result.success ? "" : JSON.stringify(result.error.issues, null, 2),
+      ).toBe(true);
+    });
+  }
+});
+
+describe("persona keys exist in their schemas", () => {
+  for (const [code, fields] of Object.entries(STADTWERK_INTAKE)) {
+    test(`requirement ${code}`, () => {
+      const info = REQUIREMENT_FIELD_MAP[code];
+      expect(info, `persona has code ${code} but the product maps no intake fields to it`).toBeDefined();
+      const shape = CATEGORY_SCHEMAS[info.categoryCode].shape;
+      for (const key of Object.keys(fields)) {
+        expect(
+          key in shape,
+          `persona field "${key}" (req ${code}) not in ${info.categoryCode} schema`,
+        ).toBe(true);
+      }
+    });
+  }
+});
+
+describe("factory defaults + persona overrides parse together", () => {
+  for (const cat of categories) {
+    test(cat, () => {
+      const schema = CATEGORY_SCHEMAS[cat];
+      const values = generateFormValues(schema, personaFieldsForCategory(cat));
+      const result = schema.safeParse(values);
+      expect(
+        result.success,
+        result.success ? "" : JSON.stringify(result.error.issues, null, 2),
+      ).toBe(true);
+    });
+  }
+});

--- a/e2e/lib/value-factory.ts
+++ b/e2e/lib/value-factory.ts
@@ -1,0 +1,74 @@
+/**
+ * Deterministic test-value generation from the same introspection the form
+ * library uses. FieldMeta in, schema-valid value out — no randomness, so
+ * every run and every CI machine produces identical data.
+ *
+ * The factory is the drift alarm's engine: when a schema gains a field or a
+ * constraint the factory cannot satisfy, the L0 parse test fails on the PR
+ * that made the change.
+ */
+import type { z } from "zod";
+import {
+  introspectSchema,
+  type FieldMeta,
+} from "@/lib/forms/schema-introspect";
+
+/** Fixed reference date: deterministic, in the recent past. */
+const REFERENCE_DATE = "2026-01-15";
+
+export function generateValue(meta: FieldMeta): unknown {
+  switch (meta.type) {
+    case "boolean":
+      return true;
+    case "enum":
+      if (!meta.options || meta.options.length === 0) {
+        throw new Error(`enum field "${meta.key}" has no options`);
+      }
+      return meta.options[0];
+    case "number": {
+      const base = meta.min ?? 1;
+      return meta.max !== undefined ? Math.min(base, meta.max) : base;
+    }
+    case "date":
+      return meta.jsDate ? new Date(REFERENCE_DATE) : REFERENCE_DATE;
+    case "email":
+      return `e2e-${meta.key.toLowerCase()}@nis2.local`;
+    case "url":
+      return `https://example.invalid/${meta.key}`;
+    case "file":
+      // File-convention fields are plain string columns holding a filename.
+      return "e2e-evidence.pdf";
+    case "array":
+      return [];
+    case "textarea":
+    case "text":
+    case "unknown":
+    default: {
+      let value = `E2E ${meta.key}`;
+      if (meta.minLength !== undefined && value.length < meta.minLength) {
+        value = value.padEnd(meta.minLength, "x");
+      }
+      if (meta.maxLength !== undefined && value.length > meta.maxLength) {
+        value = value.slice(0, meta.maxLength);
+      }
+      return value;
+    }
+  }
+}
+
+/**
+ * Full value set for a schema: generated defaults, persona overrides on top.
+ * Overrides win by key; unknown override keys are the caller's drift problem
+ * (the L0 tests assert every persona key exists in its schema).
+ */
+export function generateFormValues(
+  schema: z.ZodObject<z.ZodRawShape>,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const meta of introspectSchema(schema, [])) {
+    values[meta.key] =
+      meta.key in overrides ? overrides[meta.key] : generateValue(meta);
+  }
+  return values;
+}

--- a/e2e/lib/walker-classification.ts
+++ b/e2e/lib/walker-classification.ts
@@ -1,0 +1,45 @@
+/**
+ * How the journey walker completes each requirement. All three primary
+ * registries live in product code: CUSTOM_EDITOR_FIELDS (policy and
+ * methodology editors), requirement.moduleRef from grc-data-model (the
+ * platform module whose records evidence the requirement), and
+ * REQUIREMENT_FIELD_MAP (intake fields). This file adds ONLY the codes the
+ * product classifies through none of those.
+ *
+ * The L0 coverage test asserts every requirement code in grc-data-model
+ * resolves here — a new requirement fails CI until it is classified,
+ * usually for free via the product registries.
+ */
+import {
+  REQUIREMENT_FIELD_MAP,
+  CUSTOM_EDITOR_FIELDS,
+} from "@/lib/compliance/requirement-fields";
+
+/** Codes with no custom editor, no moduleRef, and no intake fields. */
+export const EXTRA_MODULE_BACKED: Record<string, { route: string; note: string }> = {
+  "2.3": { route: "/risks", note: "risk register module (no moduleRef in grc-data-model)" },
+  "5.3": { route: "/risks", note: "supplier risk register (no moduleRef in grc-data-model)" },
+  "9.2": { route: "/assets", note: "per-asset encryption fields (no moduleRef in grc-data-model)" },
+};
+
+export type InteractionKind =
+  | "custom-editor"
+  | "module"
+  | "intake"
+  | "unclassified";
+
+/**
+ * Priority: custom editor > module > intake. Codes can carry several
+ * registrations (2.2 has an intake field AND moduleRef "asset"); the walker
+ * drives the highest-priority surface and the intake fields ride along on
+ * the same requirement page.
+ */
+export function classifyRequirement(
+  code: string,
+  moduleRef?: string | null,
+): InteractionKind {
+  if (code in CUSTOM_EDITOR_FIELDS) return "custom-editor";
+  if (moduleRef || code in EXTRA_MODULE_BACKED) return "module";
+  if (code in REQUIREMENT_FIELD_MAP) return "intake";
+  return "unclassified";
+}

--- a/e2e/personas/stadtwerk-musterstadt.ts
+++ b/e2e/personas/stadtwerk-musterstadt.ts
@@ -1,0 +1,206 @@
+/**
+ * Persona: Stadtwerk Musterstadt GmbH — the "large company, different data"
+ * dataset for the e2e journey. Deliberately unlike the seeded Dev GmbH
+ * (energy essential, 500 employees, Munich, ISO 27001, Microsoft stack):
+ * a municipal multi-utility (electricity, gas, district heating, water),
+ * ~1,200 employees, OT-heavy, mixed tooling, no prior certification.
+ *
+ * Shape matches drizzle/seed-company-data.ts: requirement code → intake
+ * field values. Field names are the CATEGORY_FIELD_MAPPING keys; the L0
+ * drift tests fail this file the moment a schema renames or retypes one.
+ * Dates are ISO strings (the intake schemas use z.coerce.date()).
+ */
+
+export const STADTWERK_PROFILE = {
+  name: "Stadtwerk Musterstadt GmbH",
+  sector: "energy",
+  entityType: "essential" as const,
+  employeeCount: 1200,
+  city: "Musterstadt",
+} as const;
+
+export const STADTWERK_INTAKE: Record<string, Record<string, unknown>> = {
+  // GOV — Governance & Liability
+  "1.1": {
+    managementTrainingProvider: "VKU Akademie, Praesenzschulung Kritische Infrastrukturen",
+    lastManagementTraining: "2026-05-12",
+  },
+  "1.3": {
+    annualSecurityBudget: "1850000",
+    budgetApprovalDate: "2026-01-20",
+  },
+  "1.4": {
+    liabilityAcknowledged: true,
+  },
+
+  // RSK — Risk Management
+  "2.2": {
+    classificationLevels: "3_levels",
+  },
+  "2.4": {
+    residualRiskCount: 7,
+    policyVersion: "v2.1",
+    policyApprovalDate: "2026-02-14",
+  },
+
+  // INC — Incident Handling
+  "3.1": {
+    incidentLead: "Leiterin Netzleitstelle (stellv. CISO)",
+    irtTeamSize: 9,
+    secureCommsChannel: "TETRA Digitalfunk plus Threema Work",
+    incidentEscalationContacts: "P1: Geschaeftsfuehrung und CISO, P2: IT-Leitung, P3: Schichtleiter Leitstelle",
+  },
+  "3.2": {
+    classificationScheme: "bsi",
+    detectionTools: "Elastic SIEM, Claroty OT-Monitoring, Defender for Endpoint",
+    significantIncidentCriteria: "Versorgungsunterbrechung ueber 10.000 Haushalte, Leitstellenausfall ueber 30 Minuten, Abfluss personenbezogener Daten",
+  },
+  "3.3": {
+    earlyWarningSlaHours: 20,
+    bsiReportingRegistered: true,
+  },
+  "3.4": {
+    lastDrillDate: "2026-04-22",
+    drillType: "functional",
+  },
+  "3.5": {
+    postIncidentReviewOwner: "CISO mit Bericht an die Geschaeftsfuehrung",
+  },
+
+  // BCP — Business Continuity
+  "4.1": {
+    biaCompletionDate: "2026-03-01",
+    criticalProcessCount: 14,
+    rpoTargetHours: 2,
+    rtoTargetHours: 8,
+  },
+  "4.2": {
+    crisisTeamLead: "Technischer Geschaeftsfuehrer",
+    bcpActivationCriteria: "Leitstellenausfall, Ausfall Fernwirktechnik, Cyberangriff mit OT-Bezug, Hochwasserlage",
+  },
+  "4.4": {
+    backupFrequency: "hourly",
+    backupEncryption: "AES-256, Veeam mit Immutable Repository",
+    lastBackupTest: "2026-06-10",
+    backupRestoreSuccessRate: 98,
+  },
+  "4.5": {
+    lastBcpTest: "2026-05-28",
+  },
+
+  // SUP — Supply Chain
+  "5.1": {
+    singlePointOfFailureCount: 3,
+  },
+  "5.4": {
+    incidentNotificationSlaHours: 24,
+  },
+
+  // PRO — Procurement & Development
+  "6.3": {
+    vulnerabilityScanningFrequency: "weekly",
+    vulnerabilityScanTool: "Greenbone OpenVAS, Claroty fuer OT-Segmente",
+    lastPentestDate: "2025-11-18",
+    vulnerabilityDisclosureUrl: "https://www.stadtwerk-musterstadt.example/security",
+  },
+  "6.5": {
+    changeManagementTool: "Jira Service Management mit CAB-Freigabe",
+  },
+
+  // EFF — Effectiveness
+  "7.1": {
+    kpisDefinedCount: 12,
+    kpiDashboardTool: "Grafana auf Elastic-Datenbasis",
+    trendAnalysisTool: "Quartalsbericht aus Grafana und SIEM-Trends",
+  },
+  "7.2": {
+    auditFrequency: "annual",
+    lastAuditDate: "2026-01-30",
+  },
+  "7.3": {
+    lastManagementReview: "2026-02-27",
+    managementReviewReportUploaded: "management-review-2026-q1.pdf",
+  },
+  "7.4": {
+    correctiveActionTool: "Plattformmodul Verbesserungen",
+    openCorrectiveActions: 5,
+    avgClosureTimeDays: 21,
+  },
+
+  // TRN — Training & Cyber Hygiene
+  "8.1": {
+    itSecurityPolicyPublished: "it-sicherheitsleitlinie-v2.pdf",
+  },
+  "8.2": {
+    trainingPlatform: "SoSafe",
+    trainingFrequency: "semi_annual",
+    trainingCompletionRate: 91,
+    lastTrainingDate: "2026-06-02",
+    newEmployeeOnboarding: "Sicherheitsunterweisung am ersten Arbeitstag, E-Learning-Pflichtmodul in Woche eins, Leitstellenpersonal zusaetzlich OT-Einweisung",
+  },
+  "8.3": {
+    roleSpecificTrainingProvider: "SANS fuer IT-Security, VDE-Schulungen fuer Leitstellenpersonal",
+  },
+  "8.4": {
+    phishingSimFrequency: "quarterly",
+    lastPhishingTest: "2026-06-18",
+    phishingClickRate: 6,
+  },
+
+  // CRY — Cryptography
+  "9.3": {
+    keyManagementTool: "HashiCorp Vault, HSM fuer Fernwirktechnik-Zertifikate",
+    certificateMonitoringTool: "cert-manager plus manuelles Register fuer OT-Zertifikate",
+    certExpiryAlertDays: 30,
+  },
+
+  // ACC — Access Control & HR
+  "10.3": {
+    jmlTool: "Entra ID Lifecycle mit HR-Anbindung an P und I",
+    backgroundCheckScope: "Leitstellen- und Administratorenrollen, SUeG-Pruefung fuer KRITIS-Personal",
+    pamTool: "Teleport fuer IT, dedizierte Sprungserver fuer OT",
+  },
+  "10.4": {
+    lastAccessReviewDate: "2026-04-05",
+  },
+
+  // AUT — Authentication & Communications
+  "11.1": {
+    mfaTool: "Microsoft Authenticator, YubiKey fuer Administratoren",
+    mfaMethods: "FIDO2, TOTP, Push",
+    mfaCoverage: "all_users",
+    mfaCoveragePct: 97,
+    adminMfaEnforced: true,
+  },
+  "11.2": {
+    secureCommsTools: "Threema Work, TETRA Digitalfunk",
+    emergencyCommsChannel: "TETRA Digitalfunk mit Papier-Alarmierungsliste",
+    lastEmergencyCommsTest: "2026-05-15",
+  },
+  "11.3": {
+    ssoTool: "Entra ID",
+    passwordMinLength: 14,
+    sessionTimeoutMinutes: 15,
+  },
+
+  // REG — Registration & Reporting
+  "12.1": {
+    entityClassification: "essential",
+    applicableSectors: "Energie (Strom, Gas, Fernwaerme), Trinkwasser, Abwasser",
+  },
+  "12.2": {
+    mukAccountId: "MUK-SW-MUSTERSTADT-0042",
+    bsiRegistrationDate: "2026-02-10",
+    registrationProofUploaded: "bsi-registrierung-bestaetigung.pdf",
+  },
+  "12.3": {
+    contactPersonName: "Informationssicherheitsbeauftragte",
+    contactPersonEmail: "e2e-isb@nis2.local",
+    lastRegistrationUpdate: "2026-06-01",
+    nextRegistrationUpdate: "2027-06-01",
+  },
+  "12.4": {
+    informationSharingCompliant: "Teilnahme am UP KRITIS Branchenarbeitskreis Energie, Weitergabe relevanter Warnungen an die Leitstelle innerhalb von 24 Stunden",
+    correspondenceLogUploaded: "behoerdenkorrespondenz-log.pdf",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "screenshots": "bun scripts/screenshot-pitch.ts",
     "og": "og-shot",
     "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui"
+    "e2e:ui": "playwright test --ui",
+    "test:l0": "bun test e2e/l0"
   },
   "dependencies": {
     "@ai-sdk/xai": "^4.0.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,10 @@ const E2E_BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3026";
 
 export default defineConfig({
   testDir: "./e2e",
+  // e2e/l0 are bun:test unit tests (run via `bun test e2e/l0`), not
+  // browser specs — Playwright's default testMatch would otherwise load
+  // them and crash on the bun:test import.
+  testIgnore: "**/l0/**",
   outputDir: "./test-results",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
## What

Step 3 of the e2e plan: the seconds-fast schema-drift layer that fails a PR the moment the intake schemas and the test data disagree.

- **`e2e/lib/value-factory.ts`** — FieldMeta → deterministic schema-valid value, driven by the SAME `introspectSchema` the form library uses. A new field in any category schema either generates cleanly or fails L0 on that PR.
- **`e2e/personas/stadtwerk-musterstadt.ts`** — the "large company, different data" dataset: 1,200-employee municipal multi-utility (electricity/gas/heat/water), OT-heavy, realistic German values for every mapped intake field in all 12 categories. Same `Record<reqCode, fields>` shape as `SEED_COMPANY_DATA`.
- **`e2e/lib/walker-classification.ts`** — requirement → interaction kind, reusing the product's own registries (`CUSTOM_EDITOR_FIELDS` > `requirement.moduleRef` from grc-data-model > `REQUIREMENT_FIELD_MAP`); only 3 codes (2.3, 5.3, 9.2) need test-side classification because they carry none of the three.
- **`e2e/l0/`** — 110 bun tests in ~35ms: factory-parses-every-schema, persona-keys-exist, combined-parse, 49-requirement coverage.

## CI

`bun run test:l0` runs before the browser suite (fail fast, no docker needed). Playwright `testIgnore` keeps the bun:test files out of its own testMatch.

## Verified

- `bun run test:l0`: 110 pass / 0 fail (35ms)
- `bun run e2e`: 3 passed (L0 correctly not picked up by Playwright)
- `bun run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01De1NY1HDUJkkwetVKTbYtH