### PR TITLE
fix(about): move pitch deck below mission, standard centered CTA card

### DIFF
--- a/app/[locale]/(info)/about/page.tsx
+++ b/app/[locale]/(info)/about/page.tsx
@@ -147,13 +147,6 @@ export default async function TeamPage({
 
       <Separator />
 
-      {/* Pitch deck — full business overview. Migrated here from /pitch. */}
-      <section className="space-y-3">
-        <PitchDeckViewer locale={pitchLocale} stats={stats} />
-      </section>
-
-      <Separator />
-
       <div className="grid gap-6 sm:grid-cols-2">
         {/* Simon */}
         <Card>
@@ -287,12 +280,25 @@ export default async function TeamPage({
         </p>
       </section>
 
+      <Separator />
+
+      {/* Pitch deck — full business overview. Migrated here from /pitch. */}
+      <section className="space-y-3">
+        <PitchDeckViewer locale={pitchLocale} stats={stats} />
+      </section>
+
       {/* CTA */}
-      <Card>
-        <CardContent className="pt-6 flex flex-col gap-3 sm:flex-row">
-          <Button asChild>
-            <Link href="/applicability">{t("teamPage.ctaPlatform")}</Link>
-          </Button>
+      <Card className="text-center">
+        <CardContent className="pt-6 space-y-4">
+          <h2 className="text-xl font-semibold">{t("teamPage.cta.heading")}</h2>
+          <p className="text-sm text-muted-foreground">
+            {t("teamPage.cta.description")}
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button asChild>
+              <Link href="/applicability">{t("teamPage.ctaPlatform")}</Link>
+            </Button>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -6576,7 +6576,10 @@
         "heading": "Proč my",
         "body": "Nejsme konzultantská firma. Neprodáváme vám nástroj a pak vám neúčtujeme školení, jak ho používat. Vše na této platformě jsme vybudovali tím, že jsme přečetli skutečný zákon, prováděcí nařízení a pokyny BSI. Každá lekce v kurzu pro jednatele cituje svůj právní základ. Každý požadavek na platformě se mapuje na konkrétní paragraf BSIG. Jsme inženýři, kteří se rozhodli, že compliance by neměla stát šesticiferné částky."
       },
-      "ctaMission": "Přečtěte si naši misi",
+      "cta": {
+        "heading": "Vyzkoušet platformu",
+        "description": "Ověřte, zda se NIS2 vztahuje na vaši firmu, a poté plňte požadavky krok za krokem. Open source, bez závislosti na dodavateli."
+      },
       "ctaPlatform": "Začít zdarma"
     },
     "gapAssessmentLanding": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -6585,7 +6585,10 @@
         "heading": "Warum wir",
         "body": "Wir sind keine Beratungsfirma. Wir verkaufen kein Tool und kassieren dann für die Schulung. Wir haben alles auf dieser Plattform gebaut, indem wir das Gesetz, die Durchführungsverordnung und die BSI-Leitfäden gelesen haben. Jede Lektion im CEO-Kurs nennt ihre Rechtsgrundlage. Jede Anforderung in der Plattform verweist auf einen konkreten BSIG-Paragraphen. Wir sind Ingenieure, die entschieden haben, dass Compliance keine sechs Stellen kosten sollte."
       },
-      "ctaMission": "Unsere Mission lesen",
+      "cta": {
+        "heading": "Plattform ausprobieren",
+        "description": "Prüfen Sie, ob NIS2 für Ihr Unternehmen gilt, und arbeiten Sie die Anforderungen Schritt für Schritt ab. Open Source, kein Lock-in."
+      },
       "ctaPlatform": "Kostenlos starten"
     },
     "gapAssessmentLanding": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -6592,7 +6592,10 @@
         "heading": "Why us",
         "body": "We're not a consulting firm. We're not selling you a tool and then charging for the training to use it. We built everything on this platform by reading the actual law, the implementing regulation, and the BSI guidance. Every lesson in the managing director course cites its legal basis. Every requirement in the platform maps to a specific BSIG paragraph. We're engineers who decided compliance shouldn't cost six figures."
       },
-      "ctaMission": "Read our mission",
+      "cta": {
+        "heading": "Try the platform",
+        "description": "Check whether NIS2 applies to your company, then work through the requirements step by step. Open source, no lock-in."
+      },
       "ctaPlatform": "Start free"
     },
     "gapAssessmentLanding": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -6576,7 +6576,10 @@
         "heading": "Por qué nosotros",
         "body": "No somos una consultora. No le vendemos una herramienta para luego cobrarle por la formación para usarla. Construimos todo en esta plataforma leyendo la ley real, el reglamento de ejecución y la orientación del BSI. Cada lección del curso para directores gerentes cita su base jurídica. Cada requisito de la plataforma se asigna a un artículo específico del BSIG. Somos ingenieros que decidieron que el cumplimiento no debería costar seis cifras."
       },
