### PR TITLE
docs(reference): call the reference app a package demo, not a self-host path

### DIFF
--- a/apps/reference/.env.example
+++ b/apps/reference/.env.example
@@ -1,4 +1,5 @@
-# open-isms self-host environment
+# open-isms reference app environment (the package demo).
+# Self-hosting the platform uses the .env.example at the repo root instead.
 # Copy to .env and fill in the values, then `docker compose up --build`.
 
 # ── Database ────────────────────────────────────────────────────────────

--- a/apps/reference/Dockerfile
+++ b/apps/reference/Dockerfile
@@ -2,9 +2,9 @@
 #
 # Dockerfile for the open-isms reference app.
 #
-# Distinct from the nisd2.eu private Dockerfile at the monorepo root —
-# this one builds ONLY apps/reference + the OSS workspace packages.
-# Designed for self-hosters running `docker compose up` from this dir.
+# Distinct from the Dockerfile at the repo root, which builds the full
+# platform. This one builds ONLY apps/reference + the workspace packages,
+# for `docker compose up` from this dir.
 #
 # Multi-stage:
 #   deps    — bun install (cached by package manifests)

--- a/apps/reference/README.md
+++ b/apps/reference/README.md
@@ -1,6 +1,6 @@
 # open-isms (reference app)
 
-Self-hostable Next.js app skeleton for an NIS 2 ISMS, wired up to the workspace packages (`@nisd2/grc-data-model`, `@nisd2/isms-schema`, etc.).
+Minimal Next.js app skeleton for an NIS 2 ISMS, wired up to the workspace packages (`@nisd2/grc-data-model`, `@nisd2/isms-schema`, etc.). Use it to understand the packages. To run the actual platform, follow [docs/self-hosting.md](../../docs/self-hosting.md) instead: that path uses the root `docker-compose.yml`, the same image nisd2.eu runs, and needs no SMTP setup.
 
 > **Status**: landing page, email magic-link sign-in, and two portal pages (dashboard, compliance). The rest (assets, risks, suppliers, incidents, training, reviews) is still being added; until it lands, this app demonstrates the workspace + Docker setup but does not yet expose the full ISMS. See the main README for the roadmap.
 >
@@ -50,7 +50,7 @@ apps/reference/
 │   └── migrate.mjs         # runtime DB migrator (runs at container start)
 ├── public/                 # static assets served at /
 ├── Dockerfile              # multi-stage build (deps → builder → runner)
-├── docker-compose.yml      # Postgres + app for self-hosters
+├── docker-compose.yml      # Postgres + app, for running this demo
 ├── .env.example            # template for environment variables
 ├── package.json
 ├── next.config.ts

--- a/apps/reference/docker-compose.yml
+++ b/apps/reference/docker-compose.yml
@@ -1,4 +1,6 @@
-# Self-hostable open-isms reference stack: Postgres + the Next.js app.
+# open-isms reference stack: Postgres + the Next.js app skeleton.
+# This is the package demo, not the platform. To self-host the real thing,
+# use the docker-compose.yml at the repo root and follow docs/self-hosting.md.
 #
 # Quick start:
 #   1. cd apps/reference

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -120,6 +120,8 @@ Whichever you choose, uploads are the one feature that fails visibly in the brow
 
 ### Optional, each degrades one feature
 
+The ones worth a decision. `.env.example` carries the remainder: dev-only switches, the newsletter send throttle, and the separate newsletter From address.
+
 | Variable | Without it |
 |---|---|
 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | No "Sign in with Google" button. Email and password still works. |


### PR DESCRIPTION
`apps/reference` opened with "Self-hostable Next.js app skeleton" and repeated "for self-hosters" in its compose file, Dockerfile, and `.env.example`. `docs/self-hosting.md` already disclaims it under "The other compose file", but nothing pointed back the other way, so anyone browsing the folder tree on GitHub could start a Postgres on :3000 expecting an ISMS.

Every entry point into `apps/reference` now names it the package demo and points at `docs/self-hosting.md` for the real platform. Also drops the stale "nisd2.eu private Dockerfile" reference.

In `docs/self-hosting.md`, one line says outright that the optional table is the subset worth a decision, so counting its rows against the "other 25" in the paragraph above no longer reads as a gap.

Comments and prose only, no code touched.