### PR TITLE
fix(forms): clearing an optional text field on edit now persists

### DIFF
--- a/lib/forms/schema-form.tsx
+++ b/lib/forms/schema-form.tsx
@@ -111,19 +111,30 @@ export function SchemaForm<T extends z.ZodRawShape>({
   const baseResolverSchema = Object.keys(omitMask).length
     ? (schema as z.ZodObject<z.ZodRawShape>).omit(omitMask)
     : schema;
-  // Optional fields default to "" in the form, but validators like uuid or
-  // date reject the empty string, so an untouched optional field (e.g. an
-  // asset link) would block submission entirely. Empty string on an
-  // optional field means "not provided": strip it before validation.
-  const optionalKeys = fields.filter((f) => !f.required).map((f) => f.key);
-  const resolverSchema = z.preprocess((raw) => {
-    if (typeof raw !== "object" || raw === null) return raw;
-    const out = { ...(raw as Record<string, unknown>) };
-    for (const key of optionalKeys) {
-      if (out[key] === "") out[key] = undefined;
-    }
-    return out;
-  }, baseResolverSchema);
+  // Optional fields default to "" in the form. For fields whose validator
+  // rejects "" (an optional uuid link, a date, a url) that empty default
+  // would block submission, so "" must be read as "not provided". But for a
+  // plain optional string, "" is a legitimate value: the user clearing the
+  // field. Strip "" only where the field's own validator rejects it, so
+  // clearing a text field still persists the empty value.
+  const baseShape = (baseResolverSchema as z.ZodObject<z.ZodRawShape>).shape;
+  const stripEmptyKeys = fields
+    .filter((f) => !f.required)
+    .filter((f) => {
+      const fieldSchema = baseShape[f.key] as z.ZodType | undefined;
+      return fieldSchema ? !fieldSchema.safeParse("").success : false;
+    })
+    .map((f) => f.key);
+  const resolverSchema = stripEmptyKeys.length
+    ? z.preprocess((raw) => {
+        if (typeof raw !== "object" || raw === null) return raw;
+        const out = { ...(raw as Record<string, unknown>) };
+        for (const key of stripEmptyKeys) {
+          if (out[key] === "") out[key] = undefined;
+        }
+        return out;
+      }, baseResolverSchema)
+    : baseResolverSchema;
 
   // Internally FieldValues — the Zod schema enforces correctness at validation time.
   // zodResolver's Zod v4 overload needs explicit generic params to match.


### PR DESCRIPTION
## The bug (live on prod, regression from #37)

#37 fixed "optional empty fields block create submit" by stripping `"" → undefined` for every optional field. That over-reached: for a plain optional string, `""` is a legitimate value — the user **clearing** the field. Stripping it meant the cleared key reached drizzle `.set()` as `undefined` (skipped), so the old value silently survived a save the UI reported as successful.

**Repro on current prod:** edit any record in `/de/risks` (or suppliers, policies, kpis, patches…), clear an optional text field like description, save, reload — the old text comes back. Found by 4 independent review finders converging on the same trace: `CrudPage onUpdate → *UpdateSchema.partial() → drizzle .set()`.

## The fix

Strip `""` only for fields whose **own validator rejects `""`** (uuid FK, date, number, url, enum) — those need it to submit. Keep `""` for plain optional text so clears persist. The strip set is derived per field via `fieldSchema.safeParse("")`, so it self-adjusts as schemas change; no hand-maintained list.

## Verified

Against `asset`/`supplier`/`risk` validators (script in the commit):
- **Strip** (submit still works): `quantity`, `customerCompanyId`, `lastPatchDate`, `residualLikelihood`, booleans…
- **Keep** (clearing now persists): `description`, `owner`, `hostname`, `contactName`, `category`, `riskOwner`…

Typecheck clean. Regression e2e test (edit → clear → reload → assert empty) is added on the e2e branch to guard it going forward.

Not merging without your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01De1NY1HDUJkkwetVKTbYtH