### PR TITLE
fix(assessment): single confirmModuleRef enforces the same guards as signOff

### DIFF
--- a/components/compliance/RequirementDetail.tsx
+++ b/components/compliance/RequirementDetail.tsx
@@ -557,7 +557,12 @@ export function RequirementDetail({
                   isCompleted={isCompleted}
                   isConfirming={isPending}
                   onConfirm={
-                    isReviewer || !status.statusId ? undefined : handleModuleConfirm
+                    // Assigned requirements complete through the sign-off flow
+                    // (the server rejects module-confirm for them), so don't
+                    // offer a button that can only fail.
+                    isReviewer || !status.statusId || optimisticAssignments.length > 0
+                      ? undefined
+                      : handleModuleConfirm
                   }
                   editorInitialData={editorInitialData}
                 />

--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -652,7 +652,7 @@ export const assessmentRouter = router({
       const statusRow = await ctx.db.query.companyRequirementStatus.findFirst({
         where: eq(companyRequirementStatus.id, input.statusId),
         with: {
-          requirement: { columns: { id: true, code: true, moduleRef: true, categoryId: true, templateVersion: true } },
+          requirement: { columns: { id: true, code: true, moduleRef: true, categoryId: true, templateVersion: true, requiredSignOffRole: true } },
         },
       });
       if (!statusRow) {
@@ -671,11 +671,37 @@ export const assessmentRouter = router({
       });
 
       const signedOffRole = await getSignerRole(ctx.db, ctx.userId, ctx.session.role);
+      const effectiveRole: RoleKey =
+        (statusRow.requirement.requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
 
       // Audit B-2 (2026-06-10): assignment + status + chain entry inside
       // the same tx so a partial commit cannot leave the chain disagreeing
       // with the status row.
       const result = await ctx.db.transaction(async (tx) => {
+        // Same guard pair as signOff: an N-of-M requirement belongs to the
+        // assignment flow (each signer signs individually), and an unassigned
+        // requirement completes only with the required signer role (admin
+        // bypass). FOR UPDATE matches signOff's locking; like there, it locks
+        // existing rows only, so a concurrent first assignment can still race
+        // the empty read.
+        const lockedAssignments = await tx
+          .select()
+          .from(requirementAssignment)
+          .where(eq(requirementAssignment.statusId, input.statusId))
+          .for("update");
+        if (lockedAssignments.length > 0) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "This requirement has assigned signers; sign off through the assignment flow.",
+          });
+        }
+        if (ctx.session.role !== "admin" && signedOffRole !== effectiveRole) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: `This requirement requires sign-off by ${effectiveRole.toUpperCase()}.`,
+          });
+        }
+
         await tx
           .insert(requirementAssignment)
           .values({
@@ -787,6 +813,7 @@ export const assessmentRouter = router({
       const moduleRows = rows.filter(
         (r) => r.moduleRef && r.currentStatus !== "completed" && r.currentStatus !== "approved",
       );
+      if (moduleRows.length === 0) return { confirmed: 0 };
       const confirmAssignedIds = new Set(
         (
           await ctx.db


### PR DESCRIPTION
PR #41 closed the bulk sign-off/confirm bypass but left its UI-wired
sibling open: single confirmModuleRef never read requiredSignOffRole,
so a member category owner could complete CEO-required module-backed
requirements (4.2, 7.3) one click at a time.

confirmModuleRef now applies signOff's exact guard pair inside its
transaction: a requirement with assignment rows belongs to the
assignment flow (FORBIDDEN, matching the bulk path's skip), and an
unassigned requirement completes only when the caller holds the
required signer role, with the same admin bypass and error message as
signOff. The FOR UPDATE read matches signOff's locking semantics.

UI: the confirm button is no longer offered when assignments exist,
since the server would reject it.

Also moves bulkConfirmModuleRef's assignment lookup behind the
empty-set early return (review follow-up from #41).

Verified: tsc clean; adversarial review APPROVE (parity with signOff
confirmed against the full function, tenant isolation unchanged, UI
error path matches how signOff's FORBIDDEN already surfaces).
