### PR TITLE
fix(validation): bound numeric inputs by column precision, widen e2e staleness watch

### DIFF
--- a/e2e/start-server.sh
+++ b/e2e/start-server.sh
@@ -33,7 +33,7 @@ env "${APP_ENV[@]}" bun run drizzle/seed.ts
 needs_build=0
 if [ ! -f .next/BUILD_ID ]; then
   needs_build=1
-elif [ -n "$(find app components lib server schema packages messages i18n next.config.ts next.config.mjs -newer .next/BUILD_ID 2>/dev/null | head -1)" ]; then
+elif [ -n "$(find app components lib server schema packages messages i18n proxy.ts package.json bun.lock next.config.ts next.config.mjs -newer .next/BUILD_ID 2>/dev/null | head -1)" ]; then
   echo "[e2e] source changed since last build"
   needs_build=1
 fi

--- a/schema/validators.ts
+++ b/schema/validators.ts
@@ -14,7 +14,8 @@
  *   const parsed = companyInsertSchema.parse(req.body);
  */
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
-import { getTableColumns, type Table } from "drizzle-orm";
+import { getTableColumns, is, type Table } from "drizzle-orm";
+import { PgNumeric } from "drizzle-orm/pg-core";
 import { z } from "zod";
 
 // --- Table imports (alphabetical by file) ---
@@ -103,13 +104,36 @@ function numericColumns<T extends Table>(
 ): Partial<Record<keyof T["_"]["columns"], z.ZodType>> {
   const out: Partial<Record<keyof T["_"]["columns"], z.ZodType>> = {};
   for (const [name, col] of Object.entries(getTableColumns(table))) {
-    if (col.columnType === "PgNumeric") {
+    // is() over instanceof: entityKind-based, so it survives a second
+    // drizzle-orm copy in the graph where class identity would not.
+    if (is(col, PgNumeric)) {
       // Free-text validation of a number is a genuine free-text case, so the
       // regex is appropriate here. Integers and decimals only; "" is rejected
       // (SchemaForm strips it to undefined for optional columns).
-      const numericStr = z
+      const base = z
         .string()
         .regex(/^-?\d+(\.\d+)?$/, "Must be a number");
+      // pg rejects values whose integer digits exceed precision - scale with
+      // "numeric field overflow" (a 500, not a validation error), while excess
+      // fractional digits are silently rounded. Bound the integer digits from
+      // the column's own declared precision/scale so overflow fails validation.
+      const intDigitCap =
+        typeof col.precision === "number"
+          ? col.precision - (typeof col.scale === "number" ? col.scale : 0)
+          : null;
+      const numericStr =
+        intDigitCap === null
+          ? base
+          : base.refine(
+              (v) => {
+                // Strip ALL leading zeros: pg counts significant digits of
+                // the value, so "0" and "0.95" have zero integer digits.
+                const intPart = v.replace(/^-/, "").split(".")[0] ?? "";
+                const significant = intPart.replace(/^0+/, "");
+                return significant.length <= intDigitCap;
+              },
+              `Must be at most ${intDigitCap} digits before the decimal point`,
+            );
       out[name as keyof T["_"]["columns"]] = col.notNull
         ? numericStr
         : numericStr.nullish();
@@ -297,6 +321,7 @@ export const requirementUpdateSchema = requirementInsertSchema.partial().omit(om
 
 export const assessmentInsertSchema = createInsertSchema(companyAssessment, {
   ...isoDateColumns(companyAssessment),
+  ...numericColumns(companyAssessment),
 });
 export const assessmentSelectSchema = createSelectSchema(companyAssessment);
 


### PR DESCRIPTION
Follow-ups from the #44 review:

- numericColumns now derives an integer-digit cap from each column's
  declared precision/scale, so values pg would reject with 'numeric
  field overflow' (a 500) fail validation instead: cvssScore
  numeric(3,1) caps at 2 integer digits, the numeric(15,2) money
  columns at 13. Excess fractional digits stay allowed since pg rounds
  them silently. Leading zeros are stripped like pg counts significant
  digits ('0.95' has zero integer digits). Narrowing uses drizzle's
  is(col, PgNumeric) so a second drizzle-orm copy in the graph cannot
  silently disable validation.
- assessmentInsertSchema gains the numericColumns spread its
  compliancePercentage decimal(5,2) column was missing.
- e2e/start-server.sh staleness watch now covers proxy.ts,
  package.json and bun.lock, closing the remaining false-pass window
  after proxy or dependency changes.

Verified: tsc clean, bun test e2e/l0 110/110; adversarial review
APPROVE incl. a 23-value validation matrix against pg semantics and an
old-vs-new predicate run over all 8 numeric columns (zero mismatches).
