### PR TITLE
fix(training): derive batchCreate input from trainingInsertSchema

### DIFF
--- a/server/trpc/routers/training.ts
+++ b/server/trpc/routers/training.ts
@@ -6,6 +6,27 @@ import { trainingRecord } from "@/schema";
 import { trainingInsertSchema, trainingUpdateSchema } from "@/schema/validators";
 import { createPresignedPut, createPresignedGet } from "@/lib/storage";
 
+/**
+ * batchCreate writes one training_record row per participant, so its input
+ * splits the columns shared by every row from the per-participant ones. Both
+ * halves derive from trainingInsertSchema: the hand-written restatement this
+ * replaced had drifted, typing the pg `date` column nextTrainingDue as a bare
+ * string so free text reached Postgres as `invalid input syntax for type date`
+ * (a 500, not a validation error), and silently dropping trainerQualification
+ * and topicsCovered.
+ */
+const participantColumns = {
+  userId: true,
+  participantName: true,
+  participantRole: true,
+  isManagement: true,
+} as const;
+
+const batchCreateSchema = z.object({
+  training: trainingInsertSchema.omit({ ...participantColumns, id: true, companyId: true, createdAt: true }),
+  participants: z.array(trainingInsertSchema.pick(participantColumns)).min(1),
+});
+
 export const trainingRouter = router({
   list: companyProcedure.query(async ({ ctx }) => {
     if (!ctx.companyId) return [];
@@ -27,32 +48,7 @@ export const trainingRouter = router({
     }),
 
   batchCreate: companyProcedure
-    .input(
-      z.object({
-        training: z.object({
-          trainingType: z.string().min(1).max(255),
-          title: z.string().min(1).max(500),
-          description: z.string().nullish(),
-          providerName: z.string().max(255).nullish(),
-          trainerName: z.string().max(255).nullish(),
-          startedAt: z.coerce.date().nullish(),
-          completedAt: z.coerce.date().nullish(),
-          durationMinutes: z.number().int().positive().nullish(),
-          nextTrainingDue: z.string().nullish(),
-          certificateFileKey: z.string().max(500).nullish(),
-        }),
-        participants: z
-          .array(
-            z.object({
-              userId: z.string().uuid().nullish(),
-              participantName: z.string().min(1).max(255),
-              participantRole: z.string().max(255).nullish(),
-              isManagement: z.boolean(),
-            }),
-          )
-          .min(1),
-      }),
-    )
+    .input(batchCreateSchema)
     .mutation(async ({ ctx, input }) => {
       const rows = await ctx.db
         .insert(trainingRecord)


### PR DESCRIPTION
batchCreate hand-wrote a z.object restating ~14 training_record
columns, ten lines below the same table's derived insert schema
being used by create. The copy had drifted.

nextTrainingDue is a pg `date` column. The hand-written copy typed
it z.string().nullish(), bypassing isoDateColumns() in
schema/validators.ts, which exists precisely to stop free text
reaching a date column. Anything non-ISO ("irgendwann", "") passed
validation and failed at the insert with `invalid input syntax for
type date`: a 500, not a 400. Same class of defect fixed for
numeric columns in #44 and #59.

The copy also silently dropped trainerQualification and
topicsCovered, which the table and the derived schema both accept,
so batchCreate could never write them.

Both halves of the input now come from trainingInsertSchema via one
shared column mask: participants picks the per-row columns, training
omits them plus id/companyId/createdAt, matching create. New columns
on the table are covered without touching this file.

The wire shape the client sends is unchanged. Verified by parsing
TrainingPage's exact payload against the router's own input parser:
Date objects for startedAt/completedAt still pass (superjson keeps
them Dates), null and omitted nextTrainingDue still pass, and
"irgendwann", "" and "2027-02-30" now fail validation instead of
reaching Postgres.