-      "ctaMission": "Lee nuestra misión",
+      "cta": {
+        "heading": "Pruebe la plataforma",
+        "description": "Compruebe si la NIS2 se aplica a su empresa y trabaje los requisitos paso a paso. Open source, sin dependencia del proveedor."
+      },
       "ctaPlatform": "Empieza gratis"
     },
     "gapAssessmentLanding": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -6576,7 +6576,10 @@
         "heading": "Pourquoi nous",
         "body": "Nous ne sommes pas un cabinet de conseil. Nous ne vous vendons pas un outil pour ensuite facturer la formation à son utilisation. Nous avons construit tout ce qui figure sur cette plateforme en lisant la loi elle-même, le règlement d'exécution et les orientations du BSI. Chaque leçon du cours pour dirigeants cite sa base juridique. Chaque exigence de la plateforme correspond à un paragraphe précis du BSIG. Nous sommes des ingénieurs qui ont décidé que la conformité ne devrait pas coûter six chiffres."
       },
-      "ctaMission": "Lire notre mission",
+      "cta": {
+        "heading": "Essayer la plateforme",
+        "description": "Vérifiez si NIS2 s'applique à votre entreprise, puis traitez les exigences étape par étape. Open source, sans dépendance fournisseur."
+      },
       "ctaPlatform": "Commencer gratuitement"
     },
     "gapAssessmentLanding": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -6576,7 +6576,10 @@
         "heading": "Perché noi",
         "body": "Non siamo una società di consulenza. Non ti vendiamo uno strumento per poi farti pagare la formazione per usarlo. Abbiamo costruito tutto su questa piattaforma leggendo la legge effettiva, il regolamento di attuazione e le linee guida del BSI. Ogni lezione del corso per amministratori delegati cita la propria base giuridica. Ogni requisito della piattaforma è mappato a uno specifico paragrafo del BSIG. Siamo ingegneri che hanno deciso che la conformità non dovrebbe costare sei cifre."
       },
-      "ctaMission": "Leggi la nostra missione",
+      "cta": {
+        "heading": "Prova la piattaforma",
+        "description": "Verifica se la NIS2 si applica alla tua azienda e affronta i requisiti passo dopo passo. Open source, senza lock-in."
+      },
       "ctaPlatform": "Inizia gratis"
     },
     "gapAssessmentLanding": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -19895,6 +19895,26 @@
         "description": "Het platform produceert een overdrachtsmap met herinnering aan registratie-update, §38 opleidingsvolger en briefingsjabloon voor risicoacceptaties."
       },
       "cta": "Aanmelden bij het platform"
