### PR TITLE
fix(i18n): resolve portal messages by locale instead of hardcoded English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ scripts/i18n/_info-chunks/
 e2e/.auth/
 test-results/
 playwright-report/
+e2e/.artifacts/

--- a/app/[locale]/(portal)/export/page.tsx
+++ b/app/[locale]/(portal)/export/page.tsx
@@ -1,6 +1,6 @@
 import { getTranslations, getLocale } from "next-intl/server";
 import { api } from "@/lib/trpc/server";
-import complianceEn from "@/messages/compliance/en.json";
+import { getComplianceMessages } from "@/lib/messages";
 import { FileDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,6 +19,7 @@ export default async function ExportPage() {
     getLocale(),
     api.assessment.listAssessments(),
   ]);
+  const compliance = await getComplianceMessages(locale);
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -45,7 +46,7 @@ export default async function ExportPage() {
                   <div className="flex items-center justify-between">
                     <div>
                       <CardTitle className="text-base">
-                        {complianceEn.compliance.frameworkName}
+                        {compliance.compliance.frameworkName}
                       </CardTitle>
                       <CardDescription>
                         {t("started")}{" "}

--- a/app/[locale]/(portal)/layout.tsx
+++ b/app/[locale]/(portal)/layout.tsx
@@ -15,7 +15,11 @@ import {
   myRequirementCount,
   type CategoryInfo,
 } from "@/lib/compliance/access";
-import complianceEn from "@/messages/compliance/en.json";
+import { getLocale } from "next-intl/server";
+import {
+  getComplianceMessages,
+  type ComplianceMessages,
+} from "@/lib/messages";
 
 /** Map sortOrder ranges to i18n phase keys.
  * REG(0) | GOV(1) RSK(2) SUP(3) | CRY(4) ACC(5) AUT(6) | PRO(7) INC(8) BCP(9) | TRN(10) EFF(11) */
@@ -32,6 +36,7 @@ function buildSteps(
   categories: CategoryInfo[],
   access: Awaited<ReturnType<typeof getUserAccess>> | null,
   progress: Record<string, { completed: number; total: number }>,
+  compliance: ComplianceMessages,
 ) {
   return categories
     .filter((cat) => !access || canSeeCategory(access, cat.id))
@@ -42,7 +47,7 @@ function buildSteps(
       return {
         slug: cat.slug,
         code: cat.code,
-        name: complianceEn.compliance.categories[cat.code as keyof typeof complianceEn.compliance.categories]?.name ?? cat.code,
+        name: compliance.compliance.categories[cat.code as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? cat.code,
         phase: phaseForSortOrder(cat.sortOrder),
         requirementCount: reqCount,
         completedCount: Math.min(progress[cat.id]?.completed ?? 0, reqCount),
@@ -63,6 +68,7 @@ export default async function PortalLayout({
   // even before the user has set up their company. Pre-onboarding the
   // category links work as a preview — clicking lands on the onboarding banner.
   const allFrameworks = await getAllActiveCategories();
+  const compliance = await getComplianceMessages(await getLocale());
   const assessments = session.companyId
     ? await api.assessment.listAssessments()
     : [];
@@ -78,7 +84,7 @@ export default async function PortalLayout({
           ? api.assessment.getProgressByCategory({ assessmentId: assessment.id })
           : ({} as Record<string, { completed: number; total: number }>),
       ]).then(([access, progress]) => {
-        const steps = buildSteps(categories, access, progress);
+        const steps = buildSteps(categories, access, progress, compliance);
         return {
           code,
           label: framework.sidebarLabel ?? code,

--- a/app/[locale]/(portal)/review/page.tsx
+++ b/app/[locale]/(portal)/review/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { ClipboardCheck } from "lucide-react";
 import { getSession, hasReviewAccess } from "@/lib/auth";
 import { api } from "@/lib/trpc/server";
@@ -7,8 +7,12 @@ import {
   ReviewDashboard,
   type ReviewRow,
 } from "@/components/review/ReviewDashboard";
-import requirementsEn from "@/messages/requirements/en.json";
-import complianceEn from "@/messages/compliance/en.json";
+import {
+  getComplianceMessages,
+  getRequirementsMessages,
+  type ComplianceMessages,
+  type RequirementsMessages,
+} from "@/lib/messages";
 
 export default async function ReviewPage() {
   const session = await getSession();
@@ -18,14 +22,19 @@ export default async function ReviewPage() {
   }
 
   const t = await getTranslations("review");
+  const locale = await getLocale();
+  const [compliance, requirements] = await Promise.all([
+    getComplianceMessages(locale),
+    getRequirementsMessages(locale),
+  ]);
   const rawRows = await api.review.list();
   const rows = rawRows.map((r) => {
-    const reqKey = r.requirementCode.replace(/\./g, "_") as keyof typeof requirementsEn.requirements;
-    const catKey = r.categoryCode as keyof typeof complianceEn.compliance.categories;
+    const reqKey = r.requirementCode.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
+    const catKey = r.categoryCode as keyof ComplianceMessages["compliance"]["categories"];
     return {
       ...r,
-      requirementTitle: requirementsEn.requirements[reqKey]?.title ?? r.requirementCode,
-      categoryName: complianceEn.compliance.categories[catKey]?.name ?? r.categoryCode,
+      requirementTitle: requirements.requirements[reqKey]?.title ?? r.requirementCode,
+      categoryName: compliance.compliance.categories[catKey]?.name ?? r.categoryCode,
     };
   }) as ReviewRow[];
 

--- a/app/[locale]/(portal)/team/page.tsx
+++ b/app/[locale]/(portal)/team/page.tsx
@@ -1,24 +1,28 @@
 import { api } from "@/lib/trpc/server";
 import { getSession } from "@/lib/auth";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { TeamPage } from "@/components/team/TeamPage";
 import { Users } from "lucide-react";
 import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/shared/PageHeader";
-import complianceEn from "@/messages/compliance/en.json";
+import {
+  getComplianceMessages,
+  type ComplianceMessages,
+} from "@/lib/messages";
 
 export default async function TeamManagementPage() {
   const session = await getSession();
   if (!session?.companyId) redirect("/dashboard");
 
   const t = await getTranslations("team");
+  const compliance = await getComplianceMessages(await getLocale());
   const isAdmin = session.role === "admin";
   const rawMembers = await api.team.listMembers();
   const members = rawMembers.map((m) => ({
     ...m,
     assignments: m.assignments.map((a) => ({
       ...a,
-      categoryName: complianceEn.compliance.categories[a.categoryCode as keyof typeof complianceEn.compliance.categories]?.name ?? a.categoryCode,
+      categoryName: compliance.compliance.categories[a.categoryCode as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? a.categoryCode,
     })),
   }));
   const invites = isAdmin ? await api.team.listInvites() : [];

--- a/app/api/export/csv/route.ts
+++ b/app/api/export/csv/route.ts
@@ -28,7 +28,8 @@ export async function GET(request: NextRequest) {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const data = await loadReportData(assessmentId);
+  const locale = request.nextUrl.searchParams.get("locale") ?? "en";
+  const data = await loadReportData(assessmentId, locale);
 
   const headers = [
     "Category Code",

--- a/app/api/export/policy/route.ts
+++ b/app/api/export/policy/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const data = await loadPolicyData(assessmentId, categoryCode);
+  const data = await loadPolicyData(assessmentId, categoryCode, locale);
   const buffer = await renderToBuffer(
     PolicyDocument({ data, locale }),
   );

--- a/app/api/export/report/route.ts
+++ b/app/api/export/report/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: NextRequest) {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const data = await loadReportData(assessmentId);
+  const data = await loadReportData(assessmentId, locale);
   const buffer = await renderToBuffer(
     ComplianceReport({ data, locale }),
   );

--- a/e2e/i18n-sidebar.spec.ts
+++ b/e2e/i18n-sidebar.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * The portal sidebar used to build its category names from the English
+ * message bundle regardless of locale (hardcoded complianceEn import).
+ * These tests pin the fix: German users get German category names,
+ * English users keep English ones.
+ */
+test("German portal sidebar shows German category names", async ({ page }) => {
+  await page.goto("/de/dashboard");
+  await page.getByRole("button", { name: /NIS2/ }).first().click();
+  await expect(
+    page.getByText("Risikomanagement", { exact: false }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+
+  // innerText, not page.content(): the RSC flight payload in script tags
+  // legitimately carries English DB seed names; only visible text counts.
+  const text = await page.locator("body").innerText();
+  expect(text).toContain("Vorfallbehandlung");
+  expect(text).toContain("Lieferkettensicherheit");
+  expect(text).not.toContain("Incident Handling");
+  expect(text).not.toContain("Supply Chain Security");
+
+  await page.screenshot({
+    path: "e2e/.artifacts/de-sidebar.png",
+    fullPage: false,
+  });
+});
+
+test("English portal sidebar keeps English category names", async ({ page }) => {
+  await page.goto("/en/dashboard");
+  await page.getByRole("button", { name: /NIS2/ }).first().click();
+  await expect(
+    page.getByText("Risk Management", { exact: false }).first(),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const text = await page.locator("body").innerText();
+  expect(text).toContain("Incident Handling");
+  expect(text).not.toContain("Vorfallbehandlung");
+
+  await page.screenshot({
+    path: "e2e/.artifacts/en-sidebar.png",
+    fullPage: false,
+  });
+});

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,0 +1,66 @@
+import complianceEn from "@/messages/compliance/en.json";
+import requirementsEn from "@/messages/requirements/en.json";
+import { LOCALES } from "@/lib/locale";
+
+/**
+ * Locale-resolved message bundles for server code that indexes messages by
+ * dynamic keys (category codes, requirement codes) instead of next-intl's
+ * t(). The locale file is deep-merged onto the English bundle so individual
+ * untranslated keys fall back per-key instead of rendering raw key paths.
+ * English is returned for unknown locales and on load failure.
+ *
+ * Server-only by construction: this module statically imports the full
+ * English bundles (~70KB). Do not import it from client components —
+ * LOCALES and other client-safe locale utilities live in lib/locale.ts.
+ */
+export type ComplianceMessages = typeof complianceEn;
+export type RequirementsMessages = typeof requirementsEn;
+
+const LOCALE_CODES = new Set<string>(LOCALES.map((l) => l.code));
+
+function deepMergeMessages<T>(base: T, override: Record<string, unknown>): T {
+  const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(override)) {
+    const baseValue = out[key];
+    const bothObjects =
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      baseValue !== null &&
+      typeof baseValue === "object" &&
+      !Array.isArray(baseValue);
+    out[key] = bothObjects
+      ? deepMergeMessages(
+          baseValue as Record<string, unknown>,
+          value as Record<string, unknown>,
+        )
+      : value;
+  }
+  return out as T;
+}
+
+export async function getComplianceMessages(
+  locale: string,
+): Promise<ComplianceMessages> {
+  if (locale === "en" || !LOCALE_CODES.has(locale)) return complianceEn;
+  try {
+    const override = (await import(`../messages/compliance/${locale}.json`))
+      .default as Record<string, unknown>;
+    return deepMergeMessages(complianceEn, override);
+  } catch {
+    return complianceEn;
+  }
+}
+
+export async function getRequirementsMessages(
+  locale: string,
+): Promise<RequirementsMessages> {
+  if (locale === "en" || !LOCALE_CODES.has(locale)) return requirementsEn;
+  try {
+    const override = (await import(`../messages/requirements/${locale}.json`))
+      .default as Record<string, unknown>;
+    return deepMergeMessages(requirementsEn, override);
+  } catch {
+    return requirementsEn;
+  }
+}

--- a/lib/pdf/load-policy-data.ts
+++ b/lib/pdf/load-policy-data.ts
@@ -18,8 +18,12 @@ import {
   CATEGORY_FIELD_MAPPING,
 } from "@/lib/compliance/category-schemas";
 import { introspectSchema, humanize } from "@/lib/forms/schema-introspect";
-import requirementsEn from "@/messages/requirements/en.json";
-import complianceEn from "@/messages/compliance/en.json";
+import {
+  getComplianceMessages,
+  getRequirementsMessages,
+  type ComplianceMessages,
+  type RequirementsMessages,
+} from "@/lib/messages";
 
 export interface PolicyFieldValue {
   key: string;
@@ -48,7 +52,12 @@ export interface PolicyData {
 export async function loadPolicyData(
   assessmentId: string,
   categoryCode: string,
+  locale = "en",
 ): Promise<PolicyData> {
+  const [compliance, requirementMessages] = await Promise.all([
+    getComplianceMessages(locale),
+    getRequirementsMessages(locale),
+  ]);
   const assessment = await db.query.companyAssessment.findFirst({
     where: eq(companyAssessment.id, assessmentId),
     with: {
@@ -97,13 +106,14 @@ export async function loadPolicyData(
     fieldMapping,
     answers,
     metaByKey,
+    requirementMessages,
   );
 
   return {
     companyName: assessment.company.name,
     categoryCode,
-    categoryName: complianceEn.compliance.categories[categoryCode as keyof typeof complianceEn.compliance.categories]?.name ?? categoryCode,
-    frameworkName: complianceEn.compliance.frameworkName,
+    categoryName: compliance.compliance.categories[categoryCode as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? categoryCode,
+    frameworkName: compliance.compliance.frameworkName,
     signedOffBy: intake?.signedOffByUser?.name ?? null,
     signedOffAt: intake?.signedOffAt ?? null,
     groups,
@@ -115,6 +125,7 @@ function buildFieldGroups(
   fieldMapping: Record<string, string[]>,
   answers: Record<string, unknown>,
   metaByKey: Map<string, { key: string; label: string; type: string }>,
+  requirementMessages: RequirementsMessages,
 ): PolicyRequirementGroup[] {
   // Invert mapping: requirement code → field keys
   const reqFieldKeys = new Map<string, string[]>();
@@ -132,8 +143,8 @@ function buildFieldGroups(
     .map((req) => {
       const keys = reqFieldKeys.get(req.code) ?? [];
       const fields = resolveFields(keys, answers, metaByKey, usedFields);
-      const reqKey = req.code.replace(/\./g, "_") as keyof typeof requirementsEn.requirements;
-      return { code: req.code, title: requirementsEn.requirements[reqKey]?.title ?? req.code, legalRef: req.legalRef, fields };
+      const reqKey = req.code.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
+      return { code: req.code, title: requirementMessages.requirements[reqKey]?.title ?? req.code, legalRef: req.legalRef, fields };
     })
     .filter((g) => g.fields.length > 0);
 

--- a/lib/pdf/load-report-data.ts
+++ b/lib/pdf/load-report-data.ts
@@ -15,10 +15,11 @@ import {
   companyCategoryIntake,
 } from "@/schema";
 import type { SignOffSnapshot } from "@nisd2/isms-schema/tables/assessments";
-import requirementsEn from "@/messages/requirements/en.json";
-import complianceEn from "@/messages/compliance/en.json";
-
-const categoriesEn = complianceEn.compliance.categories;
+import {
+  getComplianceMessages,
+  getRequirementsMessages,
+  type RequirementsMessages,
+} from "@/lib/messages";
 
 export interface ReportEvidence {
   fileName: string;
@@ -67,7 +68,13 @@ export interface ReportData {
 
 export async function loadReportData(
   assessmentId: string,
+  locale = "en",
 ): Promise<ReportData> {
+  const [compliance, requirementMessages] = await Promise.all([
+    getComplianceMessages(locale),
+    getRequirementsMessages(locale),
+  ]);
+  const categoryMessages = compliance.compliance.categories;
   const assessment = await db.query.companyAssessment.findFirst({
     where: eq(companyAssessment.id, assessmentId),
     with: {
@@ -122,8 +129,8 @@ export async function loadReportData(
         completedCount++;
       }
 
-      const reqKey = req.code.replace(/\./g, "_") as keyof typeof requirementsEn.requirements;
-      const reqI18n = requirementsEn.requirements[reqKey];
+      const reqKey = req.code.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
+      const reqI18n = requirementMessages.requirements[reqKey];
       return {
         code: req.code,
         title: reqI18n?.title ?? req.code,
@@ -146,7 +153,7 @@ export async function loadReportData(
       };
     });
 
-    const catI18n = categoriesEn[cat.code as keyof typeof categoriesEn];
+    const catI18n = categoryMessages[cat.code as keyof typeof categoryMessages];
     return {
       code: cat.code,
       name: catI18n?.name ?? cat.code,
@@ -162,7 +169,7 @@ export async function loadReportData(
   return {
     companyName: assessment.company.name,
     companySector: assessment.company.sector,
-    frameworkName: complianceEn.compliance.frameworkName,
+    frameworkName: compliance.compliance.frameworkName,
     assessmentDate: assessment.startedAt,
     totalRequirements: allRequirements.length,
     completedCount,

--- a/messages/compliance/de.json
+++ b/messages/compliance/de.json
@@ -218,143 +218,178 @@
         "bsiGuidance": "Auditoren prüfen, dass Maßnahmen tatsächlich umgesetzt und nicht nur dokumentiert sind. Erwarten Sie technische Nachweise: Konfigurationsscreenshots, Patch-Logs, SIEM-Ausgaben, Backup-Restore-Testergebnisse und Zugriffsüberprüfungsunterlagen."
       },
       "AI-LIT": {
-        "name": "AI Literacy",
-        "description": "Ensure staff and persons operating AI systems on the company's behalf have a sufficient level of AI literacy.",
+        "name": "KI-Kompetenz",
+        "description": "Sicherstellen, dass Mitarbeitende und Personen, die KI-Systeme im Auftrag des Unternehmens betreiben, über ausreichende KI-Kompetenz verfügen.",
         "legalBasis": "Art. 4 EU AI Act",
-        "threatLandscape": "Untrained staff using AI tools cause data leakage, hallucination-driven errors, and deepfake exposure that organisations cannot defend in audit or court.",
+        "threatLandscape": "Ungeschulte Mitarbeitende verursachen mit KI-Tools Datenabfluss, Fehler durch Halluzinationen und Deepfake-Risiken, die sich in Audit oder Gerichtsverfahren nicht verteidigen lassen.",
         "bsiGuidance": ""
       },
       "AI-PRO": {
-        "name": "Prohibited Practices",
-        "description": "Screen AI use cases against the eight (plus one) banned practices in Art. 5 and document the screening outcome.",
+        "name": "Verbotene Praktiken",
+        "description": "KI-Anwendungsfälle gegen die acht (plus eine) verbotenen Praktiken aus Art. 5 prüfen und das Prüfergebnis dokumentieren.",
         "legalBasis": "Art. 5 EU AI Act",
-        "threatLandscape": "Using a prohibited practice triggers the highest penalty tier (EUR 35M or 7% of global turnover) regardless of intent.",
+        "threatLandscape": "Der Einsatz einer verbotenen Praktik löst unabhängig vom Vorsatz die höchste Bußgeldstufe aus (35 Mio. EUR oder 7 % des weltweiten Umsatzes).",
         "bsiGuidance": ""
       },
       "AI-INV": {
-        "name": "AI System Inventory",
-        "description": "Maintain an inventory of every AI system in use, classify each by risk tier, and re-classify on substantial modification.",
+        "name": "KI-Inventar",
+        "description": "Inventar aller eingesetzten KI-Systeme führen, jedes System einer Risikoklasse zuordnen und bei wesentlichen Änderungen neu einstufen.",
         "legalBasis": "Art. 6, 25, 26 EU AI Act",
-        "threatLandscape": "Without an inventory, shadow-AI deployments evade oversight and create unmitigated compliance and liability exposure.",
+        "threatLandscape": "Ohne Inventar entzieht sich Schatten-KI der Aufsicht, und es entstehen unbehandelte Risiken für Compliance und Haftung.",
         "bsiGuidance": ""
       },
       "AI-RSK": {
-        "name": "AI Risk Management",
-        "description": "Operate a documented risk management system for high-risk AI systems, with annual review and treatment of identified risks.",
+        "name": "KI-Risikomanagement",
+        "description": "Dokumentiertes Risikomanagementsystem für Hochrisiko-KI-Systeme betreiben, mit jährlicher Überprüfung und Behandlung der erkannten Risiken.",
         "legalBasis": "Art. 9 EU AI Act",
-        "threatLandscape": "Unmanaged AI risks (bias, drift, robustness failures) translate directly into incident exposure under Art. 73.",
+        "threatLandscape": "Unbehandelte KI-Risiken (Bias, Drift, mangelnde Robustheit) führen direkt zu meldepflichtigen Vorfällen nach Art. 73.",
         "bsiGuidance": ""
       },
       "AI-FRI": {
-        "name": "Fundamental Rights Impact Assessment",
-        "description": "Conduct a Fundamental Rights Impact Assessment before deploying high-risk AI systems in public, financial, or insurance contexts.",
+        "name": "Grundrechte-Folgenabschätzung",
+        "description": "Grundrechte-Folgenabschätzung vor dem Einsatz von Hochrisiko-KI-Systemen im öffentlichen Bereich sowie bei Finanz- und Versicherungsdienstleistungen durchführen.",
         "legalBasis": "Art. 27 EU AI Act",
-        "threatLandscape": "Skipping the FRIA exposes the deployer to civil claims from affected persons and to market-surveillance enforcement.",
+        "threatLandscape": "Ohne Folgenabschätzung drohen dem Betreiber zivilrechtliche Ansprüche betroffener Personen und Maßnahmen der Marktüberwachung.",
         "bsiGuidance": ""
       },
       "AI-OVS": {
-        "name": "Human Oversight",
-        "description": "Designate a competent human overseer per high-risk AI system and verify oversight effectiveness annually.",
+        "name": "Menschliche Aufsicht",
+        "description": "Für jedes Hochrisiko-KI-System eine kompetente aufsichtsführende Person benennen und die Wirksamkeit der Aufsicht jährlich überprüfen.",
         "legalBasis": "Art. 14, Art. 26(2) EU AI Act",
-        "threatLandscape": "Autonomous high-risk AI systems without effective human override breach Art. 14 and create direct provider/deployer liability.",
+        "threatLandscape": "Autonome Hochrisiko-KI-Systeme ohne wirksame menschliche Eingriffsmöglichkeit verstoßen gegen Art. 14 und begründen unmittelbare Haftung von Anbieter und Betreiber.",
         "bsiGuidance": ""
       },
       "AI-TRA": {
-        "name": "Transparency",
-        "description": "Disclose AI interactions and AI-generated content to end users; watermark synthetic content; disclose deepfakes.",
+        "name": "Transparenz",
+        "description": "KI-Interaktionen und KI-generierte Inhalte gegenüber Endnutzern offenlegen, synthetische Inhalte kennzeichnen, Deepfakes offenlegen.",
         "legalBasis": "Art. 50 EU AI Act",
-        "threatLandscape": "Lack of disclosure on chatbots and synthetic content breaches Art. 50 and undermines trust with customers and regulators.",
+        "threatLandscape": "Fehlende Kennzeichnung von Chatbots und synthetischen Inhalten verstößt gegen Art. 50 und untergräbt das Vertrauen von Kunden und Aufsichtsbehörden.",
         "bsiGuidance": ""
       },
       "AI-INC": {
-        "name": "AI Incident Reporting",
-        "description": "Document the AI incident response procedure; notify the market surveillance authority of serious incidents within 15 days.",
+        "name": "KI-Vorfallsmeldung",
+        "description": "Verfahren zur Reaktion auf KI-Vorfälle dokumentieren; schwerwiegende Vorfälle innerhalb von 15 Tagen an die Marktüberwachungsbehörde melden.",
         "legalBasis": "Art. 73 EU AI Act",
-        "threatLandscape": "Failure to notify within the 15-day window triggers the second penalty tier (EUR 15M or 3% of turnover).",
+        "threatLandscape": "Wird die 15-Tage-Frist versäumt, greift die zweite Bußgeldstufe (15 Mio. EUR oder 3 % des Umsatzes).",
         "bsiGuidance": ""
       },
       "AI-DOC": {
-        "name": "Technical Documentation",
-        "description": "Maintain Annex IV technical documentation, automatic logging, and the EU Declaration of Conformity for high-risk AI systems.",
+        "name": "Technische Dokumentation",
+        "description": "Technische Dokumentation nach Anhang IV, automatische Protokollierung und EU-Konformitätserklärung für Hochrisiko-KI-Systeme pflegen.",
         "legalBasis": "Art. 11, 12, 18, 19, 47 · Annex IV, V EU AI Act",
-        "threatLandscape": "Incomplete technical documentation prevents conformity assessment and blocks placing on the EU market.",
+        "threatLandscape": "Unvollständige technische Dokumentation verhindert die Konformitätsbewertung und blockiert das Inverkehrbringen auf dem EU-Markt.",
         "bsiGuidance": ""
       },
       "AI-GPI": {
-        "name": "General-Purpose AI",
-        "description": "GPAI provider obligations: model card, copyright policy, training-content summary, plus systemic-risk evaluation when training compute exceeds 10^25 FLOPs.",
+        "name": "GPAI-Modelle",
+        "description": "Pflichten für GPAI-Anbieter: Modellkarte, Urheberrechtsrichtlinie, Zusammenfassung der Trainingsinhalte sowie Bewertung systemischer Risiken ab einem Trainingsaufwand von 10^25 FLOPs.",
         "legalBasis": "Art. 51-55 EU AI Act",
-        "threatLandscape": "GPAI providers that miss transparency obligations face EU AI Office enforcement directly, with fines under Art. 101.",
+        "threatLandscape": "GPAI-Anbieter, die Transparenzpflichten versäumen, unterliegen direkt der Durchsetzung durch das EU AI Office, mit Bußgeldern nach Art. 101.",
         "bsiGuidance": ""
       },
       "CRA-MFG": {
-        "name": "Manufacturer Obligations",
-        "description": "Per-product cybersecurity risk assessment and management body sign-off before placing the product on the EU market.",
+        "name": "Herstellerpflichten",
+        "description": "Cyberrisikobewertung je Produkt und Freigabe durch die Geschäftsleitung vor dem Inverkehrbringen auf dem EU-Markt.",
         "legalBasis": "Art. 13 EU CRA",
-        "threatLandscape": "Manufacturers that ship without a documented risk assessment have no defence when actively exploited vulnerabilities surface.",
+        "threatLandscape": "Hersteller, die ohne dokumentierte Risikobewertung ausliefern, stehen ohne Verteidigung da, wenn aktiv ausgenutzte Schwachstellen auftauchen.",
         "bsiGuidance": ""
       },
       "CRA-ESS": {
-        "name": "Essential Cybersecurity Requirements",
-        "description": "Compliance with Annex I Part I: no known exploitable vulnerabilities at placing on market, secure by default, protection of data confidentiality, integrity, availability.",
+        "name": "Grundlegende Cybersicherheitsanforderungen",
+        "description": "Einhaltung von Anhang I Teil I: keine bekannten ausnutzbaren Schwachstellen beim Inverkehrbringen, sichere Voreinstellungen, Schutz von Vertraulichkeit, Integrität und Verfügbarkeit der Daten.",
         "legalBasis": "Annex I Part I EU CRA",
-        "threatLandscape": "Products that fail essential requirements cannot legally remain on the EU market and trigger the highest penalty tier.",
+        "threatLandscape": "Produkte, die die grundlegenden Anforderungen verfehlen, dürfen nicht auf dem EU-Markt bleiben und lösen die höchste Bußgeldstufe aus.",
         "bsiGuidance": ""
       },
       "CRA-VLN": {
-        "name": "Vulnerability Handling",
-        "description": "Documented vulnerability handling, coordinated disclosure policy, security updates without delay, and public disclosure of fixed vulnerabilities.",
+        "name": "Schwachstellenmanagement",
+        "description": "Dokumentierte Schwachstellenbehandlung, koordinierte Offenlegung, Sicherheitsupdates ohne Verzögerung und öffentliche Bekanntgabe behobener Schwachstellen.",
         "legalBasis": "Annex I Part II EU CRA",
-        "threatLandscape": "Vendors without a vulnerability handling process cannot meet the 24h / 72h / 14-day reporting cascade and become liable for downstream incidents.",
+        "threatLandscape": "Anbieter ohne Schwachstellenprozess können die Meldekaskade von 24 Stunden, 72 Stunden und 14 Tagen nicht einhalten und haften für Folgevorfälle.",
         "bsiGuidance": ""
       },
       "CRA-INC": {
-        "name": "Active Exploitation Reporting",
-        "description": "24-hour early warning to ENISA and CSIRT, 72-hour notification, 14-day final report for actively exploited vulnerabilities and severe incidents.",
+        "name": "Meldung aktiver Ausnutzung",
+        "description": "Frühwarnung an ENISA und CSIRT innerhalb von 24 Stunden, Meldung innerhalb von 72 Stunden, Abschlussbericht nach 14 Tagen bei aktiv ausgenutzten Schwachstellen und schwerwiegenden Vorfällen.",
         "legalBasis": "Art. 14 EU CRA",
-        "threatLandscape": "Missed reporting deadlines (other than the 24h deadline for SMEs) trigger the highest penalty tier and product-recall powers.",
+        "threatLandscape": "Versäumte Meldefristen (außer der 24-Stunden-Frist für KMU) lösen die höchste Bußgeldstufe und Rückrufbefugnisse aus.",
         "bsiGuidance": ""
       },
       "CRA-CONF": {
-        "name": "Conformity Assessment",
-        "description": "Conformity assessment route per product class (self-assessment Module A, Module B+C with notified body, or Module H quality system) followed by CE marking.",
+        "name": "Konformitätsbewertung",
+        "description": "Konformitätsbewertungsverfahren je Produktklasse (Selbstbewertung Modul A, Modul B+C mit benannter Stelle oder Qualitätssystem Modul H), anschließend CE-Kennzeichnung.",
         "legalBasis": "Art. 24, Art. 27 EU CRA",
-        "threatLandscape": "Products without valid conformity assessment cannot be placed on the EU market from 11 December 2027.",
+        "threatLandscape": "Produkte ohne gültige Konformitätsbewertung dürfen ab dem 11. Dezember 2027 nicht mehr auf dem EU-Markt bereitgestellt werden.",
         "bsiGuidance": ""
       },
       "CRA-DOC": {
-        "name": "Technical Documentation",
-        "description": "Maintain Annex VII technical documentation for each product placed on the EU market.",
+        "name": "Technische Dokumentation",
+        "description": "Technische Dokumentation nach Anhang VII für jedes auf dem EU-Markt bereitgestellte Produkt pflegen.",
         "legalBasis": "Art. 28 · Annex VII EU CRA",
-        "threatLandscape": "Missing or incomplete technical documentation blocks market surveillance verification and triggers product withdrawal.",
+        "threatLandscape": "Fehlende oder unvollständige technische Dokumentation blockiert die Überprüfung durch die Marktüberwachung und führt zur Marktrücknahme.",
         "bsiGuidance": ""
       },
       "CRA-SUP": {
-        "name": "Support Period",
-        "description": "Publicly commit to a security update support period (default five years or expected product life, whichever is longer).",
+        "name": "Supportzeitraum",
+        "description": "Öffentliche Zusage eines Zeitraums für Sicherheitsupdates (standardmäßig fünf Jahre oder die erwartete Produktlebensdauer, je nachdem, was länger ist).",
         "legalBasis": "Art. 13(8) EU CRA",
-        "threatLandscape": "Failure to support the full period exposes the manufacturer to claims from customers stranded on insecure products.",
+        "threatLandscape": "Wer den vollen Zeitraum nicht abdeckt, riskiert Ansprüche von Kunden, die auf unsicheren Produkten sitzen bleiben.",
         "bsiGuidance": ""
       },
       "CRA-SBOM": {
         "name": "Software Bill of Materials",
-        "description": "Generate and maintain a machine-readable Software Bill of Materials for each product placed on the EU market.",
+        "description": "Maschinenlesbare Software-Stückliste (SBOM) für jedes auf dem EU-Markt bereitgestellte Produkt erstellen und pflegen.",
         "legalBasis": "Annex I Part II §1 EU CRA",
-        "threatLandscape": "Without an SBOM, manufacturers cannot trace which products contain a vulnerable component and miss the Art. 14 reporting window.",
+        "threatLandscape": "Ohne SBOM können Hersteller nicht nachvollziehen, welche Produkte eine verwundbare Komponente enthalten, und verpassen das Meldefenster nach Art. 14.",
         "bsiGuidance": ""
       },
       "CRA-IMP": {
-        "name": "Importer and Distributor",
-        "description": "Importers verify manufacturer compliance before placing on market; distributors perform due diligence on conformity markings.",
+        "name": "Einführer und Händler",
+        "description": "Einführer prüfen die Konformität des Herstellers vor dem Inverkehrbringen; Händler prüfen Konformitätskennzeichnungen mit gebotener Sorgfalt.",
         "legalBasis": "Art. 18, Art. 19 EU CRA",
-        "threatLandscape": "Importers and distributors that miss verification inherit manufacturer liability under Art. 22.",
+        "threatLandscape": "Einführer und Händler, die diese Prüfung versäumen, übernehmen nach Art. 22 die Herstellerhaftung.",
         "bsiGuidance": ""
       },
       "CRA-OSS": {
-        "name": "Open-Source Steward",
-        "description": "Open-source software stewards adopt a cybersecurity policy, coordinated vulnerability disclosure, and report actively exploited vulnerabilities.",
+        "name": "Open-Source-Steward",
+        "description": "Verwalter quelloffener Software führen eine Cybersicherheitsrichtlinie und koordinierte Schwachstellenoffenlegung ein und melden aktiv ausgenutzte Schwachstellen.",
         "legalBasis": "Art. 24 EU CRA",
-        "threatLandscape": "OSS stewards are penalty-exempt under Art. 64(10), but downstream commercial users still depend on their reporting.",
+        "threatLandscape": "OSS-Verwalter sind nach Art. 64(10) von Bußgeldern ausgenommen; nachgelagerte kommerzielle Nutzer sind dennoch auf ihre Meldungen angewiesen.",
+        "bsiGuidance": ""
+      },
+      "DPA": {
+        "name": "Auftragsverarbeitung",
+        "description": "Auftragsverarbeitungsverträge nach Art. 28 DSGVO mit allen Auftragsverarbeitern, die personenbezogene Daten verarbeiten",
+        "legalBasis": "Art. 28 DSGVO",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "ROP": {
+        "name": "Verarbeitungsverzeichnis",
+        "description": "Dokumentation aller Verarbeitungstätigkeiten nach Art. 30 DSGVO: Zweck, Rechtsgrundlage, Empfänger, Speicherdauer",
+        "legalBasis": "Art. 30 DSGVO",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "TOM": {
+        "name": "Technische und organisatorische Maßnahmen",
+        "description": "Sicherheitsmaßnahmen zum Schutz personenbezogener Daten nach Art. 32 DSGVO",
+        "legalBasis": "Art. 32 DSGVO",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "BRC": {
+        "name": "Datenpannen",
+        "description": "Meldeprozess innerhalb von 72 Stunden und Dokumentation von Datenschutzverletzungen nach Art. 33/34 DSGVO",
+        "legalBasis": "Art. 33, Art. 34 DSGVO",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "DSR": {
+        "name": "Betroffenenrechte",
+        "description": "Bearbeitung von Anfragen zu Auskunft, Löschung, Datenübertragbarkeit und Widerspruch innerhalb eines Monats",
+        "legalBasis": "Art. 12-22 DSGVO",
+        "threatLandscape": "",
         "bsiGuidance": ""
       }
     }


### PR DESCRIPTION
German users saw English on the portal sidebar, team page, review page, export page, and in generated PDFs/CSVs: those surfaces built category and requirement names from a hardcoded import of `messages/*/en.json`. Reported by our DRK user.

- New `lib/messages.ts`: loads the locale's compliance/requirements bundle and deep-merges it onto English, so untranslated keys fall back per-key instead of rendering raw key paths. Kept separate from `lib/locale.ts`, which client components import (the English bundles are ~70KB and must not enter the client bundle).
- Portal layout, team, review, export pages resolve via `getLocale()`; the export API routes pass their existing `locale` query param through to `loadReportData`/`loadPolicyData`.
- Fills the German compliance namespace: the five GDPR categories were missing entirely (rendered raw key paths like `compliance.categories.DPA.name`), and all EU AI Act + CRA category strings were untranslated English.
- E2e spec pins the fix (German sidebar German, English sidebar English); verified in a local browser run against the seeded stack.

Out of scope, needs a follow-up: cron/email senders (deadlines, escalation, digest) still send English requirement titles because no user locale is stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgqgsrHnYuqTd1fbd2m8zM