### PR TITLE
test(e2e): module edit/delete + cross-tenant isolation

### DIFF
--- a/components/policies/PoliciesPage.tsx
+++ b/components/policies/PoliciesPage.tsx
@@ -65,8 +65,8 @@ export function PoliciesPage({ items, inline }: { items: Record<string, unknown>
                 <TableCell>{item.effectiveFrom ? new Date(item.effectiveFrom as string).toLocaleDateString() : "\u2014"}</TableCell>
                 <TableCell>{item.reviewDue ? new Date(item.reviewDue as string).toLocaleDateString() : "\u2014"}</TableCell>
                 <TableCell className="text-right">
-                  <Button variant="ghost" size="icon" onClick={() => onEdit(item)}><Pencil className="h-4 w-4" /></Button>
-                  <Button variant="ghost" size="icon" onClick={() => onDelete(item.id as string)}><Trash2 className="h-4 w-4" /></Button>
+                  <Button variant="ghost" size="icon" data-testid="row-edit" onClick={() => onEdit(item)}><Pencil className="h-4 w-4" /></Button>
+                  <Button variant="ghost" size="icon" data-testid="row-delete" onClick={() => onDelete(item.id as string)}><Trash2 className="h-4 w-4" /></Button>
                 </TableCell>
               </TableRow>
             ))}

--- a/components/risks/RisksPage.tsx
+++ b/components/risks/RisksPage.tsx
@@ -143,8 +143,8 @@ export function RisksPage({ items, inline, methodology: serverMethodology, asset
                   <TableCell>{(item.riskOwner as string) || "\u2014"}</TableCell>
                   <TableCell className="text-right">
                     <Button variant="ghost" size="icon" onClick={() => setLinkRiskId(item.id as string)}><Link2 className="h-4 w-4" /></Button>
-                    <Button variant="ghost" size="icon" onClick={() => onEdit(item)}><Pencil className="h-4 w-4" /></Button>
-                    <Button variant="ghost" size="icon" onClick={() => onDelete(item.id as string)}><Trash2 className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" data-testid="row-edit" onClick={() => onEdit(item)}><Pencil className="h-4 w-4" /></Button>
+                    <Button variant="ghost" size="icon" data-testid="row-delete" onClick={() => onDelete(item.id as string)}><Trash2 className="h-4 w-4" /></Button>
                   </TableCell>
                 </TableRow>
               );

--- a/e2e/l2/edit-delete.spec.ts
+++ b/e2e/l2/edit-delete.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * L2 module edit + delete: the CrudPage sweep is create-only, so the
+ * onUpdate/onDelete paths (the PR #25 bug class in the edit dialog, and
+ * silent-corruption on update) were untested. This drives edit and delete
+ * through the real UI on two representative CrudPage modules (risks,
+ * policies); the flow — row action -> SchemaForm defaultValues -> update
+ * mutation / delete confirm -> refresh — is shared by all twelve.
+ *
+ * The row edit/delete buttons carry data-testid row-edit / row-delete
+ * (one per row); the spec scopes to the row holding its unique marker.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { fillFields } from "../lib/form-driver";
+import { introspectSchema } from "@/lib/forms/schema-introspect";
+import { riskInsertSchema, policyInsertSchema } from "@/schema/validators";
+import { generateValue } from "../lib/value-factory";
+import { e2eQuery } from "../lib/db";
+
+const MODULES = [
+  {
+    route: "risks",
+    table: "risk",
+    schema: riskInsertSchema as unknown as Parameters<typeof introspectSchema>[0],
+    titleField: "title",
+    createTitle: "E2E Edit-Delete Ausgangsrisiko",
+    editedTitle: "E2E Edit-Delete Risiko GEAENDERT",
+  },
+  {
+    route: "policies",
+    table: "policy",
+    schema: policyInsertSchema as unknown as Parameters<typeof introspectSchema>[0],
+    titleField: "title",
+    createTitle: "E2E Edit-Delete Ausgangsrichtlinie",
+    editedTitle: "E2E Edit-Delete Richtlinie GEAENDERT",
+  },
+];
+
+async function createRecord(
+  page: Page,
+  mod: (typeof MODULES)[number],
+): Promise<void> {
+  const metas = introspectSchema(mod.schema);
+  const values: Record<string, unknown> = {};
+  for (const meta of metas) {
+    if (meta.key.endsWith("Id")) continue; // optional FK links stay empty
+    values[meta.key] =
+      meta.key === mod.titleField ? mod.createTitle : generateValue(meta);
+  }
+  await page.goto(`/de/${mod.route}`);
+  const submit = page.getByTestId("schema-form-submit");
+  await expect(submit).toBeVisible({ timeout: 20_000 });
+  await fillFields(page, metas, values);
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.request().method() === "POST" && r.url().includes(".create"),
+      { timeout: 20_000 },
+    ),
+    submit.click(),
+  ]);
+  await expect(page.getByText(mod.createTitle).first()).toBeVisible({ timeout: 20_000 });
+}
+
+for (const mod of MODULES) {
+  test(`${mod.route}: edit an existing record, change persists`, async ({ page }) => {
+    await createRecord(page, mod);
+
+    // Open the created row's edit form via its scoped row-edit button.
+    const row = page.locator("tr", { hasText: mod.createTitle }).first();
+    await row.getByTestId("row-edit").click();
+
+    // SchemaForm edit form is pre-filled; change the title and save. The
+    // control may be an input or a textarea (long-maxLength strings render
+    // as textareas), so match either.
+    const titleField = page
+      .locator(`[data-field="${mod.titleField}"] input, [data-field="${mod.titleField}"] textarea`)
+      .first();
+    await expect(titleField).toHaveValue(mod.createTitle, { timeout: 10_000 });
+    await titleField.fill(mod.editedTitle);
+    await Promise.all([
+      page.waitForResponse(
+        (r) => r.request().method() === "POST" && r.url().includes(".update"),
+        { timeout: 20_000 },
+      ),
+      page.getByTestId("schema-form-submit").click(),
+    ]);
+
+    // Persisted: reload and both the UI and the DB show the new value.
+    await page.reload();
+    await expect(page.getByText(mod.editedTitle).first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(mod.createTitle)).toHaveCount(0);
+    const rows = await e2eQuery<{ title: string }>(
+      `SELECT title FROM ${mod.table} WHERE title = $1`,
+      [mod.editedTitle],
+    );
+    expect(rows.length).toBe(1);
+  });
+
+  test(`${mod.route}: delete a record, it is gone from UI and DB`, async ({ page }) => {
+    const title = `${mod.createTitle} zum Loeschen`;
+    await createRecord(page, { ...mod, createTitle: title });
+
+    page.once("dialog", (d) => d.accept()); // CrudPage delete uses window.confirm
+    const row = page.locator("tr", { hasText: title }).first();
+    await Promise.all([
+      page.waitForResponse(
+        (r) => r.request().method() === "POST" && r.url().includes(".delete"),
+        { timeout: 20_000 },
+      ),
+      row.getByTestId("row-delete").click(),
+    ]);
+
+    await page.reload();
+    await expect(page.getByText(title)).toHaveCount(0, { timeout: 20_000 });
+    const rows = await e2eQuery<{ id: string }>(
+      `SELECT id FROM ${mod.table} WHERE title = $1`,
+      [title],
+    );
+    expect(rows.length).toBe(0);
+  });
+}

