### PR TITLE
fix(assessment): scope getPrerequisiteStatuses to the caller's tenant

### DIFF
--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -458,6 +458,11 @@ export const assessmentRouter = router({
   getPrerequisiteStatuses: companyProcedure
     .input(z.object({ assessmentId: z.string().uuid(), requirementId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
+      // companyProcedure only guarantees a companyId exists; it does not scope
+      // the assessmentId the caller sends. Without this the leftJoin below reads
+      // another tenant's completion state for any assessment id the caller knows.
+      await verifyAssessmentOwnership(ctx.db, input.assessmentId, ctx.companyId);
+
       const rows = await ctx.db
         .select({
           code: requirement.code,


### PR DESCRIPTION
getPrerequisiteStatuses accepted an assessmentId from the caller and
joined companyRequirementStatus on it without ever verifying the
assessment belongs to the caller's company. companyProcedure only
asserts that a companyId exists on the context; it does not scope
inputs. Any authenticated user holding another tenant's assessment
UUID could therefore read that tenant's prerequisite completion
state for a given requirement.

It was the only procedure in the router that missed the check: five
procedures take an assessmentId and the other four already call
verifyAssessmentOwnership (lines 345, 435, 790, 916).

Narrow in payload (booleans for one requirement's prerequisites) and
it needs a UUID obtained out of band, but 'verify the entity belongs
to the caller's tenant, don't trust the caller to only provide their
own IDs' has no exceptions.

Found by the CLAUDE.md principles audit and confirmed by adversarial
review against the full router.

Verified: tsc clean, bun test e2e/l0 110/110.
