### PR TITLE
Harden numeric-column validation and free-text status/severity rendering

### DIFF
--- a/components/patches/PatchesPage.tsx
+++ b/components/patches/PatchesPage.tsx
@@ -67,7 +67,7 @@ export function PatchesPage({ items, inline }: { items: Record<string, unknown>[
                 <TableCell className="font-medium">{item.patchIdentifier as string}</TableCell>
                 <TableCell>{(item.title as string) || "\u2014"}</TableCell>
                 <TableCell>
-                  <StatusBadge status={item.severity as string} config={severityConfig} label={t(`severity.${item.severity as string}`)} />
+                  <StatusBadge status={item.severity as string} config={severityConfig} label={t.has(`severity.${item.severity as string}`) ? t(`severity.${item.severity as string}`) : (item.severity as string)} />
                 </TableCell>
                 <TableCell>
                   <StatusBadge status={item.status as string} config={statusConfig} label={t(`status.${item.status as string}`)} />

--- a/components/policies/PoliciesPage.tsx
+++ b/components/policies/PoliciesPage.tsx
@@ -60,7 +60,13 @@ export function PoliciesPage({ items, inline }: { items: Record<string, unknown>
                 <TableCell>{item.type as string}</TableCell>
                 <TableCell>{item.version as string}</TableCell>
                 <TableCell>
-                  <StatusBadge status={item.status as string} config={statusConfig} label={t(`status.${item.status as string}`)} />
+                  {/* policy.status is a free-text varchar (not a DB enum): an
+                      unmapped value must fall back, not crash the render. */}
+                  <StatusBadge
+                    status={item.status as string}
+                    config={statusConfig}
+                    label={t.has(`status.${item.status as string}`) ? t(`status.${item.status as string}`) : (item.status as string)}
+                  />
                 </TableCell>
                 <TableCell>{item.effectiveFrom ? new Date(item.effectiveFrom as string).toLocaleDateString() : "\u2014"}</TableCell>
                 <TableCell>{item.reviewDue ? new Date(item.reviewDue as string).toLocaleDateString() : "\u2014"}</TableCell>

--- a/components/vulnerabilities/VulnerabilitiesPage.tsx
+++ b/components/vulnerabilities/VulnerabilitiesPage.tsx
@@ -69,9 +69,9 @@ export function VulnerabilitiesPage({ items, inline }: { items: Record<string, u
                 <TableCell className="font-mono text-sm">{(item.cveId as string) || "\u2014"}</TableCell>
                 <TableCell className="font-medium">{item.title as string}</TableCell>
                 <TableCell>
-                  <StatusBadge status={item.severity as string} config={severityConfig} label={t(`severity.${item.severity as string}`)} />
+                  <StatusBadge status={item.severity as string} config={severityConfig} label={t.has(`severity.${item.severity as string}`) ? t(`severity.${item.severity as string}`) : (item.severity as string)} />
                 </TableCell>
-                <TableCell>{item.source ? t(`source.${item.source as string}`) : "\u2014"}</TableCell>
+                <TableCell>{item.source ? (t.has(`source.${item.source as string}`) ? t(`source.${item.source as string}`) : (item.source as string)) : "\u2014"}</TableCell>
                 <TableCell>
                   <StatusBadge status={item.status as string} config={statusConfig} label={t(`status.${item.status as string}`)} />
                 </TableCell>

--- a/e2e/start-server.sh
+++ b/e2e/start-server.sh
@@ -56,7 +56,20 @@ env "${APP_ENV[@]}" node scripts/runtime-migrate.mjs
 echo "[e2e] seeding (drizzle/seed.ts refuses NODE_ENV=production by itself)"
 env "${APP_ENV[@]}" bun run drizzle/seed.ts
 
+# Rebuild when there is no build yet OR any source file is newer than the last
+# build. `next start` serves a static production bundle, so without the staleness
+# check a rerun would serve a stale bundle and a green suite would not reflect
+# the current source (a false pass). Only the source dirs that actually feed the
+# bundle are watched; errors on any absent path are swallowed so the check never
+# aborts the run.
+needs_build=0
 if [ ! -f .next/BUILD_ID ]; then
+  needs_build=1
+elif [ -n "$(find app components lib server schema packages messages i18n next.config.ts next.config.mjs -newer .next/BUILD_ID 2>/dev/null | head -1)" ]; then
+  echo "[e2e] source changed since last build"
+  needs_build=1
+fi
+if [ "$needs_build" = 1 ]; then
   echo "[e2e] building production bundle"
   env "${APP_ENV[@]}" SKIP_ENV_VALIDATION=1 bun run build:webpack
 fi

--- a/schema/validators.ts
+++ b/schema/validators.ts
@@ -90,11 +90,40 @@ function isoDateColumns<T extends Table>(
   return out;
 }
 
+/**
+ * pg `numeric`/`decimal` columns surface from drizzle-zod as bare strings,
+ * so free text ("ca. 95%", "12k") flows to Postgres and fails the insert
+ * with `invalid input syntax for type numeric` — a 500, not a validation
+ * error. Same shape as isoDateColumns: constrain those columns to a numeric
+ * string so the form and the server reject non-numbers up front. Derived
+ * from table metadata; explicit overrides after the spread still win.
+ */
+function numericColumns<T extends Table>(
+  table: T,
+): Partial<Record<keyof T["_"]["columns"], z.ZodType>> {
+  const out: Partial<Record<keyof T["_"]["columns"], z.ZodType>> = {};
+  for (const [name, col] of Object.entries(getTableColumns(table))) {
+    if (col.columnType === "PgNumeric") {
+      // Free-text validation of a number is a genuine free-text case, so the
+      // regex is appropriate here. Integers and decimals only; "" is rejected
+      // (SchemaForm strips it to undefined for optional columns).
+      const numericStr = z
+        .string()
+        .regex(/^-?\d+(\.\d+)?$/, "Must be a number");
+      out[name as keyof T["_"]["columns"]] = col.notNull
+        ? numericStr
+        : numericStr.nullish();
+    }
+  }
+  return out;
+}
+
 // ============================================================================
 // Organization
 // ============================================================================
 
 export const companyInsertSchema = createInsertSchema(company, {
+  ...numericColumns(company),
   name: z.string().min(2).max(255),
   sector: z.string().min(1).max(255),
   contactEmail: z.union([
@@ -422,6 +451,7 @@ export const riskSupplierInsertSchema = createInsertSchema(riskSupplier);
 // ============================================================================
 
 export const incidentInsertSchema = createInsertSchema(incident, {
+  ...numericColumns(incident),
   title: z.string().min(1).max(500),
   description: z.string().min(1),
 });
@@ -532,6 +562,7 @@ export const patchRecordUpdateSchema = patchRecordInsertSchema.partial().omit(om
 
 export const vulnerabilityInsertSchema = createInsertSchema(vulnerability, {
   ...isoDateColumns(vulnerability),
+  ...numericColumns(vulnerability),
   title: z.string().min(1).max(500),
   severity: z.string().min(1).max(50),
 });
@@ -578,6 +609,7 @@ export const improvementItemUpdateSchema = improvementItemInsertSchema.partial()
 // ============================================================================
 
 export const kpiMeasurementInsertSchema = createInsertSchema(kpiMeasurement, {
+  ...numericColumns(kpiMeasurement),
   kpiName: z.string().min(1).max(255),
 });
 export const kpiMeasurementSelectSchema = createSelectSchema(kpiMeasurement);


### PR DESCRIPTION
Fixes two live product bugs found by the e2e journey suite, plus an e2e-harness false-pass fix.

## 1. Numeric 500s
pg `numeric`/`decimal` columns surface from drizzle-zod as bare strings, so free-text form input reached Postgres and failed the insert with a 500 instead of a validation error. A `numericColumns()` helper (mirroring the existing `isoDateColumns()`) constrains `PgNumeric` columns to a numeric string, spread into the four insert schemas whose numeric columns are user-form-editable:

- `company` — annual revenue, global turnover, security budget
- `incident` — estimated financial damage
- `vulnerability` — CVSS score
- `kpiMeasurement` — value, target

`compliancePercentage` (companyAssessment) is server-computed and never a mutation input, so it is intentionally left alone.

## 2. MISSING_MESSAGE render crash
`policy.status`, `patch.severity`, `vulnerability.severity` and `vulnerability.source` are free-text `varchar` columns (not DB enums), so a value with no i18n key threw inside the translated badge/cell render and crashed the page. These now fall back to the raw value via `t.has(key) ? t(key) : value`.

Enum-backed status/severity fields are deliberately unchanged: the DB constraint rejects any unmapped value at insert, so a missing key there is a real i18n gap that should surface, not a user-reachable crash.

## 3. e2e harness false pass
`start-server.sh` (`next start` serves a static bundle) only rebuilt when no build existed, so a rerun after a source edit served a stale bundle and a green suite did not reflect current source. It now also rebuilds when any watched source dir is newer than the last build. Without this, the fixes above would have shown a false green.

## Verification
Full e2e suite: 82 passed / 0 failed, `MISSING_MESSAGE` count 0, numeric-error count 0, against a freshly rebuilt bundle. Typecheck clean.