### PR TITLE
fix(docs): generate AUTH_SECRET in the seed example instead of hardcoding one

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -54,7 +54,7 @@ A fresh database has zero requirements in it. Migrations create the tables; they
 
 ```bash
 DATABASE_URL="postgres://openisms:YOUR_PASSWORD@localhost:5432/openisms" \
-AUTH_SECRET="anything-at-least-32-characters-long" \
+AUTH_SECRET="$(openssl rand -base64 32)" \
 bun run drizzle/seed.ts
 ```
 


### PR DESCRIPTION
The seed command in the self-hosting guide carried a literal 36-char
AUTH_SECRET. Two problems:

- Gitleaks has failed on main since it landed (generic-api-key,
  entropy 3.78, docs/self-hosting.md:57), so the secret scanner has
  been red and stops being a useful signal.
- Worse for readers: it is a copy-pasteable block, so every self-hoster
  who follows the guide ends up sharing the same session-signing key.

The seed only needs a value that passes the 32-char Zod check that
importing @/lib/db triggers; it never signs anything with it, so a
throwaway is correct here. This matches what line 28 of the same guide
already does when populating .env, and the DATABASE_URL on the line
above which already uses a YOUR_PASSWORD placeholder.

Verified: gitleaks detect --no-git over the tree reports no leaks.