+    },
+    "teamPage": {
+      "meta": {
+        "title": "Team - NISD2.eu",
+        "description": "Maak kennis met het team achter NISD2.eu. Twee oprichters die de Europese NIS2-kostenpost halveren."
+      },
+      "badge": "Team",
+      "title": "Wie we zijn",
+      "subtitle": "Twee oprichters die de NIS2-rekening willen halveren. Geen adviesbureau, geen VC-financiering. Alleen de overtuiging dat compliance geen zes cijfers hoeft te kosten.",
+      "simon": "Meer dan 10 jaar softwareontwikkeling in veiligheidskritische sectoren. Senior engineer en tech lead voor een top-5-bank in de EU, Europa's grootste producent van motion plastics en VC-gefinancierde platforms. Bracht de volledige NIS2-rechtsketen in kaart (richtlijn, uitvoeringsverordening 2024/2690, BSIG, IT-Grundschutz) en bouwde daarmee het NISD2-platform, de bestuurderscursus met 47 lessen en de gap-assessment met 116 vragen. Bouwt daarnaast AI-legaltech voor Duitse rechtspraak. Woont in Keulen.",
+      "cory": "M.Eng mechatronica met focus op embedded systems en AI-integratie. Verantwoordelijk voor businessdevelopment, partnerschappen en implementatieondersteuning bij klanten. Achtergrond in softwareontwikkeling met Python, TypeScript en IoT-systemen. Slaat de brug tussen technische compliance-eisen en de bedrijfsrealiteit van de organisaties die ze moeten invoeren. Woont in Duitsland.",
+      "whyUs": {
+        "heading": "Waarom wij",
+        "body": "We zijn geen adviesbureau. We verkopen u geen tool om vervolgens de training voor het gebruik ervan in rekening te brengen. Alles op dit platform is gebouwd op basis van de wet zelf, de uitvoeringsverordening en de BSI-richtsnoeren. Elke les in de bestuurderscursus vermeldt zijn juridische grondslag. Elke eis in het platform verwijst naar een specifieke BSIG-paragraaf. We zijn engineers die vonden dat compliance geen zes cijfers hoeft te kosten."
+      },
+      "cta": {
+        "heading": "Probeer het platform",
+        "description": "Controleer of NIS2 op uw bedrijf van toepassing is en werk de vereisten stap voor stap af. Open source, geen lock-in."
+      },
+      "ctaPlatform": "Gratis starten"
     }
   }
 }

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -6576,7 +6576,10 @@
         "heading": "Dlaczego my",
         "body": "Nie jesteśmy firmą konsultingową. Nie sprzedajemy Ci narzędzia, a potem nie pobieramy opłat za szkolenie z jego obsługi. Wszystko na tej platformie zbudowaliśmy, czytając samo prawo, rozporządzenie wykonawcze oraz wytyczne BSI. Każda lekcja w kursie dla zarządzających przytacza swoją podstawę prawną. Każdy wymóg na platformie odwzorowuje konkretny paragraf BSIG. Jesteśmy inżynierami, którzy uznali, że zgodność nie powinna kosztować sześciu cyfr."
       },
-      "ctaMission": "Przeczytaj naszą misję",
+      "cta": {
+        "heading": "Wypróbuj platformę",
+        "description": "Sprawdź, czy NIS2 dotyczy Twojej firmy, a następnie realizuj wymagania krok po kroku. Open source, bez uzależnienia od dostawcy."
+      },
       "ctaPlatform": "Zacznij za darmo"
     },
     "gapAssessmentLanding": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -6576,7 +6576,10 @@
         "heading": "Porquê nós",
         "body": "Não somos uma firma de consultoria. Não lhe vendemos uma ferramenta para depois cobrar a formação para a usar. Construímos tudo nesta plataforma lendo a lei propriamente dita, o regulamento de execução e as orientações do BSI. Cada lição do curso para diretores-gerais cita a sua base jurídica. Cada requisito na plataforma remete para um parágrafo específico do BSIG. Somos engenheiros que decidiram que a conformidade não deveria custar seis dígitos."
       },
-      "ctaMission": "Ler a nossa missão",
+      "cta": {
+        "heading": "Experimentar a plataforma",
+        "description": "Verifique se a NIS2 se aplica à sua empresa e trabalhe os requisitos passo a passo. Open source, sem dependência de fornecedor."
+      },
       "ctaPlatform": "Começar gratuitamente"
     },
     "gapAssessmentLanding": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -6576,7 +6576,10 @@
         "heading": "De ce noi",
         "body": "Nu suntem o firmă de consultanță. Nu vă vindem un instrument și apoi vă taxăm pentru instruirea de a-l folosi. Am construit tot ce este pe această platformă citind legea propriu-zisă, regulamentul de punere în aplicare și ghidurile BSI. Fiecare lecție din cursul pentru directori își citează temeiul juridic. Fiecare cerință din platformă se raportează la un paragraf BSIG specific. Suntem ingineri care au decis că conformitatea nu ar trebui să coste șase cifre."
       },
-      "ctaMission": "Citește misiunea noastră",
+      "cta": {
+        "heading": "Încercați platforma",
+        "description": "Verificați dacă NIS2 se aplică companiei dumneavoastră, apoi parcurgeți cerințele pas cu pas. Open source, fără dependență de furnizor."
+      },
       "ctaPlatform": "Începe gratuit"
     },
     "gapAssessmentLanding": {


### PR DESCRIPTION
Reorders the /about (Team) page: the pitch deck slideshow moves from directly under the page header to below the mission section, so the page reads founders, why us, mission, deck, CTA.

Rebuilds the Start free CTA from a lone left-aligned button in an empty card to the centered heading + description + button card pattern already used by the wiki CTA cards. Adds `teamPage.cta.heading` / `teamPage.cta.description` to all 10 info locales, backfills the missing `teamPage` block in nl (the nl about page rendered raw message keys), and removes the unused `ctaMission` key.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgqgsrHnYuqTd1fbd2m8zM