### PR TITLE
fix(i18n): apply code-review findings from the locale-resolution fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ scripts/i18n/_info-chunks/
 e2e/.auth/
 test-results/
 playwright-report/
-e2e/.artifacts/

--- a/app/[locale]/(portal)/export/page.tsx
+++ b/app/[locale]/(portal)/export/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations, getLocale } from "next-intl/server";
 import { api } from "@/lib/trpc/server";
 import { getComplianceMessages } from "@/lib/messages";
+import { formatAbsolute } from "@/lib/format";
 import { FileDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -50,9 +51,7 @@ export default async function ExportPage() {
                       </CardTitle>
                       <CardDescription>
                         {t("started")}{" "}
-                        {new Date(assessment.startedAt).toLocaleDateString(
-                          locale === "de" ? "de-DE" : "en-US",
-                        )}
+                        {formatAbsolute(assessment.startedAt, locale)}
                       </CardDescription>
                     </div>
                     <Badge variant="outline" className="font-mono text-xs">

--- a/app/[locale]/(portal)/journey/page.tsx
+++ b/app/[locale]/(portal)/journey/page.tsx
@@ -39,7 +39,7 @@ export default async function JourneyPage({
   const focusCategory = focusRaw ? focusRaw.toUpperCase() : null;
 
   const { items, aggregate } = await api.journey.getItems({
-    locale: locale === "de" ? "de" : "en",
+    locale: rawLocale,
   });
 
   // A draft company (auto-provisioned at verification) renders the full seeded

--- a/app/[locale]/(portal)/layout.tsx
+++ b/app/[locale]/(portal)/layout.tsx
@@ -18,6 +18,7 @@ import {
 import { getLocale } from "next-intl/server";
 import {
   getComplianceMessages,
+  getCategoryName,
   type ComplianceMessages,
 } from "@/lib/messages";
 
@@ -47,7 +48,7 @@ function buildSteps(
       return {
         slug: cat.slug,
         code: cat.code,
-        name: compliance.compliance.categories[cat.code as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? cat.code,
+        name: getCategoryName(compliance, cat.code),
         phase: phaseForSortOrder(cat.sortOrder),
         requirementCount: reqCount,
         completedCount: Math.min(progress[cat.id]?.completed ?? 0, reqCount),
@@ -67,11 +68,11 @@ export default async function PortalLayout({
   // Always load framework structure so the sidebar shows NIS2 / GDPR groups
   // even before the user has set up their company. Pre-onboarding the
   // category links work as a preview — clicking lands on the onboarding banner.
-  const allFrameworks = await getAllActiveCategories();
-  const compliance = await getComplianceMessages(await getLocale());
-  const assessments = session.companyId
-    ? await api.assessment.listAssessments()
-    : [];
+  const [allFrameworks, compliance, assessments] = await Promise.all([
+    getAllActiveCategories(),
+    getLocale().then(getComplianceMessages),
+    session.companyId ? api.assessment.listAssessments() : [],
+  ]);
 
   const frameworks: FrameworkGroup[] = await Promise.all(
     [...allFrameworks.entries()].map(([code, { framework, categories }]) => {

--- a/app/[locale]/(portal)/review/page.tsx
+++ b/app/[locale]/(portal)/review/page.tsx
@@ -10,8 +10,8 @@ import {
 import {
   getComplianceMessages,
   getRequirementsMessages,
-  type ComplianceMessages,
-  type RequirementsMessages,
+  getCategoryName,
+  getRequirementTitle,
 } from "@/lib/messages";
 
 export default async function ReviewPage() {
@@ -21,22 +21,21 @@ export default async function ReviewPage() {
     redirect("/dashboard");
   }
 
-  const t = await getTranslations("review");
-  const locale = await getLocale();
-  const [compliance, requirements] = await Promise.all([
-    getComplianceMessages(locale),
-    getRequirementsMessages(locale),
+  const [t, [compliance, requirements], rawRows] = await Promise.all([
+    getTranslations("review"),
+    getLocale().then((locale) =>
+      Promise.all([
+        getComplianceMessages(locale),
+        getRequirementsMessages(locale),
+      ]),
+    ),
+    api.review.list(),
   ]);
-  const rawRows = await api.review.list();
-  const rows = rawRows.map((r) => {
-    const reqKey = r.requirementCode.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
-    const catKey = r.categoryCode as keyof ComplianceMessages["compliance"]["categories"];
-    return {
-      ...r,
-      requirementTitle: requirements.requirements[reqKey]?.title ?? r.requirementCode,
-      categoryName: compliance.compliance.categories[catKey]?.name ?? r.categoryCode,
-    };
-  }) as ReviewRow[];
+  const rows = rawRows.map((r) => ({
+    ...r,
+    requirementTitle: getRequirementTitle(requirements, r.requirementCode),
+    categoryName: getCategoryName(compliance, r.categoryCode),
+  })) as ReviewRow[];
 
   const pendingCount = rows.filter((r) => r.status === "completed").length;
   const approvedCount = rows.filter((r) => r.status === "approved").length;

--- a/app/[locale]/(portal)/team/page.tsx
+++ b/app/[locale]/(portal)/team/page.tsx
@@ -5,27 +5,26 @@ import { TeamPage } from "@/components/team/TeamPage";
 import { Users } from "lucide-react";
 import { redirect } from "next/navigation";
 import { PageHeader } from "@/components/shared/PageHeader";
-import {
-  getComplianceMessages,
-  type ComplianceMessages,
-} from "@/lib/messages";
+import { getComplianceMessages, getCategoryName } from "@/lib/messages";
 
 export default async function TeamManagementPage() {
   const session = await getSession();
   if (!session?.companyId) redirect("/dashboard");
 
-  const t = await getTranslations("team");
-  const compliance = await getComplianceMessages(await getLocale());
   const isAdmin = session.role === "admin";
-  const rawMembers = await api.team.listMembers();
+  const [t, compliance, rawMembers, invites] = await Promise.all([
+    getTranslations("team"),
+    getLocale().then(getComplianceMessages),
+    api.team.listMembers(),
+    isAdmin ? api.team.listInvites() : [],
+  ]);
   const members = rawMembers.map((m) => ({
     ...m,
     assignments: m.assignments.map((a) => ({
       ...a,
-      categoryName: compliance.compliance.categories[a.categoryCode as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? a.categoryCode,
+      categoryName: getCategoryName(compliance, a.categoryCode),
     })),
   }));
-  const invites = isAdmin ? await api.team.listInvites() : [];
 
   return (
     <div className="mx-auto max-w-4xl">

--- a/app/api/export/policy/route.ts
+++ b/app/api/export/policy/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { companyAssessment } from "@/schema";
 import { eq } from "drizzle-orm";
 import { loadPolicyData } from "@/lib/pdf/load-policy-data";
+import { pdfLocale } from "@/lib/pdf/format";
 import { PolicyDocument } from "@/lib/pdf/policy-document";
 import { rateLimit } from "@/lib/rate-limit";
 
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
 
   const assessmentId = request.nextUrl.searchParams.get("assessmentId");
   const categoryCode = request.nextUrl.searchParams.get("categoryCode");
-  const locale = request.nextUrl.searchParams.get("locale") ?? "en";
+  const locale = pdfLocale(request.nextUrl.searchParams.get("locale"));
 
   if (!assessmentId || !categoryCode) {
     return new Response("Missing assessmentId or categoryCode", { status: 400 });

--- a/app/api/export/report/route.ts
+++ b/app/api/export/report/route.ts
@@ -5,6 +5,7 @@ import { db } from "@/lib/db";
 import { companyAssessment } from "@/schema";
 import { eq } from "drizzle-orm";
 import { loadReportData } from "@/lib/pdf/load-report-data";
+import { pdfLocale } from "@/lib/pdf/format";
 import { ComplianceReport } from "@/lib/pdf/compliance-report";
 import { rateLimit } from "@/lib/rate-limit";
 
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
   }
 
   const assessmentId = request.nextUrl.searchParams.get("assessmentId");
-  const locale = request.nextUrl.searchParams.get("locale") ?? "en";
+  const locale = pdfLocale(request.nextUrl.searchParams.get("locale"));
 
   if (!assessmentId) {
     return new Response("Missing assessmentId", { status: 400 });

--- a/components/audit-readiness/AuditReadinessPage.tsx
+++ b/components/audit-readiness/AuditReadinessPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Loader2, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc/client";
@@ -11,6 +11,7 @@ import type { AssessmentEvaluation } from "@/lib/eval/eval-schema";
 
 export function AuditReadinessPage() {
   const t = useTranslations("audit-readiness");
+  const locale = useLocale();
   const [result, setResult] = useState<AssessmentEvaluation | null>(null);
   const [isPending, startTransition] = useTransition();
   const [reEvaluatingCode, setReEvaluatingCode] = useState<string | null>(null);
@@ -20,14 +21,14 @@ export function AuditReadinessPage() {
 
   function handleStartEvaluation() {
     startTransition(async () => {
-      const data = await evaluateAll.mutateAsync();
+      const data = await evaluateAll.mutateAsync({ locale });
       setResult(data);
     });
   }
 
   function handleReEvaluate(categoryCode: string) {
     setReEvaluatingCode(categoryCode);
-    evaluateSection.mutateAsync({ categoryCode }).then((updated) => {
+    evaluateSection.mutateAsync({ categoryCode, locale }).then((updated) => {
       setResult((prev) => {
         if (!prev) return prev;
         const sections = prev.sections.map((s) =>

--- a/e2e/i18n-sidebar.spec.ts
+++ b/e2e/i18n-sidebar.spec.ts
@@ -5,41 +5,41 @@ import { test, expect } from "@playwright/test";
  * message bundle regardless of locale (hardcoded complianceEn import).
  * These tests pin the fix: German users get German category names,
  * English users keep English ones.
+ *
+ * Assertions are scoped to the sidebar element (not the whole body) so
+ * a future widget that legitimately renders English DB seed names in the
+ * page content cannot fail the negative checks. networkidle after goto
+ * ensures hydration before clicking the Radix collapsible trigger (a
+ * pre-hydration click is silently lost).
  */
+const SIDEBAR = '[data-slot="sidebar"]';
+
 test("German portal sidebar shows German category names", async ({ page }) => {
-  await page.goto("/de/dashboard");
+  await page.goto("/de/dashboard", { waitUntil: "networkidle" });
   await page.getByRole("button", { name: /NIS2/ }).first().click();
+
+  const sidebar = page.locator(SIDEBAR).first();
   await expect(
-    page.getByText("Risikomanagement", { exact: false }).first(),
+    sidebar.getByText("Risikomanagement", { exact: false }).first(),
   ).toBeVisible({ timeout: 30_000 });
 
-  // innerText, not page.content(): the RSC flight payload in script tags
-  // legitimately carries English DB seed names; only visible text counts.
-  const text = await page.locator("body").innerText();
+  const text = await sidebar.innerText();
   expect(text).toContain("Vorfallbehandlung");
   expect(text).toContain("Lieferkettensicherheit");
   expect(text).not.toContain("Incident Handling");
   expect(text).not.toContain("Supply Chain Security");
-
-  await page.screenshot({
-    path: "e2e/.artifacts/de-sidebar.png",
-    fullPage: false,
-  });
 });
 
 test("English portal sidebar keeps English category names", async ({ page }) => {
-  await page.goto("/en/dashboard");
+  await page.goto("/en/dashboard", { waitUntil: "networkidle" });
   await page.getByRole("button", { name: /NIS2/ }).first().click();
+
+  const sidebar = page.locator(SIDEBAR).first();
   await expect(
-    page.getByText("Risk Management", { exact: false }).first(),
+    sidebar.getByText("Risk Management", { exact: false }).first(),
   ).toBeVisible({ timeout: 30_000 });
 
-  const text = await page.locator("body").innerText();
+  const text = await sidebar.innerText();
   expect(text).toContain("Incident Handling");
   expect(text).not.toContain("Vorfallbehandlung");
-
-  await page.screenshot({
-    path: "e2e/.artifacts/en-sidebar.png",
-    fullPage: false,
-  });
 });

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,13 +1,14 @@
 import complianceEn from "@/messages/compliance/en.json";
 import requirementsEn from "@/messages/requirements/en.json";
-import { LOCALES } from "@/lib/locale";
+import { routing } from "@/i18n/routing";
 
 /**
  * Locale-resolved message bundles for server code that indexes messages by
  * dynamic keys (category codes, requirement codes) instead of next-intl's
  * t(). The locale file is deep-merged onto the English bundle so individual
  * untranslated keys fall back per-key instead of rendering raw key paths.
- * English is returned for unknown locales and on load failure.
+ * English is returned for unknown locales; load failures log once per
+ * locale per process and serve English.
  *
  * Server-only by construction: this module statically imports the full
  * English bundles (~70KB). Do not import it from client components —
@@ -16,11 +17,23 @@ import { LOCALES } from "@/lib/locale";
 export type ComplianceMessages = typeof complianceEn;
 export type RequirementsMessages = typeof requirementsEn;
 
-const LOCALE_CODES = new Set<string>(LOCALES.map((l) => l.code));
+type CategoryCode = keyof ComplianceMessages["compliance"]["categories"];
+type RequirementKey = keyof RequirementsMessages["requirements"];
+
+const LOCALE_CODES = new Set<string>(routing.locales);
+
+/** "de-DE", "DE", " de " → "de"; empty or unsupported → "en". */
+function normalizeLocale(locale: string): string {
+  const base = locale.trim().toLowerCase().split("-")[0] ?? "";
+  return LOCALE_CODES.has(base) ? base : "en";
+}
 
 function deepMergeMessages<T>(base: T, override: Record<string, unknown>): T {
   const out: Record<string, unknown> = { ...(base as Record<string, unknown>) };
   for (const [key, value] of Object.entries(override)) {
+    // "" is the untranslated-field sentinel in the bundles; an empty
+    // override must not mask a later-filled English value.
+    if (value === "") continue;
     const baseValue = out[key];
     const bothObjects =
       value !== null &&
@@ -39,28 +52,80 @@ function deepMergeMessages<T>(base: T, override: Record<string, unknown>): T {
   return out as T;
 }
 
-export async function getComplianceMessages(
+function loadMerged<T>(
+  ns: "compliance" | "requirements",
   locale: string,
-): Promise<ComplianceMessages> {
-  if (locale === "en" || !LOCALE_CODES.has(locale)) return complianceEn;
-  try {
-    const override = (await import(`../messages/compliance/${locale}.json`))
-      .default as Record<string, unknown>;
-    return deepMergeMessages(complianceEn, override);
-  } catch {
-    return complianceEn;
-  }
+  en: T,
+): Promise<T> {
+  const mod =
+    ns === "compliance"
+      ? import(`../messages/compliance/${locale}.json`)
+      : import(`../messages/requirements/${locale}.json`);
+  return mod.then(
+    (m) => deepMergeMessages(en, m.default as Record<string, unknown>),
+    (err) => {
+      console.error(
+        `[messages] failed to load ${ns}/${locale}.json, serving English:`,
+        err,
+      );
+      return en;
+    },
+  );
 }
 
-export async function getRequirementsMessages(
+const complianceCache = new Map<string, Promise<ComplianceMessages>>();
+const requirementsCache = new Map<string, Promise<RequirementsMessages>>();
+
+export function getComplianceMessages(
+  locale: string,
+): Promise<ComplianceMessages> {
+  const loc = normalizeLocale(locale);
+  if (loc === "en") return Promise.resolve(complianceEn);
+  const cached = complianceCache.get(loc);
+  if (cached) return cached;
+  const loading = loadMerged("compliance", loc, complianceEn);
+  complianceCache.set(loc, loading);
+  return loading;
+}
+
+export function getRequirementsMessages(
   locale: string,
 ): Promise<RequirementsMessages> {
-  if (locale === "en" || !LOCALE_CODES.has(locale)) return requirementsEn;
-  try {
-    const override = (await import(`../messages/requirements/${locale}.json`))
-      .default as Record<string, unknown>;
-    return deepMergeMessages(requirementsEn, override);
-  } catch {
-    return requirementsEn;
-  }
+  const loc = normalizeLocale(locale);
+  if (loc === "en") return Promise.resolve(requirementsEn);
+  const cached = requirementsCache.get(loc);
+  if (cached) return cached;
+  const loading = loadMerged("requirements", loc, requirementsEn);
+  requirementsCache.set(loc, loading);
+  return loading;
+}
+
+export function getCategory(
+  messages: ComplianceMessages,
+  code: string,
+): ComplianceMessages["compliance"]["categories"][CategoryCode] | undefined {
+  return messages.compliance.categories[code as CategoryCode];
+}
+
+export function getCategoryName(
+  messages: ComplianceMessages,
+  code: string,
+): string {
+  return getCategory(messages, code)?.name ?? code;
+}
+
+export function getRequirementTitle(
+  messages: RequirementsMessages,
+  code: string,
+): string {
+  const key = code.replace(/\./g, "_") as RequirementKey;
+  return messages.requirements[key]?.title ?? code;
+}
+
+export function getRequirementDescription(
+  messages: RequirementsMessages,
+  code: string,
+): string | null {
+  const key = code.replace(/\./g, "_") as RequirementKey;
+  return messages.requirements[key]?.description ?? null;
 }

--- a/lib/pdf/compliance-report.tsx
+++ b/lib/pdf/compliance-report.tsx
@@ -7,6 +7,11 @@ import {
 } from "@react-pdf/renderer";
 import { styles } from "./styles";
 import { formatFieldValue, getDateLocale } from "./format";
+import {
+  getDocumentLabels,
+  getReportLabels,
+  getStatusLabel,
+} from "./policy-labels";
 import { humanize } from "@/lib/forms/schema-introspect";
 import type { ReportData, ReportRequirement } from "./load-report-data";
 
@@ -15,7 +20,7 @@ interface ComplianceReportProps {
   locale: string;
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status, locale }: { status: string; locale: string }) {
   const variantStyle =
     status === "approved"
       ? styles.statusApproved
@@ -27,7 +32,7 @@ function StatusBadge({ status }: { status: string }) {
 
   return (
     <Text style={[styles.statusBadge, variantStyle]}>
-      {status.replace("_", " ")}
+      {getStatusLabel(status, locale)}
     </Text>
   );
 }
@@ -40,25 +45,26 @@ function RequirementSection({
   locale: string;
 }) {
   const dateLocale = getDateLocale(locale);
+  const labels = getReportLabels(locale);
 
   return (
     <View style={styles.requirementBlock} wrap={false}>
       <View style={styles.requirementHeader}>
         <Text style={styles.requirementCode}>{req.code}</Text>
         <Text style={styles.requirementTitle}>{req.title}</Text>
-        <StatusBadge status={req.status} />
+        <StatusBadge status={req.status} locale={locale} />
       </View>
 
       {/* Sign-off data */}
       {req.signedOffRole && (
         <View>
           <View style={styles.fieldRow}>
-            <Text style={styles.fieldLabel}>Signed off by</Text>
+            <Text style={styles.fieldLabel}>{labels.signedOffBy}</Text>
             <Text style={styles.fieldValue}>{req.signedOffRole}</Text>
           </View>
           {req.signedOffAt && (
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Signed off at</Text>
+              <Text style={styles.fieldLabel}>{labels.signedOffAt}</Text>
               <Text style={styles.fieldValue}>
                 {new Date(req.signedOffAt).toLocaleDateString(dateLocale)}
               </Text>
@@ -66,13 +72,13 @@ function RequirementSection({
           )}
           {req.signOffSnapshot?.templateVersion && (
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Template version</Text>
+              <Text style={styles.fieldLabel}>{labels.templateVersion}</Text>
               <Text style={styles.fieldValue}>v{req.signOffSnapshot.templateVersion}</Text>
             </View>
           )}
           {req.signOffSnapshot?.derivedData && Object.keys(req.signOffSnapshot.derivedData).length > 0 && (
             <View style={styles.fieldRow}>
-              <Text style={styles.fieldLabel}>Operational data</Text>
+              <Text style={styles.fieldLabel}>{labels.operationalData}</Text>
               <Text style={styles.fieldValue}>
                 {Object.entries(req.signOffSnapshot.derivedData)
                   .map(([key, val]) => {
@@ -89,7 +95,7 @@ function RequirementSection({
       {/* Evidence files */}
       {req.evidence.length > 0 && (
         <View>
-          <Text style={styles.sectionLabel}>Evidence Files</Text>
+          <Text style={styles.sectionLabel}>{labels.evidenceFiles}</Text>
           {req.evidence.map((e, i) => (
             <Text key={i} style={styles.evidenceItem}>
               {e.fileName}
@@ -104,7 +110,7 @@ function RequirementSection({
       {/* Review feedback */}
       {req.reviewFeedback && (
         <View style={styles.feedbackBlock}>
-          <Text style={styles.feedbackLabel}>Reviewer Feedback</Text>
+          <Text style={styles.feedbackLabel}>{labels.reviewerFeedback}</Text>
           <Text style={styles.feedbackText}>{req.reviewFeedback}</Text>
         </View>
       )}
@@ -119,33 +125,31 @@ export function ComplianceReport({ data, locale }: ComplianceReportProps) {
       : "0";
 
   const unapprovedCount = data.completedCount - data.approvedCount;
+  const labels = getReportLabels(locale);
 
   return (
     <Document>
       {/* Cover Page */}
       <Page size="A4" style={[styles.page, styles.coverPage]}>
-        <Text style={styles.coverTitle}>Compliance Report</Text>
+        <Text style={styles.coverTitle}>{labels.title}</Text>
         <Text style={styles.coverSubtitle}>{data.frameworkName}</Text>
         <Text style={styles.coverMeta}>{data.companyName}</Text>
         {data.companySector && (
-          <Text style={styles.coverMeta}>Sector: {data.companySector}</Text>
+          <Text style={styles.coverMeta}>{labels.sector}: {data.companySector}</Text>
         )}
         <Text style={styles.coverMeta}>
-          Generated: {new Date().toLocaleDateString(getDateLocale(locale))}
+          {labels.generated}: {new Date().toLocaleDateString(getDateLocale(locale))}
         </Text>
         <Text style={styles.coverMeta}>
-          Assessment started:{" "}
+          {labels.assessmentStarted}:{" "}
           {data.assessmentDate.toLocaleDateString(getDateLocale(locale))}
         </Text>
 
         {unapprovedCount > 0 && (
           <View style={styles.draftBanner}>
-            <Text style={styles.draftTitle}>
-              DRAFT — Contains unapproved submissions
-            </Text>
+            <Text style={styles.draftTitle}>{labels.draftTitle}</Text>
             <Text style={styles.draftText}>
-              {unapprovedCount} of {data.completedCount} completed items are
-              pending reviewer approval.
+              {labels.draftText(unapprovedCount, data.completedCount)}
             </Text>
           </View>
         )}
@@ -153,31 +157,31 @@ export function ComplianceReport({ data, locale }: ComplianceReportProps) {
         <View style={[styles.statsRow, { marginTop: unapprovedCount > 0 ? 12 : 40 }]}>
           <View style={styles.statBox}>
             <Text style={styles.statValue}>{percentage}%</Text>
-            <Text style={styles.statLabel}>Compliance</Text>
+            <Text style={styles.statLabel}>{labels.statCompliance}</Text>
           </View>
           <View style={styles.statBox}>
             <Text style={styles.statValue}>{data.completedCount}</Text>
-            <Text style={styles.statLabel}>Completed</Text>
+            <Text style={styles.statLabel}>{labels.statCompleted}</Text>
           </View>
           <View style={styles.statBox}>
             <Text style={styles.statValue}>{data.approvedCount}</Text>
-            <Text style={styles.statLabel}>Approved</Text>
+            <Text style={styles.statLabel}>{labels.statApproved}</Text>
           </View>
           {unapprovedCount > 0 && (
             <View style={styles.statBox}>
               <Text style={styles.statValue}>{unapprovedCount}</Text>
-              <Text style={styles.statLabel}>Pending Approval</Text>
+              <Text style={styles.statLabel}>{labels.statPendingApproval}</Text>
             </View>
           )}
           <View style={styles.statBox}>
             <Text style={styles.statValue}>{data.totalRequirements}</Text>
-            <Text style={styles.statLabel}>Total</Text>
+            <Text style={styles.statLabel}>{labels.statTotal}</Text>
           </View>
         </View>
 
         <View style={styles.footer}>
-          <Text>Compliance Report — {data.companyName}</Text>
-          <Text>Confidential</Text>
+          <Text>{labels.title} · {data.companyName}</Text>
+          <Text>{getDocumentLabels(locale).confidential}</Text>
         </View>
       </Page>
 
@@ -210,10 +214,10 @@ export function ComplianceReport({ data, locale }: ComplianceReportProps) {
           {/* Intake form answers */}
           {cat.intakeAnswers && Object.keys(cat.intakeAnswers).length > 0 && (
             <View style={{ marginBottom: 12 }}>
-              <Text style={styles.sectionLabel}>Category Intake</Text>
+              <Text style={styles.sectionLabel}>{labels.categoryIntake}</Text>
               {cat.intakeSignedOffAt && (
                 <View style={styles.fieldRow}>
-                  <Text style={styles.fieldLabel}>Signed off</Text>
+                  <Text style={styles.fieldLabel}>{labels.signedOff}</Text>
                   <Text style={styles.fieldValue}>
                     {new Date(cat.intakeSignedOffAt).toLocaleDateString(getDateLocale(locale))}
                   </Text>
@@ -235,7 +239,7 @@ export function ComplianceReport({ data, locale }: ComplianceReportProps) {
           ))}
 
           <View style={styles.footer} fixed>
-            <Text>{data.companyName} — {data.frameworkName}</Text>
+            <Text>{data.companyName} · {data.frameworkName}</Text>
             <Text
               render={({ pageNumber, totalPages }) =>
                 `${pageNumber} / ${totalPages}`

--- a/lib/pdf/format.ts
+++ b/lib/pdf/format.ts
@@ -2,6 +2,18 @@
  * Shared formatting utilities for PDF document rendering.
  */
 
+export type PdfLocale = "en" | "de";
+
+/**
+ * PDF text renders with the base-14 Helvetica fonts only (WinAnsi/CP1252
+ * encoding), which silently garbles pl/cs/ro characters. Until a Unicode
+ * font is registered via Font.register, PDFs render only in the two
+ * hand-authored locales and everything else falls back to English.
+ */
+export function pdfLocale(raw: string | null): PdfLocale {
+  return raw?.trim().toLowerCase().split("-")[0] === "de" ? "de" : "en";
+}
+
 export function getDateLocale(locale: string): string {
   return locale === "de" ? "de-DE" : "en-US";
 }

--- a/lib/pdf/load-policy-data.ts
+++ b/lib/pdf/load-policy-data.ts
@@ -21,9 +21,11 @@ import { introspectSchema, humanize } from "@/lib/forms/schema-introspect";
 import {
   getComplianceMessages,
   getRequirementsMessages,
-  type ComplianceMessages,
+  getCategoryName,
+  getRequirementTitle,
   type RequirementsMessages,
 } from "@/lib/messages";
+import { getDocumentLabels } from "./policy-labels";
 
 export interface PolicyFieldValue {
   key: string;
@@ -54,17 +56,17 @@ export async function loadPolicyData(
   categoryCode: string,
   locale = "en",
 ): Promise<PolicyData> {
-  const [compliance, requirementMessages] = await Promise.all([
+  const [compliance, requirementMessages, assessment] = await Promise.all([
     getComplianceMessages(locale),
     getRequirementsMessages(locale),
+    db.query.companyAssessment.findFirst({
+      where: eq(companyAssessment.id, assessmentId),
+      with: {
+        company: { columns: { name: true } },
+        framework: { columns: { id: true } },
+      },
+    }),
   ]);
-  const assessment = await db.query.companyAssessment.findFirst({
-    where: eq(companyAssessment.id, assessmentId),
-    with: {
-      company: { columns: { name: true } },
-      framework: { columns: { id: true } },
-    },
-  });
 
   if (!assessment) throw new Error("Assessment not found");
 
@@ -107,12 +109,13 @@ export async function loadPolicyData(
     answers,
     metaByKey,
     requirementMessages,
+    getDocumentLabels(locale).general,
   );
 
   return {
     companyName: assessment.company.name,
     categoryCode,
-    categoryName: compliance.compliance.categories[categoryCode as keyof ComplianceMessages["compliance"]["categories"]]?.name ?? categoryCode,
+    categoryName: getCategoryName(compliance, categoryCode),
     frameworkName: compliance.compliance.frameworkName,
     signedOffBy: intake?.signedOffByUser?.name ?? null,
     signedOffAt: intake?.signedOffAt ?? null,
@@ -126,6 +129,7 @@ function buildFieldGroups(
   answers: Record<string, unknown>,
   metaByKey: Map<string, { key: string; label: string; type: string }>,
   requirementMessages: RequirementsMessages,
+  generalLabel: string,
 ): PolicyRequirementGroup[] {
   // Invert mapping: requirement code → field keys
   const reqFieldKeys = new Map<string, string[]>();
@@ -143,8 +147,7 @@ function buildFieldGroups(
     .map((req) => {
       const keys = reqFieldKeys.get(req.code) ?? [];
       const fields = resolveFields(keys, answers, metaByKey, usedFields);
-      const reqKey = req.code.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
-      return { code: req.code, title: requirementMessages.requirements[reqKey]?.title ?? req.code, legalRef: req.legalRef, fields };
+      return { code: req.code, title: getRequirementTitle(requirementMessages, req.code), legalRef: req.legalRef, fields };
     })
     .filter((g) => g.fields.length > 0);
 
@@ -159,7 +162,7 @@ function buildFieldGroups(
   if (ungroupedFields.length > 0) {
     groups.push({
       code: "GENERAL",
-      title: "General",
+      title: generalLabel,
       legalRef: null,
       fields: ungroupedFields,
     });

--- a/lib/pdf/load-report-data.ts
+++ b/lib/pdf/load-report-data.ts
@@ -18,7 +18,9 @@ import type { SignOffSnapshot } from "@nisd2/isms-schema/tables/assessments";
 import {
   getComplianceMessages,
   getRequirementsMessages,
-  type RequirementsMessages,
+  getCategory,
+  getRequirementTitle,
+  getRequirementDescription,
 } from "@/lib/messages";
 
 export interface ReportEvidence {
@@ -70,18 +72,17 @@ export async function loadReportData(
   assessmentId: string,
   locale = "en",
 ): Promise<ReportData> {
-  const [compliance, requirementMessages] = await Promise.all([
+  const [compliance, requirementMessages, assessment] = await Promise.all([
     getComplianceMessages(locale),
     getRequirementsMessages(locale),
+    db.query.companyAssessment.findFirst({
+      where: eq(companyAssessment.id, assessmentId),
+      with: {
+        company: { columns: { name: true, sector: true } },
+        framework: { columns: { id: true, code: true } },
+      },
+    }),
   ]);
-  const categoryMessages = compliance.compliance.categories;
-  const assessment = await db.query.companyAssessment.findFirst({
-    where: eq(companyAssessment.id, assessmentId),
-    with: {
-      company: { columns: { name: true, sector: true } },
-      framework: { columns: { id: true, code: true } },
-    },
-  });
 
   if (!assessment) throw new Error("Assessment not found");
 
@@ -129,12 +130,10 @@ export async function loadReportData(
         completedCount++;
       }
 
-      const reqKey = req.code.replace(/\./g, "_") as keyof RequirementsMessages["requirements"];
-      const reqI18n = requirementMessages.requirements[reqKey];
       return {
         code: req.code,
-        title: reqI18n?.title ?? req.code,
-        description: reqI18n?.description ?? "",
+        title: getRequirementTitle(requirementMessages, req.code),
+        description: getRequirementDescription(requirementMessages, req.code) ?? "",
         priority: req.priority,
         legalRef: req.legalRef,
         evidenceType: req.evidenceType,
@@ -153,7 +152,7 @@ export async function loadReportData(
       };
     });
 
-    const catI18n = categoryMessages[cat.code as keyof typeof categoryMessages];
+    const catI18n = getCategory(compliance, cat.code);
     return {
       code: cat.code,
       name: catI18n?.name ?? cat.code,

--- a/lib/pdf/policy-labels.ts
+++ b/lib/pdf/policy-labels.ts
@@ -1,5 +1,5 @@
 /**
- * Localized labels for policy PDF documents.
+ * Localized labels for the PDF documents (policy + compliance report).
  *
  * React-PDF components can't use next-intl hooks, so we maintain
  * a small set of document-level labels here, keyed by locale.
@@ -63,6 +63,106 @@ const LABELS: Record<string, DocumentLabels> = {
     general: "Allgemein",
   },
 };
+
+interface ReportLabels {
+  title: string;
+  sector: string;
+  generated: string;
+  assessmentStarted: string;
+  draftTitle: string;
+  draftText: (pending: number, completed: number) => string;
+  statCompliance: string;
+  statCompleted: string;
+  statApproved: string;
+  statPendingApproval: string;
+  statTotal: string;
+  signedOffBy: string;
+  signedOffAt: string;
+  templateVersion: string;
+  operationalData: string;
+  evidenceFiles: string;
+  reviewerFeedback: string;
+  signedOff: string;
+  categoryIntake: string;
+}
+
+const REPORT_LABELS: Record<string, ReportLabels> = {
+  en: {
+    title: "Compliance Report",
+    sector: "Sector",
+    generated: "Generated",
+    assessmentStarted: "Assessment started",
+    draftTitle: "DRAFT: Contains unapproved submissions",
+    draftText: (pending, completed) =>
+      `${pending} of ${completed} completed items are pending reviewer approval.`,
+    statCompliance: "Compliance",
+    statCompleted: "Completed",
+    statApproved: "Approved",
+    statPendingApproval: "Pending Approval",
+    statTotal: "Total",
+    signedOffBy: "Signed off by",
+    signedOffAt: "Signed off at",
+    templateVersion: "Template version",
+    operationalData: "Operational data",
+    evidenceFiles: "Evidence Files",
+    reviewerFeedback: "Reviewer Feedback",
+    signedOff: "Signed off",
+    categoryIntake: "Category Intake",
+  },
+  de: {
+    title: "Compliance-Bericht",
+    sector: "Sektor",
+    generated: "Erstellt am",
+    assessmentStarted: "Assessment gestartet am",
+    draftTitle: "ENTWURF: Enthält nicht freigegebene Einreichungen",
+    draftText: (pending, completed) =>
+      `${pending} von ${completed} abgeschlossenen Punkten warten auf Freigabe durch die Prüfung.`,
+    statCompliance: "Compliance",
+    statCompleted: "Abgeschlossen",
+    statApproved: "Freigegeben",
+    statPendingApproval: "Freigabe ausstehend",
+    statTotal: "Gesamt",
+    signedOffBy: "Freigegeben von",
+    signedOffAt: "Freigegeben am",
+    templateVersion: "Vorlagenversion",
+    operationalData: "Betriebsdaten",
+    evidenceFiles: "Nachweisdateien",
+    reviewerFeedback: "Prüferfeedback",
+    signedOff: "Freigegeben",
+    categoryIntake: "Kategorieerfassung",
+  },
+};
+
+const STATUS_LABELS: Record<string, Record<string, string>> = {
+  en: {
+    not_started: "not started",
+    in_progress: "in progress",
+    completed: "completed",
+    approved: "approved",
+    rejected: "rejected",
+    not_applicable: "not applicable",
+  },
+  de: {
+    not_started: "nicht begonnen",
+    in_progress: "in Bearbeitung",
+    completed: "abgeschlossen",
+    approved: "freigegeben",
+    rejected: "abgelehnt",
+    not_applicable: "nicht anwendbar",
+  },
+};
+
+export function getReportLabels(locale: string): ReportLabels {
+  return REPORT_LABELS[locale] ?? REPORT_LABELS["en"];
+}
+
+export function getStatusLabel(status: string, locale: string): string {
+  return (
+    STATUS_LABELS[locale]?.[status] ??
+    STATUS_LABELS["en"]?.[status] ??
+    status.replace(/_/g, " ")
+  );
+}
 
 export function getPolicyTitle(categoryCode: string, locale: string): string {
   return (

--- a/messages/compliance/de.json
+++ b/messages/compliance/de.json
@@ -351,7 +351,7 @@
         "bsiGuidance": ""
       },
       "CRA-OSS": {
-        "name": "Open-Source-Steward",
+        "name": "Verwalter quelloffener Software",
         "description": "Verwalter quelloffener Software führen eine Cybersicherheitsrichtlinie und koordinierte Schwachstellenoffenlegung ein und melden aktiv ausgenutzte Schwachstellen.",
         "legalBasis": "Art. 24 EU CRA",
         "threatLandscape": "OSS-Verwalter sind nach Art. 64(10) von Bußgeldern ausgenommen; nachgelagerte kommerzielle Nutzer sind dennoch auf ihre Meldungen angewiesen.",

--- a/messages/compliance/nl.json
+++ b/messages/compliance/nl.json
@@ -218,143 +218,178 @@
         "bsiGuidance": "Auditors controleren of maatregelen daadwerkelijk zijn geïmplementeerd, niet alleen gedocumenteerd. Verwacht technisch bewijs: configuratieschermafdrukken, patchlogs, SIEM-uitvoer, resultaten van back-uphersteltests en toegangsbeoordelingsverslagen."
       },
       "AI-LIT": {
-        "name": "AI Literacy",
-        "description": "Ensure staff and persons operating AI systems on the company's behalf have a sufficient level of AI literacy.",
+        "name": "AI-geletterdheid",
+        "description": "Waarborgen dat medewerkers en personen die namens het bedrijf AI-systemen bedienen over voldoende AI-geletterdheid beschikken.",
         "legalBasis": "Art. 4 EU AI Act",
-        "threatLandscape": "Untrained staff using AI tools cause data leakage, hallucination-driven errors, and deepfake exposure that organisations cannot defend in audit or court.",
+        "threatLandscape": "Ongetrainde medewerkers veroorzaken met AI-tools datalekken, fouten door hallucinaties en deepfake-risico's die in een audit of rechtszaak niet te verdedigen zijn.",
         "bsiGuidance": ""
       },
       "AI-PRO": {
-        "name": "Prohibited Practices",
-        "description": "Screen AI use cases against the eight (plus one) banned practices in Art. 5 and document the screening outcome.",
+        "name": "Verboden praktijken",
+        "description": "AI-toepassingen toetsen aan de acht (plus één) verboden praktijken uit art. 5 en het toetsingsresultaat documenteren.",
         "legalBasis": "Art. 5 EU AI Act",
-        "threatLandscape": "Using a prohibited practice triggers the highest penalty tier (EUR 35M or 7% of global turnover) regardless of intent.",
+        "threatLandscape": "Het gebruik van een verboden praktijk activeert ongeacht de intentie de hoogste boetecategorie (35 mln. EUR of 7% van de wereldwijde omzet).",
         "bsiGuidance": ""
       },
       "AI-INV": {
-        "name": "AI System Inventory",
-        "description": "Maintain an inventory of every AI system in use, classify each by risk tier, and re-classify on substantial modification.",
+        "name": "AI-inventaris",
+        "description": "Inventaris bijhouden van elk gebruikt AI-systeem, elk systeem indelen in een risicoklasse en bij wezenlijke wijzigingen opnieuw classificeren.",
         "legalBasis": "Art. 6, 25, 26 EU AI Act",
-        "threatLandscape": "Without an inventory, shadow-AI deployments evade oversight and create unmitigated compliance and liability exposure.",
+        "threatLandscape": "Zonder inventaris onttrekt schaduw-AI zich aan toezicht en ontstaan onbehandelde risico's voor compliance en aansprakelijkheid.",
         "bsiGuidance": ""
       },
       "AI-RSK": {
-        "name": "AI Risk Management",
-        "description": "Operate a documented risk management system for high-risk AI systems, with annual review and treatment of identified risks.",
+        "name": "AI-risicobeheer",
+        "description": "Gedocumenteerd risicobeheersysteem voor AI-systemen met een hoog risico, met jaarlijkse evaluatie en behandeling van vastgestelde risico's.",
         "legalBasis": "Art. 9 EU AI Act",
-        "threatLandscape": "Unmanaged AI risks (bias, drift, robustness failures) translate directly into incident exposure under Art. 73.",
+        "threatLandscape": "Onbehandelde AI-risico's (bias, drift, gebrekkige robuustheid) leiden direct tot meldplichtige incidenten volgens art. 73.",
         "bsiGuidance": ""
       },
       "AI-FRI": {
-        "name": "Fundamental Rights Impact Assessment",
-        "description": "Conduct a Fundamental Rights Impact Assessment before deploying high-risk AI systems in public, financial, or insurance contexts.",
+        "name": "Grondrechteneffectbeoordeling",
+        "description": "Grondrechteneffectbeoordeling uitvoeren vóór de inzet van AI-systemen met een hoog risico in de publieke sector en bij financiële en verzekeringsdiensten.",
         "legalBasis": "Art. 27 EU AI Act",
-        "threatLandscape": "Skipping the FRIA exposes the deployer to civil claims from affected persons and to market-surveillance enforcement.",
+        "threatLandscape": "Zonder effectbeoordeling dreigen civielrechtelijke claims van betrokkenen en maatregelen van het markttoezicht.",
         "bsiGuidance": ""
       },
       "AI-OVS": {
-        "name": "Human Oversight",
-        "description": "Designate a competent human overseer per high-risk AI system and verify oversight effectiveness annually.",
+        "name": "Menselijk toezicht",
+        "description": "Voor elk AI-systeem met een hoog risico een competente toezichthouder aanwijzen en de effectiviteit van het toezicht jaarlijks controleren.",
         "legalBasis": "Art. 14, Art. 26(2) EU AI Act",
-        "threatLandscape": "Autonomous high-risk AI systems without effective human override breach Art. 14 and create direct provider/deployer liability.",
+        "threatLandscape": "Autonome AI-systemen met een hoog risico zonder effectieve menselijke ingreep schenden art. 14 en scheppen directe aansprakelijkheid voor aanbieder en gebruiksverantwoordelijke.",
         "bsiGuidance": ""
       },
       "AI-TRA": {
-        "name": "Transparency",
-        "description": "Disclose AI interactions and AI-generated content to end users; watermark synthetic content; disclose deepfakes.",
+        "name": "Transparantie",
+        "description": "AI-interacties en AI-gegenereerde content aan eindgebruikers bekendmaken, synthetische content markeren, deepfakes vermelden.",
         "legalBasis": "Art. 50 EU AI Act",
-        "threatLandscape": "Lack of disclosure on chatbots and synthetic content breaches Art. 50 and undermines trust with customers and regulators.",
+        "threatLandscape": "Ontbrekende markering van chatbots en synthetische content schendt art. 50 en ondermijnt het vertrouwen van klanten en toezichthouders.",
         "bsiGuidance": ""
       },
       "AI-INC": {
-        "name": "AI Incident Reporting",
-        "description": "Document the AI incident response procedure; notify the market surveillance authority of serious incidents within 15 days.",
+        "name": "Melding van AI-incidenten",
+        "description": "Procedure voor de reactie op AI-incidenten documenteren; ernstige incidenten binnen 15 dagen melden aan de markttoezichtautoriteit.",
         "legalBasis": "Art. 73 EU AI Act",
-        "threatLandscape": "Failure to notify within the 15-day window triggers the second penalty tier (EUR 15M or 3% of turnover).",
+        "threatLandscape": "Bij overschrijding van de termijn van 15 dagen geldt de tweede boetecategorie (15 mln. EUR of 3% van de omzet).",
         "bsiGuidance": ""
       },
       "AI-DOC": {
-        "name": "Technical Documentation",
-        "description": "Maintain Annex IV technical documentation, automatic logging, and the EU Declaration of Conformity for high-risk AI systems.",
+        "name": "Technische documentatie",
+        "description": "Technische documentatie volgens bijlage IV, automatische logging en de EU-conformiteitsverklaring voor AI-systemen met een hoog risico bijhouden.",
         "legalBasis": "Art. 11, 12, 18, 19, 47 · Annex IV, V EU AI Act",
-        "threatLandscape": "Incomplete technical documentation prevents conformity assessment and blocks placing on the EU market.",
+        "threatLandscape": "Onvolledige technische documentatie verhindert de conformiteitsbeoordeling en blokkeert het in de handel brengen op de EU-markt.",
         "bsiGuidance": ""
       },
       "AI-GPI": {
-        "name": "General-Purpose AI",
-        "description": "GPAI provider obligations: model card, copyright policy, training-content summary, plus systemic-risk evaluation when training compute exceeds 10^25 FLOPs.",
+        "name": "GPAI-modellen",
+        "description": "Verplichtingen voor GPAI-aanbieders: modelkaart, auteursrechtbeleid, samenvatting van de trainingsdata en beoordeling van systeemrisico's vanaf een trainingsomvang van 10^25 FLOPs.",
         "legalBasis": "Art. 51-55 EU AI Act",
-        "threatLandscape": "GPAI providers that miss transparency obligations face EU AI Office enforcement directly, with fines under Art. 101.",
+        "threatLandscape": "GPAI-aanbieders die transparantieverplichtingen verzuimen, vallen direct onder handhaving door het EU AI Office, met boetes volgens art. 101.",
         "bsiGuidance": ""
       },
       "CRA-MFG": {
-        "name": "Manufacturer Obligations",
-        "description": "Per-product cybersecurity risk assessment and management body sign-off before placing the product on the EU market.",
+        "name": "Fabrikantverplichtingen",
+        "description": "Cyberrisicobeoordeling per product en goedkeuring door de directie vóór het in de handel brengen op de EU-markt.",
         "legalBasis": "Art. 13 EU CRA",
-        "threatLandscape": "Manufacturers that ship without a documented risk assessment have no defence when actively exploited vulnerabilities surface.",
+        "threatLandscape": "Fabrikanten die zonder gedocumenteerde risicobeoordeling leveren, staan zonder verweer wanneer actief uitgebuite kwetsbaarheden opduiken.",
         "bsiGuidance": ""
       },
       "CRA-ESS": {
-        "name": "Essential Cybersecurity Requirements",
-        "description": "Compliance with Annex I Part I: no known exploitable vulnerabilities at placing on market, secure by default, protection of data confidentiality, integrity, availability.",
+        "name": "Essentiële cyberbeveiligingseisen",
+        "description": "Naleving van bijlage I deel I: geen bekende uitbuitbare kwetsbaarheden bij het in de handel brengen, veilige standaardinstellingen, bescherming van vertrouwelijkheid, integriteit en beschikbaarheid van gegevens.",
         "legalBasis": "Annex I Part I EU CRA",
-        "threatLandscape": "Products that fail essential requirements cannot legally remain on the EU market and trigger the highest penalty tier.",
+        "threatLandscape": "Producten die niet aan de essentiële eisen voldoen, mogen niet op de EU-markt blijven en activeren de hoogste boetecategorie.",
         "bsiGuidance": ""
       },
       "CRA-VLN": {
-        "name": "Vulnerability Handling",
-        "description": "Documented vulnerability handling, coordinated disclosure policy, security updates without delay, and public disclosure of fixed vulnerabilities.",
+        "name": "Kwetsbaarhedenbeheer",
+        "description": "Gedocumenteerde afhandeling van kwetsbaarheden, gecoördineerde openbaarmaking, beveiligingsupdates zonder vertraging en publieke bekendmaking van verholpen kwetsbaarheden.",
         "legalBasis": "Annex I Part II EU CRA",
-        "threatLandscape": "Vendors without a vulnerability handling process cannot meet the 24h / 72h / 14-day reporting cascade and become liable for downstream incidents.",
+        "threatLandscape": "Aanbieders zonder kwetsbaarhedenproces kunnen de meldcascade van 24 uur, 72 uur en 14 dagen niet halen en zijn aansprakelijk voor vervolgincidenten.",
         "bsiGuidance": ""
       },
       "CRA-INC": {
-        "name": "Active Exploitation Reporting",
-        "description": "24-hour early warning to ENISA and CSIRT, 72-hour notification, 14-day final report for actively exploited vulnerabilities and severe incidents.",
+        "name": "Melding van actieve uitbuiting",
+        "description": "Vroegtijdige waarschuwing aan ENISA en het CSIRT binnen 24 uur, melding binnen 72 uur, eindrapport na 14 dagen bij actief uitgebuite kwetsbaarheden en ernstige incidenten.",
         "legalBasis": "Art. 14 EU CRA",
-        "threatLandscape": "Missed reporting deadlines (other than the 24h deadline for SMEs) trigger the highest penalty tier and product-recall powers.",
+        "threatLandscape": "Gemiste meldtermijnen (behalve de 24-uurstermijn voor kmo's) activeren de hoogste boetecategorie en terugroepbevoegdheden.",
         "bsiGuidance": ""
       },
       "CRA-CONF": {
-        "name": "Conformity Assessment",
-        "description": "Conformity assessment route per product class (self-assessment Module A, Module B+C with notified body, or Module H quality system) followed by CE marking.",
+        "name": "Conformiteitsbeoordeling",
+        "description": "Conformiteitsbeoordelingsprocedure per productklasse (zelfbeoordeling module A, module B+C met aangemelde instantie of kwaliteitssysteem module H), gevolgd door CE-markering.",
         "legalBasis": "Art. 24, Art. 27 EU CRA",
-        "threatLandscape": "Products without valid conformity assessment cannot be placed on the EU market from 11 December 2027.",
+        "threatLandscape": "Producten zonder geldige conformiteitsbeoordeling mogen vanaf 11 december 2027 niet meer op de EU-markt worden aangeboden.",
         "bsiGuidance": ""
       },
       "CRA-DOC": {
-        "name": "Technical Documentation",
-        "description": "Maintain Annex VII technical documentation for each product placed on the EU market.",
+        "name": "Technische documentatie",
+        "description": "Technische documentatie volgens bijlage VII bijhouden voor elk op de EU-markt aangeboden product.",
         "legalBasis": "Art. 28 · Annex VII EU CRA",
-        "threatLandscape": "Missing or incomplete technical documentation blocks market surveillance verification and triggers product withdrawal.",
+        "threatLandscape": "Ontbrekende of onvolledige technische documentatie blokkeert de controle door het markttoezicht en leidt tot het uit de handel nemen van het product.",
         "bsiGuidance": ""
       },
       "CRA-SUP": {
-        "name": "Support Period",
-        "description": "Publicly commit to a security update support period (default five years or expected product life, whichever is longer).",
+        "name": "Ondersteuningsperiode",
+        "description": "Publieke toezegging van een periode voor beveiligingsupdates (standaard vijf jaar of de verwachte levensduur van het product, als die langer is).",
         "legalBasis": "Art. 13(8) EU CRA",
-        "threatLandscape": "Failure to support the full period exposes the manufacturer to claims from customers stranded on insecure products.",
+        "threatLandscape": "Wie de volledige periode niet dekt, riskeert claims van klanten die met onveilige producten blijven zitten.",
         "bsiGuidance": ""
       },
       "CRA-SBOM": {
         "name": "Software Bill of Materials",
-        "description": "Generate and maintain a machine-readable Software Bill of Materials for each product placed on the EU market.",
+        "description": "Machineleesbare software-stuklijst (SBOM) opstellen en bijhouden voor elk op de EU-markt aangeboden product.",
         "legalBasis": "Annex I Part II §1 EU CRA",
-        "threatLandscape": "Without an SBOM, manufacturers cannot trace which products contain a vulnerable component and miss the Art. 14 reporting window.",
+        "threatLandscape": "Zonder SBOM kunnen fabrikanten niet nagaan welke producten een kwetsbare component bevatten en missen ze het meldvenster van art. 14.",
         "bsiGuidance": ""
       },
       "CRA-IMP": {
-        "name": "Importer and Distributor",
-        "description": "Importers verify manufacturer compliance before placing on market; distributors perform due diligence on conformity markings.",
+        "name": "Importeurs en distributeurs",
+        "description": "Importeurs controleren de conformiteit van de fabrikant vóór het in de handel brengen; distributeurs controleren conformiteitsmarkeringen met de nodige zorgvuldigheid.",
         "legalBasis": "Art. 18, Art. 19 EU CRA",
-        "threatLandscape": "Importers and distributors that miss verification inherit manufacturer liability under Art. 22.",
+        "threatLandscape": "Importeurs en distributeurs die deze controle verzuimen, nemen volgens art. 22 de fabrikantaansprakelijkheid over.",
         "bsiGuidance": ""
       },
       "CRA-OSS": {
-        "name": "Open-Source Steward",
-        "description": "Open-source software stewards adopt a cybersecurity policy, coordinated vulnerability disclosure, and report actively exploited vulnerabilities.",
+        "name": "Beheerder van opensourcesoftware",
+        "description": "Beheerders van opensourcesoftware voeren een cyberbeveiligingsbeleid en gecoördineerde openbaarmaking van kwetsbaarheden in en melden actief uitgebuite kwetsbaarheden.",
         "legalBasis": "Art. 24 EU CRA",
-        "threatLandscape": "OSS stewards are penalty-exempt under Art. 64(10), but downstream commercial users still depend on their reporting.",
+        "threatLandscape": "OSS-beheerders zijn volgens art. 64, lid 10, vrijgesteld van boetes; commerciële afnemers verderop in de keten blijven niettemin afhankelijk van hun meldingen.",
+        "bsiGuidance": ""
+      },
+      "DPA": {
+        "name": "Verwerkersovereenkomsten",
+        "description": "Verwerkersovereenkomsten volgens art. 28 AVG met alle verwerkers die persoonsgegevens verwerken",
+        "legalBasis": "Art. 28 AVG",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "ROP": {
+        "name": "Verwerkingsregister",
+        "description": "Documentatie van alle verwerkingsactiviteiten volgens art. 30 AVG: doel, rechtsgrondslag, ontvangers, bewaartermijn",
+        "legalBasis": "Art. 30 AVG",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "TOM": {
+        "name": "Technische en organisatorische maatregelen",
+        "description": "Beveiligingsmaatregelen ter bescherming van persoonsgegevens volgens art. 32 AVG",
+        "legalBasis": "Art. 32 AVG",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "BRC": {
+        "name": "Datalekken",
+        "description": "Meldproces binnen 72 uur en documentatie van inbreuken volgens art. 33/34 AVG",
+        "legalBasis": "Art. 33, art. 34 AVG",
+        "threatLandscape": "",
+        "bsiGuidance": ""
+      },
+      "DSR": {
+        "name": "Rechten van betrokkenen",
+        "description": "Afhandeling van verzoeken om inzage, verwijdering, overdraagbaarheid en bezwaar binnen één maand",
+        "legalBasis": "Art. 12-22 AVG",
+        "threatLandscape": "",
         "bsiGuidance": ""
       }
     }

--- a/server/trpc/routers/journey.ts
+++ b/server/trpc/routers/journey.ts
@@ -14,33 +14,11 @@ import {
 import { env } from "@/lib/env";
 import { daysUntilDeadline } from "@/lib/compliance/deadlines";
 import { isJourneyAllowed } from "@/lib/journey-flag";
-import requirementsEn from "@/messages/requirements/en.json";
-import requirementsDe from "@/messages/requirements/de.json";
-
-const I18N = {
-  en: requirementsEn.requirements as Record<
-    string,
-    { title?: string; description?: string }
-  >,
-  de: requirementsDe.requirements as Record<
-    string,
-    { title?: string; description?: string }
-  >,
-} as const;
-
-type Locale = keyof typeof I18N;
-
-function resolveTitle(code: string, locale: Locale): string {
-  const key = code.replace(/\./g, "_");
-  return I18N[locale][key]?.title ?? I18N.en[key]?.title ?? code;
-}
-
-function resolveDescription(code: string, locale: Locale): string | null {
-  const key = code.replace(/\./g, "_");
-  return (
-    I18N[locale][key]?.description ?? I18N.en[key]?.description ?? null
-  );
-}
+import {
+  getRequirementsMessages,
+  getRequirementTitle,
+  getRequirementDescription,
+} from "@/lib/messages";
 
 /**
  * Terminal/done statuses. "completed" is the normal user sign-off result,
@@ -79,7 +57,7 @@ function isReviewStatus(s: string): boolean {
  */
 export const journeyRouter = router({
   getItems: companyProcedure
-    .input(z.object({ locale: z.enum(["en", "de"]).optional() }).optional())
+    .input(z.object({ locale: z.string().optional() }).optional())
     .query(async ({ ctx, input }) => {
     // Defense-in-depth: page.tsx redirects unauthorised users from the
     // /journey route, but the tRPC procedure itself must also gate or
@@ -191,9 +169,10 @@ export const journeyRouter = router({
       });
     }
 
-    // Resolve requirement titles/descriptions in the caller's locale (NL falls
-    // back to EN: only en/de message bundles exist for requirement strings).
-    const locale: Locale = input?.locale ?? "en";
+    // Resolve requirement titles/descriptions in the caller's locale.
+    // getRequirementsMessages validates the value and falls back to English
+    // per-key for untranslated entries.
+    const requirements = await getRequirementsMessages(input?.locale ?? "en");
     const nowDate = new Date();
     const items = rows.map((r) => {
       const status = r.status ?? "not_started";
@@ -210,8 +189,8 @@ export const journeyRouter = router({
       return {
         id: r.statusId,
         code: r.code,
-        title: resolveTitle(r.code, locale),
-        description: resolveDescription(r.code, locale),
+        title: getRequirementTitle(requirements, r.code),
+        description: getRequirementDescription(requirements, r.code),
         categoryCode: r.categoryCode,
         categorySlug: r.categorySlug,
         status,

--- a/server/trpc/routers/llm.ts
+++ b/server/trpc/routers/llm.ts
@@ -72,7 +72,7 @@ export const llmRouter = router({
     }),
 
   evaluateSection: companyProcedure
-    .input(z.object({ categoryCode: z.string() }))
+    .input(z.object({ categoryCode: z.string(), locale: z.string().optional() }))
     .mutation(async ({ ctx, input }) => {
       // Honor the aiDataSharing="none" opt-out before loading sign-off snapshots.
       await requireAiEnabled(ctx.db, ctx.companyId);
@@ -84,7 +84,7 @@ export const llmRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "No assessment found" });
       }
 
-      const reportData = await loadReportData(assessment.id);
+      const reportData = await loadReportData(assessment.id, input.locale);
       const category = reportData.categories.find((c) => c.code === input.categoryCode);
       if (!category) {
         throw new TRPCError({ code: "NOT_FOUND", message: `Category ${input.categoryCode} not found` });
@@ -103,7 +103,8 @@ export const llmRouter = router({
     }),
 
   evaluateAll: companyProcedure
-    .mutation(async ({ ctx }) => {
+    .input(z.object({ locale: z.string().optional() }).optional())
+    .mutation(async ({ ctx, input }) => {
       // Honor the aiDataSharing="none" opt-out before loading sign-off snapshots.
       await requireAiEnabled(ctx.db, ctx.companyId);
 
@@ -114,7 +115,7 @@ export const llmRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "No assessment found" });
       }
 
-      const reportData = await loadReportData(assessment.id);
+      const reportData = await loadReportData(assessment.id, input?.locale);
       const orgContext = await loadOrgContext(ctx.db, ctx.companyId);
       return evaluateAssessment(reportData, orgContext);
     }),


### PR DESCRIPTION
Follow-up to #52, applying the confirmed findings from its code review.

**PDF exports**: clamped to en/de via `pdfLocale()` — the base-14 Helvetica fonts are WinAnsi-encoded and silently garble pl/cs/ro characters ("bezpieczeństwa" printed as "bezpieczeDstwa"), so those locales serve English until a Unicode font is registered. Report chrome (cover, stats, sign-off labels, status badges, draft banner) is now localized via `getReportLabels`/`getStatusLabel`; the policy PDF's ungrouped section finally uses the localized "Allgemein" that shipped unused.

**lib/messages.ts hardening**: locale normalization ('de-DE'/'DE'/'' all resolve), allowlist from `routing.locales`, per-locale memoization, load failures log instead of failing silent, empty-string overrides no longer mask English values, and `getCategoryName`/`getRequirementTitle` accessors replace seven copy-pasted cast expressions. Independent awaits joined into `Promise.all` in the portal layout, team, review, and both PDF loaders.

**Missed surfaces**: `llm.ts` evaluate mutations take a locale input (audit-readiness showed English on /de); `journey.ts` drops its parallel en/de-only I18N map for the shared loader, so nl/fr/cs/pt/ro journeys localize.

**Translations**: nl compliance gets the 5 GDPR categories + Dutch AI Act/CRA strings (official act terminology); de CRA-OSS renamed to the EUR-Lex term "Verwalter quelloffener Software". Export page dates use the shared BCP-47 formatter.

**E2e**: networkidle before the collapsible click, sidebar-scoped assertions, screenshots dropped. Typecheck clean; sidebar spec 3/3 against a fresh production build.

Not addressed (documented follow-ups): stored user locale for email senders, wiki coercion of small locales to German, raw redirect() cleanup, es/it bulk translations, CI wiring for scripts/i18n/validate.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgqgsrHnYuqTd1fbd2m8zM