--- a/e2e/l3/cross-tenant.spec.ts
+++ b/e2e/l3/cross-tenant.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * L3 cross-tenant isolation — the company-ending failure mode. The whole
+ * suite otherwise runs as one seeded company, so a dropped `companyId`
+ * filter in any ownership guard would go unnoticed. This provisions a
+ * SECOND company (Rival GmbH) with its own asset, then, as the Dev GmbH
+ * admin (the authenticated session every spec uses), attacks Rival's asset
+ * over the real tRPC endpoint and asserts Rival's data is untouched.
+ *
+ * Ground truth is always Postgres after the attack, not the HTTP envelope,
+ * so the assertions hold regardless of how tRPC reports a rejected call.
+ */
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { e2eQuery } from "../lib/db";
+
+const RIVAL_ASSET_NAME = "RIVAL Kronjuwelen Server";
+
+/** superjson httpBatchLink call shapes. */
+async function trpcMutation(
+  request: APIRequestContext,
+  proc: string,
+  input: unknown,
+) {
+  return request.post(`/api/trpc/${proc}?batch=1`, {
+    data: { "0": { json: input } },
+    headers: { "content-type": "application/json" },
+    failOnStatusCode: false,
+  });
+}
+async function trpcQuery(
+  request: APIRequestContext,
+  proc: string,
+  input: unknown,
+) {
+  const q = encodeURIComponent(JSON.stringify({ "0": { json: input } }));
+  return request.get(`/api/trpc/${proc}?batch=1&input=${q}`, {
+    failOnStatusCode: false,
+  });
+}
+
+test("cross-tenant: one company cannot read, update or delete another's asset", async ({ request }) => {
+  // Provision Rival GmbH + its asset directly (a real second tenant).
+  const [company] = await e2eQuery<{ id: string }>(
+    `INSERT INTO company (name, sector, entity_type, activated_at, acts_as_nis2_entity)
+     VALUES ('Rival GmbH (Testdaten)', 'energy', 'important', NOW(), true)
+     RETURNING id`,
+  );
+  const rivalCompanyId = company.id;
+  const [asset] = await e2eQuery<{ id: string }>(
+    `INSERT INTO asset (company_id, name, type)
+     VALUES ($1, $2, 'server')
+     RETURNING id`,
+    [rivalCompanyId, RIVAL_ASSET_NAME],
+  );
+  const rivalAssetId = asset.id;
+
+  // The acting session is the Dev GmbH admin (chromium storageState). Confirm
+  // Rival's company id differs from the attacker's, so this is truly cross-tenant.
+  const [attacker] = await e2eQuery<{ company_id: string }>(
+    `SELECT company_id FROM "user" WHERE email = 'dev@nis2.local'`,
+  );
+  expect(attacker.company_id).not.toBe(rivalCompanyId);
+
+  // Attack 1 — read: asset.list returns only the caller's own assets.
+  const listRes = await trpcQuery(request, "asset.list", null);
+  expect(listRes.status(), "asset.list endpoint reachable").toBe(200);
+  const listBody = await listRes.text();
+  // Non-vacuity: the call actually ran AS Dev GmbH (its own seeded asset is
+  // present), so the absence of Rival's asset is real isolation, not a
+  // 404/unauthenticated no-op.
+  expect(listBody, "attacker's own assets returned (call was authenticated)").toContain(
+    "Customer Database",
+  );
+  expect(listBody).not.toContain(rivalAssetId);
+  expect(listBody).not.toContain(RIVAL_ASSET_NAME);
+
+  // Attack 2 — update someone else's asset by id. tRPC answers (not 404),
+  // proving the mutation ran; its effect on Rival is checked in the DB below.
+  const updRes = await trpcMutation(request, "asset.update", {
+    id: rivalAssetId,
+    name: "PWNED BY DEV GMBH",
+  });
+  expect(updRes.status(), "asset.update endpoint reachable").not.toBe(404);
+
+  // Attack 3 — delete someone else's asset by id.
+  const delRes = await trpcMutation(request, "asset.delete", { id: rivalAssetId });
+  expect(delRes.status(), "asset.delete endpoint reachable").not.toBe(404);
+
+  // Ground truth: Rival's asset still exists with its original name.
+  const rows = await e2eQuery<{ name: string }>(
+    `SELECT name FROM asset WHERE id = $1`,
+    [rivalAssetId],
+  );
+  expect(rows.length, "Rival asset was deleted across tenants").toBe(1);
+  expect(rows[0].name, "Rival asset was renamed across tenants").toBe(RIVAL_ASSET_NAME);
+});


