### PR TITLE
fix(compliance): label requirement citations by their own framework

### DIFF
--- a/app/[locale]/(portal)/compliance/[categorySlug]/[requirementCode]/page.tsx
+++ b/app/[locale]/(portal)/compliance/[categorySlug]/[requirementCode]/page.tsx
@@ -237,6 +237,9 @@ export default async function RequirementDetailPage({
     frameworkRef: req.frameworkRef,
     importance: req.importance,
     moduleRef: req.moduleRef,
+    frameworkCode: req.category.framework.code,
+    referenceUrl: req.category.referenceUrl,
+    nationalUrl: req.category.nationalUrl,
   };
 
   return (

--- a/components/compliance/RequirementDetail.tsx
+++ b/components/compliance/RequirementDetail.tsx
@@ -40,6 +40,7 @@ import { renderFieldInput } from "@/lib/forms/field-renderer";
 import type { CustomEditorKey } from "@/lib/compliance/requirement-fields";
 import type { FieldMeta } from "@/lib/forms/schema-introspect";
 import type { RequirementGuidanceData } from "@/lib/ai/guidance-types";
+import { buildCitationRows, type FrameworkLabel } from "@/lib/compliance/citations";
 import type { Asset } from "@/schema/types";
 import type { RoleKey } from "@/lib/compliance/role-keys";
 import {
@@ -62,19 +63,6 @@ import { teachingLessonForCategory } from "@/lib/training/lesson-journey-map";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Law URL helpers
-// ---------------------------------------------------------------------------
-function nis2Url(ref: string): string | null {
-  const m = ref.match(/Art\.\s*(\d+)/);
-  return m ? `https://www.nis-2-directive.com/NIS_2_Directive_Article_${m[1]}.html` : null;
-}
-
-function bsigUrl(ref: string): string | null {
-  const m = ref.match(/§(\d+)/);
-  return m ? `https://www.gesetze-im-internet.de/bsig_2025/__${m[1]}.html` : null;
-}
-
-// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -90,6 +78,9 @@ export interface RequirementData {
   frameworkRef: string | null;
   importance: string | null;
   moduleRef: string | null;
+  frameworkCode: string | null;
+  referenceUrl: string | null;
+  nationalUrl: string | null;
 }
 
 export interface StatusData {
@@ -193,6 +184,9 @@ export function RequirementDetail({
   const t = useTranslations("compliance");
   const tf = useTranslations("form");
   const tc = useTranslations("common");
+  // Framework names live in the portal namespace, the same catalog the sidebar
+  // reads, so a citation is named the way the rest of the app names it.
+  const tp = useTranslations("portal");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -227,6 +221,10 @@ export function RequirementDetail({
   const isCompleted =
     status.currentStatus === "completed" || status.currentStatus === "approved";
   const isNA = status.currentStatus === "not_applicable";
+
+  const citationRows = buildCitationRows(requirement);
+  const citationLabel = (label: FrameworkLabel) =>
+    label.kind === "message" ? tp(label.key) : label.text;
 
   const [naOpen, setNaOpen] = useState(false);
   const [naReason, setNaReason] = useState("");
@@ -678,38 +676,31 @@ export function RequirementDetail({
                   <dd className="text-xs text-red-600 dark:text-red-400">{t("mandatory")}</dd>
                 </div>
               )}
-              {requirement.frameworkRef && (
-                <div className="flex items-center justify-between">
-                  <dt className="text-muted-foreground">NIS2</dt>
-                  <dd>
-                    <a
-                      href={nis2Url(requirement.frameworkRef) ?? "#"}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {requirement.frameworkRef}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
+              {/* The link sits on the framework name, not on the citation:
+                  it opens that law's source page for this category, which is
+                  not always the exact article the citation names. */}
+              {citationRows.map((row) => (
+                <div key={row.id} className="flex items-start justify-between gap-3">
+                  <dt className="shrink-0 text-muted-foreground">
+                    {row.href ? (
+                      <a
+                        href={row.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1 hover:text-foreground transition-colors"
+                      >
+                        {citationLabel(row.label)}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    ) : (
+                      citationLabel(row.label)
+                    )}
+                  </dt>
+                  <dd className="text-right text-xs text-muted-foreground">
+                    {row.citation}
                   </dd>
                 </div>
-              )}
-              {requirement.legalRef && (
-                <div className="flex items-center justify-between">
-                  <dt className="text-muted-foreground">BSIG</dt>
-                  <dd>
-                    <a
-                      href={bsigUrl(requirement.legalRef) ?? "#"}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {requirement.legalRef}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </dd>
-                </div>
-              )}
+              ))}
             </dl>
             {teachingLesson && (
               <Link

--- a/lib/compliance/citations.ts
+++ b/lib/compliance/citations.ts
@@ -1,0 +1,127 @@
+/**
+ * Legal citation rows for a requirement, resolved per framework.
+ *
+ * Kept out of role-mapping.ts and the schema modules so client components can
+ * import it without pulling drizzle-orm into the bundle. The framework enum is
+ * imported as a type only, which erases at compile time while still making a
+ * newly added framework a compile error in FRAMEWORK_CITATION_STYLE below.
+ */
+
+import type { frameworkEnum } from "@nisd2/grc-data-model/enums";
+
+type FrameworkCode = (typeof frameworkEnum.enumValues)[number];
+
+/**
+ * How a framework names itself to the reader.
+ *
+ * `message` resolves against the `portal` namespace, which already carries the
+ * framework names in all ten locales and is what the sidebar renders. That is
+ * what makes gdpr read as DSGVO in German and GDPR everywhere else.
+ *
+ * `literal` covers frameworks with no message key, whose names are the same
+ * proper noun in every locale.
+ */
+export type FrameworkLabel =
+  | { readonly kind: "message"; readonly key: string }
+  | { readonly kind: "literal"; readonly text: string };
+
+interface FrameworkCitationStyle {
+  readonly label: FrameworkLabel;
+  /**
+   * The national law transposing this framework, if it has one.
+   *
+   * This is what decides whether a requirement cites one text or two, and it
+   * cannot be read off the citation strings. NIS 2 stores the EU article in
+   * `frameworkRef` and the German transposition in `legalRef` — "Art. 21(2)(b)"
+   * against "§30(2) Nr. 2 BSIG", two citations of two different texts. Directly
+   * applicable regulations and standards have no transposition, so their
+   * `legalRef` is the same citation as `frameworkRef`, only fuller:
+   * "Art. 28" against "GDPR Art. 28(3)".
+   */
+  readonly nationalLaw: string | null;
+}
+
+/**
+ * Deliberately keyed off the framework enum rather than
+ * `complianceFramework.sidebarLabel`: that column is nullable free text, and a
+ * missing or unexpected value there must not decide how a legal citation is
+ * labelled.
+ */
+export const FRAMEWORK_CITATION_STYLE: Record<FrameworkCode, FrameworkCitationStyle> = {
+  nis2: { label: { kind: "message", key: "nis2" }, nationalLaw: "BSIG" },
+  gdpr: { label: { kind: "message", key: "dsgvo" }, nationalLaw: null },
+  iso27001: { label: { kind: "message", key: "iso27001" }, nationalLaw: null },
+  eu_ai_act: { label: { kind: "message", key: "aiact" }, nationalLaw: null },
+  eu_cra: { label: { kind: "message", key: "cra" }, nationalLaw: null },
+  arbeitsschutz: { label: { kind: "literal", text: "Arbeitsschutz" }, nationalLaw: null },
+  brandschutz: { label: { kind: "literal", text: "Brandschutz" }, nationalLaw: null },
+  bsi_grundschutz: { label: { kind: "literal", text: "BSI IT-Grundschutz" }, nationalLaw: null },
+};
+
+export interface CitationSource {
+  readonly frameworkCode: string | null;
+  readonly frameworkRef: string | null;
+  readonly legalRef: string | null;
+  /** requirement_category.reference_url — the framework's primary source. */
+  readonly referenceUrl: string | null;
+  /** requirement_category.national_url — the national transposition, if any. */
+  readonly nationalUrl: string | null;
+}
+
+export interface CitationRow {
+  readonly id: "framework" | "national";
+  readonly label: FrameworkLabel;
+  /** Rendered verbatim. A legal citation is never reformatted for looks. */
+  readonly citation: string;
+  /**
+   * The curated source page for this requirement's category, or null.
+   *
+   * Scoped to the category, not to the citation beside it: a citation may name
+   * several articles and the category carries one URL. Attaching it to the
+   * framework label rather than to the citation text is what keeps that
+   * promise honest. Never a placeholder — no URL means no link.
+   */
+  readonly href: string | null;
+}
+
+const nonEmpty = (value: string | null): string | null => {
+  const trimmed = value?.trim() ?? "";
+  return trimmed === "" ? null : trimmed;
+};
+
+const isFrameworkCode = (code: string | null): code is FrameworkCode =>
+  code !== null && Object.hasOwn(FRAMEWORK_CITATION_STYLE, code);
+
+export function buildCitationRows(source: CitationSource): readonly CitationRow[] {
+  if (!isFrameworkCode(source.frameworkCode)) return [];
+
+  const style = FRAMEWORK_CITATION_STYLE[source.frameworkCode];
+  const frameworkRef = nonEmpty(source.frameworkRef);
+  const legalRef = nonEmpty(source.legalRef);
+
+  // With a national transposition the two columns cite different texts, so each
+  // gets its own labelled row. Without one they cite the same text and the
+  // fuller of the two says everything the other would.
+  const frameworkCitation = style.nationalLaw ? frameworkRef : (legalRef ?? frameworkRef);
+
+  const rows: readonly (CitationRow | null)[] = [
+    frameworkCitation === null
+      ? null
+      : {
+          id: "framework",
+          label: style.label,
+          citation: frameworkCitation,
+          href: nonEmpty(source.referenceUrl),
+        },
+    style.nationalLaw === null || legalRef === null
+      ? null
+      : {
+          id: "national",
+          label: { kind: "literal", text: style.nationalLaw },
+          citation: legalRef,
+          href: nonEmpty(source.nationalUrl),
+        },
+  ];
+
+  return rows.filter((row) => row !== null);
+}

--- a/server/trpc/routers/requirement.ts
+++ b/server/trpc/routers/requirement.ts
@@ -51,6 +51,11 @@ export const requirementRouter = router({
               id: true,
               code: true,
               slug: true,
+              // Curated source links for the citation block. Without these the
+              // UI has to guess a URL from the citation text, which lands the
+              // reader in the wrong law.
+              referenceUrl: true,
+              nationalUrl: true,
             },
             with: {
               framework: { columns: { code: true } },


### PR DESCRIPTION
The citation block in the requirement sidebar was hardcoded to NIS 2. It
rendered <dt>NIS2</dt> over frameworkRef and <dt>BSIG</dt> over legalRef for
every framework, and built both hrefs by regexing an article or paragraph
number out of the citation text.

Every non-NIS2 framework was mislabelled, several with a working link into
the wrong law:

  GDPR    frameworkRef "Art. 28" rendered as NIS2 Art. 28 and linked to NIS 2
          Article 28 (domain name registration data) when GDPR Art. 28 is the
          processor article. Its legalRef "GDPR Art. 28(3)" has no section
          sign, so it was a dead link under a BSIG label.
  EU CRA  legalRef "CRA Annex I Part I §1" matched the section regex and
          linked to §1 BSIG.
  ISO     clause refs match neither regex, so all 116 requirements showed two
          wrong labels over two dead links.

Citations now come from the data instead of a regex. requirement_category
already carries referenceUrl (the framework's primary source) and nationalUrl
(the national transposition), both curated per category, so getByCode selects
them and the page hands them to the component with the framework code.

lib/compliance/citations.ts maps each framework in the enum to its display
label and, where one exists, its national transposition. That map decides how
many rows a requirement gets. NIS 2 has a transposition, so its two columns
cite two different texts ("Art. 21(2)(b)" and "§30(2) Nr. 2 BSIG") and each
gets its own labelled row. Directly applicable regulations and standards have
none, so legalRef is the same citation as frameworkRef, only fuller, and one
row says everything.

Labels resolve through the portal message namespace, which already names every
framework in all ten locales, so gdpr reads as DSGVO in German and GDPR
elsewhere. No new message keys.

The link moved from the citation to the framework name. A citation can name
several articles while the category carries one URL, so the link promises only
the law it is named after, opened at this category's source page. Where no URL
exists the citation renders as plain text; nothing ever links to "#".

Verified against the live database: 165 requirements across nis2 and iso27001
produce a labelled row each, with no dead or placeholder links.
