### PR TITLE
feat(e2e): L3 sign-off — single signer, N-of-M across two sessions, chain verification

### DIFF
--- a/components/compliance/SignOffButton.tsx
+++ b/components/compliance/SignOffButton.tsx
@@ -16,6 +16,7 @@ export function SignOffButton({ isSubmitting, onSignOff }: SignOffButtonProps) {
     <Button
       variant="default"
       size="sm"
+      data-testid="sign-off-button"
       disabled={isSubmitting}
       onClick={() => onSignOff()}
     >

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,13 +1,13 @@
 /**
  * Setup project: provision + authenticate, once per run.
  *
- * Runs after the webServer is up (compose + migrate + seed happen in
- * e2e/start-server.sh). Provisioning is deliberately minimal: the seed
- * already creates the Dev GmbH company and its admin user with a verified
- * email; the only thing missing for credentials login is a password hash.
+ * Runs after the webServer is up (compose + hermetic DB reset + migrate +
+ * seed happen in e2e/start-server.sh). Provisioning is deliberately
+ * minimal: the seed creates Dev GmbH and its admin with a verified email;
+ * the harness adds only what login and the multi-user specs need — a
+ * password hash, and a second management member for N-of-M sign-offs.
  */
-import { test as setup, expect } from "@playwright/test";
-import { Client } from "pg";
+import { test as setup, expect, type Page } from "@playwright/test";
 import bcrypt from "bcryptjs";
 import {
   S3Client,
@@ -17,13 +17,23 @@ import {
 } from "@aws-sdk/client-s3";
 import {
   assertE2eTargets,
-  E2E_DATABASE_URL,
   E2E_USER_EMAIL,
   E2E_USER_PASSWORD,
+  E2E_MANAGER_EMAIL,
   E2E_STORAGE_STATE,
+  E2E_STORAGE_STATE_MANAGER,
 } from "./lib/env";
+import { e2eQuery } from "./lib/db";
 
-setup("provision and authenticate", async ({ page }) => {
+async function login(page: Page, email: string): Promise<void> {
+  await page.goto("/de/auth/signin");
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(E2E_USER_PASSWORD);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/(journey|dashboard)/, { timeout: 30_000 });
+}
+
+setup("provision and authenticate", async ({ page, browser }) => {
   assertE2eTargets();
 
   // Evidence bucket for the MinIO stack (idempotent).
@@ -45,30 +55,37 @@ setup("provision and authenticate", async ({ page }) => {
   }
 
   // Give the seeded admin a password so the real credentials form works.
-  const pg = new Client({ connectionString: E2E_DATABASE_URL });
-  await pg.connect();
-  try {
-    const hash = await bcrypt.hash(E2E_USER_PASSWORD, 10);
-    const res = await pg.query(
-      `UPDATE "user" SET password_hash = $1 WHERE email = $2`,
-      [hash, E2E_USER_EMAIL],
+  const hash = await bcrypt.hash(E2E_USER_PASSWORD, 10);
+  const updated = await e2eQuery(
+    `UPDATE "user" SET password_hash = $1 WHERE email = $2 RETURNING id`,
+    [hash, E2E_USER_EMAIL],
+  );
+  if (updated.length !== 1) {
+    throw new Error(
+      `expected exactly 1 seeded user for ${E2E_USER_EMAIL}, got ${updated.length}. Did drizzle/seed.ts run?`,
     );
-    if (res.rowCount !== 1) {
-      throw new Error(
-        `expected exactly 1 seeded user for ${E2E_USER_EMAIL}, got ${res.rowCount}. Did drizzle/seed.ts run?`,
-      );
-    }
-  } finally {
-    await pg.end();
   }
 
-  // Log in through the real form and keep the session for all specs.
-  await page.goto("/de/auth/signin");
-  await page.locator("#email").fill(E2E_USER_EMAIL);
-  await page.locator("#password").fill(E2E_USER_PASSWORD);
-  await page.locator('button[type="submit"]').click();
-  await page.waitForURL(/\/(journey|dashboard)/, { timeout: 30_000 });
-  await expect(page.locator("body")).toBeVisible();
+  // Second user: management member in the same company, for N-of-M.
+  await e2eQuery(
+    `INSERT INTO "user" (company_id, email, name, role, is_management, email_verified_at, password_hash)
+     SELECT company_id, $2, 'E2E Management', 'member', true, NOW(), $3
+       FROM "user" WHERE email = $1
+     ON CONFLICT (email) DO UPDATE
+       SET password_hash = EXCLUDED.password_hash,
+           company_id = EXCLUDED.company_id,
+           is_management = true`,
+    [E2E_USER_EMAIL, E2E_MANAGER_EMAIL, hash],
+  );
 
+  // Log both users in through the real form; each keeps a session file.
+  await login(page, E2E_USER_EMAIL);
+  await expect(page.locator("body")).toBeVisible();
   await page.context().storageState({ path: E2E_STORAGE_STATE });
+
+  const managerContext = await browser.newContext();
+  const managerPage = await managerContext.newPage();
+  await login(managerPage, E2E_MANAGER_EMAIL);
+  await managerContext.storageState({ path: E2E_STORAGE_STATE_MANAGER });
+  await managerContext.close();
 });

--- a/e2e/l2/modules.spec.ts
+++ b/e2e/l2/modules.spec.ts
@@ -20,11 +20,10 @@ import {
   internalAuditInsertSchema,
   managementReviewInsertSchema,
 } from "@/schema/validators";
-import { Client } from "pg";
 import { introspectSchema } from "@/lib/forms/schema-introspect";
 import { generateValue } from "../lib/value-factory";
 import { fillFields } from "../lib/form-driver";
-import { E2E_DATABASE_URL, assertE2eTargets } from "../lib/env";
+import { e2eQuery } from "../lib/db";
 
 type AnySchema = Parameters<typeof introspectSchema>[0];
 
@@ -61,15 +60,8 @@ test.describe("module create sweep", () => {
       // exist by the time this runs. (UX finding: the field deserves the
       // same asset picker other pages use.)
       if (mod.route === "patches") {
-        assertE2eTargets();
-        const pg = new Client({ connectionString: E2E_DATABASE_URL });
-        await pg.connect();
-        try {
-          const { rows } = await pg.query("SELECT id FROM asset LIMIT 1");
-          if (rows[0]) overrides.assetId = rows[0].id;
-        } finally {
-          await pg.end();
-        }
+        const rows = await e2eQuery<{ id: string }>("SELECT id FROM asset LIMIT 1");
+        if (rows[0]) overrides.assetId = rows[0].id;
       }
       const values: Record<string, unknown> = {};
       for (const meta of metas) {

--- a/e2e/l3/signoff.spec.ts
+++ b/e2e/l3/signoff.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * L3 sign-off: the evidentiary core. Single-signer completion, N-of-M
+ * across two real user sessions, tamper-evident chain rows, and the
+ * (currently dormant) cross-framework carry-over.
+ *
+ * Runs after l1/l2 in the same hermetic run, so the intake specs have
+ * already saved answers and every target is signable (saving answers
+ * flips completed requirements back to in_progress by design).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  nis2Categories,
+  getNis2RequirementsForCategory,
+} from "@nisd2/grc-data-model/frameworks";
+import { e2eQuery } from "../lib/db";
+import { E2E_STORAGE_STATE_MANAGER, E2E_MANAGER_EMAIL, E2E_USER_EMAIL } from "../lib/env";
+
+const SINGLE_TARGET = "3.1"; // incident lead — no required role, admin signs alone
+const NOFM_TARGET = "1.4"; // personal liability — CEO-role, two assigned signers
+
+const slugByCode = new Map<string, string>();
+for (const cat of nis2Categories) {
+  for (const r of getNis2RequirementsForCategory(cat.slug)) {
+    slugByCode.set(r.code, cat.slug);
+  }
+}
+
+async function statusRow(code: string): Promise<{ id: string; status: string; signed_off_by: string | null }> {
+  const rows = await e2eQuery<{ id: string; status: string; signed_off_by: string | null }>(
+    `SELECT s.id, s.status, s.signed_off_by
+       FROM company_requirement_status s
+       JOIN requirement r ON r.id = s.requirement_id
+       JOIN company_assessment a ON a.id = s.assessment_id
+       JOIN compliance_framework f ON f.id = a.framework_id
+      WHERE f.code = 'nis2' AND r.code = $1`,
+    [code],
+  );
+  expect(rows.length, `status row for ${code}`).toBe(1);
+  return rows[0];
+}
+
+/**
+ * Ensure the requirement is signable, via the product's own invalidation
+ * path: saving answers flips a completed requirement back to in_progress.
+ * Makes the spec self-sufficient instead of depending on l1 side effects.
+ */
+async function makeSignable(page: Page, code: string): Promise<void> {
+  await page.goto(`/de/compliance/${slugByCode.get(code)}/${code}`);
+  if (await page.getByTestId("sign-off-button").isVisible().catch(() => false)) {
+    return;
+  }
+  const edit = page.getByTestId("requirement-edit");
+  const save = page.getByTestId("requirement-save");
+  await expect(edit.or(save).first()).toBeVisible({ timeout: 20_000 });
+  if (await edit.isVisible()) await edit.click();
+  await save.click();
+  await expect(edit).toBeVisible({ timeout: 20_000 });
+  await page.reload();
+}
+
+async function signOffViaUi(page: Page, code: string): Promise<void> {
+  await makeSignable(page, code);
+  const button = page.getByTestId("sign-off-button");
+  await expect(button).toBeVisible({ timeout: 20_000 });
+  const [resp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes("assessment.signOff") && r.request().method() === "POST",
+      { timeout: 20_000 },
+    ),
+    button.click(),
+  ]);
+  expect(resp.ok(), `signOff mutation HTTP ${resp.status()}`).toBe(true);
+}
+
+test("single signer: admin sign-off completes the requirement", async ({ page }) => {
+  await makeSignable(page, SINGLE_TARGET);
+  const before = await statusRow(SINGLE_TARGET);
+  expect(before.status).not.toBe("completed");
+
+  await signOffViaUi(page, SINGLE_TARGET);
+
+  const after = await statusRow(SINGLE_TARGET);
+  expect(after.status).toBe("completed");
+  expect(after.signed_off_by).not.toBeNull();
+
+  // The sign-off button is gone after a reload (completed state).
+  await page.reload();
+  await expect(page.getByTestId("sign-off-button")).toHaveCount(0);
+});
+
+test("N-of-M: two assigned signers, partial then complete", async ({ page, browser }) => {
+  const status = await statusRow(NOFM_TARGET);
+
+  // Assign both users (assignment seeding via SQL; the assignment UI gets
+  // its own spec with the team flow).
+  await e2eQuery(
+    `INSERT INTO requirement_assignment (status_id, user_id, assigned_by)
+     SELECT $1, u.id, u.id FROM "user" u WHERE u.email = ANY($2)
+     ON CONFLICT (status_id, user_id) DO NOTHING`,
+    [status.id, [E2E_USER_EMAIL, E2E_MANAGER_EMAIL]],
+  );
+
+  // Members act only on categories they own (admins bypass); make the
+  // manager the GOV category owner, as a team invite would.
+  await e2eQuery(
+    `INSERT INTO category_assignment (assessment_id, category_id, user_id, assigned_by)
+     SELECT s.assessment_id, r.category_id, mu.id, mu.id
+       FROM company_requirement_status s
+       JOIN requirement r ON r.id = s.requirement_id
+       CROSS JOIN "user" mu
+      WHERE s.id = $1 AND mu.email = $2
+     ON CONFLICT (assessment_id, category_id) DO UPDATE SET user_id = EXCLUDED.user_id`,
+    [status.id, E2E_MANAGER_EMAIL],
+  );
+
+  // Signer 1 (admin): partial — status stays open, 1 of 2 recorded.
+  await signOffViaUi(page, NOFM_TARGET);
+  const partial = await statusRow(NOFM_TARGET);
+  expect(partial.status).toBe("in_progress");
+  const signedCount = await e2eQuery<{ n: string }>(
+    `SELECT count(*)::text AS n FROM requirement_assignment WHERE status_id = $1 AND signed_off_at IS NOT NULL`,
+    [status.id],
+  );
+  expect(signedCount[0].n).toBe("1");
+
+  // The journey board shows the partial sign-off (1/2) on the node.
+  await page.goto("/de/journey");
+  await expect(page.getByTestId(`journey-node-${NOFM_TARGET}`)).toContainText("1/2");
+
+  // Signer 2 (management member, real second session): completes it.
+  const managerContext = await browser.newContext({ storageState: E2E_STORAGE_STATE_MANAGER });
+  const managerPage = await managerContext.newPage();
+  await signOffViaUi(managerPage, NOFM_TARGET);
+  await managerContext.close();
+
+  const done = await statusRow(NOFM_TARGET);
+  expect(done.status).toBe("completed");
+});
+
+test("sign-off chain: append-only history rows exist for both sign-offs", async () => {
+  for (const code of [SINGLE_TARGET, NOFM_TARGET]) {
+    const status = await statusRow(code);
+    const rows = await e2eQuery<{ version: number; checksum: string | null }>(
+      `SELECT version, checksum FROM sign_off_history WHERE status_id = $1 ORDER BY version`,
+      [status.id],
+    );
+    expect(rows.length, `chain rows for ${code}`).toBeGreaterThan(0);
+    rows.forEach((r, i) => {
+      expect(Number(r.version), `versions strictly increase for ${code}`).toBe(i + 1);
+      expect(r.checksum, `checksum present for ${code}`).toBeTruthy();
+    });
+  }
+});
+
+test("cross-framework carry-over credits the linked ISO requirement", async () => {
+  const pairs = await e2eQuery<{ n: string }>(
+    `SELECT count(*)::text AS n FROM requirement_satisfaction`,
+  );
+  test.skip(
+    pairs[0].n === "0",
+    "requirement_satisfaction is empty in the default seed — carry-over is dormant (recorded coverage gap; seeding the NIS2<->ISO pairs is a product decision)",
+  );
+
+  // When pairs exist: signing SINGLE_TARGET must credit its linked pair.
+  const credited = await e2eQuery<{ status: string }>(
+    `SELECT s.status
+       FROM requirement_satisfaction rs
+       JOIN requirement src ON src.id IN (rs.requirement_a_id, rs.requirement_b_id) AND src.code = $1
+       JOIN requirement dst ON dst.id IN (rs.requirement_a_id, rs.requirement_b_id) AND dst.id <> src.id
+       JOIN company_requirement_status s ON s.requirement_id = dst.id`,
+    [SINGLE_TARGET],
+  );
+  for (const row of credited) {
+    expect(["completed", "approved"]).toContain(row.status);
+  }
+});

--- a/e2e/lib/db.ts
+++ b/e2e/lib/db.ts
@@ -1,0 +1,22 @@
+/**
+ * Direct SQL against the e2e database, for provisioning and for asserting
+ * persistence independently of the UI. Every call re-checks the
+ * never-on-prod guard and opens a short-lived connection.
+ */
+import { Client } from "pg";
+import { assertE2eTargets, E2E_DATABASE_URL } from "./env";
+
+export async function e2eQuery<T = Record<string, unknown>>(
+  sql: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  assertE2eTargets();
+  const pg = new Client({ connectionString: E2E_DATABASE_URL });
+  await pg.connect();
+  try {
+    const res = await pg.query(sql, params);
+    return res.rows as T[];
+  } finally {
+    await pg.end();
+  }
+}

--- a/e2e/lib/env.ts
+++ b/e2e/lib/env.ts
@@ -21,7 +21,12 @@ export const E2E_BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3026";
 export const E2E_USER_EMAIL = "dev@nis2.local";
 export const E2E_USER_PASSWORD = "e2e-Passw0rd-local-only";
 
+/** Second user (management member), provisioned by auth.setup for the
+ *  N-of-M sign-off specs. Same password as the admin. */
+export const E2E_MANAGER_EMAIL = "e2e-management@nis2.local";
+
 export const E2E_STORAGE_STATE = "e2e/.auth/admin.json";
+export const E2E_STORAGE_STATE_MANAGER = "e2e/.auth/manager.json";
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   testIgnore: "**/l0/**",
   outputDir: "./test-results",
   fullyParallel: false,
+  // One shared tenant, deliberate cross-file order: l1 intake saves flip
+  // seeded-complete requirements back to signable before l3 signs them.
+  // Parallel workers break that order (and race router.refresh on the
+  // same company), so the suite is serial by design.
+  workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: [["list"], ["html", { open: "never" }]],


### PR DESCRIPTION
## What

The evidentiary core of the plan: sign-offs tested end to end.

- **Single signer**: admin signs a requirement through the real button; status flips to completed in Postgres, the button is gone after reload.
- **N-of-M**: requirement 1.4 (CEO role) with two assigned signers in **two real browser sessions** — the admin's signature leaves it in_progress with the **1/2 partial badge asserted on the journey node**, the management member's session completes it. Members are category-gated, so the spec makes the manager the GOV category owner exactly as a team invite would.
- **Chain**: `sign_off_history` rows verified per signed status — version sequence and checksum presence (deep chain recomputation via `verifySignOffChain` is a follow-up).
- **Carry-over**: documented skip — `requirement_satisfaction` is empty in the default seed, so `propagateSatisfaction` is dormant. **Product decision for Simon**: seed the NIS2↔ISO pairs to activate cross-framework crediting, then this test asserts it automatically.
- **Self-sufficiency**: `makeSignable` drives the product's own invalidation path (saving answers flips completed → in_progress), so the spec passes standalone and in suite — this also pins that invalidation behavior as tested.

Infrastructure: second management user provisioned with its own storage state; guarded SQL centralized in `e2e/lib/db.ts`; `workers: 1` pinned (one shared tenant, deliberate cross-file order — parallel workers raced the seed state).

## Verified

- Standalone: 4 passed + 1 documented skip (7s)
- Full suite: **67 passed + 1 skipped** (1.2m), hermetic DB per run
- `bun test e2e/l0`: 110 pass; typecheck clean

Awaiting review — not merging without an explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01De1NY1HDUJkkwetVKTbYtH