### PR DESCRIPTION
## What

Closes the highest-friction coverage gap from the review: the l2 module sweep was **create-only**, so `CrudPage`'s update and delete paths (the PR #25 bug class in the edit dialog, and silent data-corruption on update) had zero coverage.

`e2e/l2/edit-delete.spec.ts` drives both through the real UI on two representative modules (risks, policies):
- **Edit**: open the created row's edit form via a scoped `row-edit` button, change the title through the pre-filled SchemaForm, save, assert the new value in **UI and Postgres** and the old value gone.
- **Delete**: create another, click `row-delete`, accept the `window.confirm`, assert gone from **UI and Postgres**.

The CrudPage flow is shared by all twelve modules, so two prove the mechanism; extending to the rest is one testid pair + one config row each.

Stacked on #39 (base `feat/e2e-editors`); rebases onto main when that merges.

## Product hooks

`data-testid="row-edit"` / `row-delete` on the RisksPage and PoliciesPage row action buttons (icon-only, previously unselectable).

## Verified

- Full suite **81 passed + 1 skip**; typecheck clean.
- One iteration to green: the title control is a `textarea` (long maxLength), not an `input` — selector widened.

## Note (not fixed here)

PoliciesPage logs `MISSING_MESSAGE: policies.status.<value>` when a status value isn't a known i18n key — an arbitrary status string breaks the row's translated render. Same "string column with app-level enum semantics" class as the numeric-column finding; worth a product follow-up.

Not merging without your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01De1NY1HDUJkkwetVKTbYtH