### PR TITLE
chore(questionnaire): add a publish path and name the source of truth

### DIFF
--- a/packages/nis2-supply-chain-questionnaire-schema/README.md
+++ b/packages/nis2-supply-chain-questionnaire-schema/README.md
@@ -7,6 +7,17 @@
 
 It exists because every German Mittelstand procurement team is currently inventing its own supplier questionnaire from scratch and sending suppliers five slightly different versions of the same NIS2-anchored questions. This repo is one shared, openly maintained, legally-anchored questionnaire that any of them can adopt or fork.
 
+## Where this is developed
+
+The source of truth for this package is the `packages/nis2-supply-chain-questionnaire-schema/`
+directory of the [open-isms](https://github.com/NISD2/open-isms) monorepo, because that is the
+copy the supplier portal imports and therefore the copy that is actually exercised. This
+repository is a publication mirror, updated by running `scripts/push-questionnaire-schema.sh`
+in the monorepo.
+
+Practical consequence: open issues and pull requests here, but expect the fix to land in the
+monorepo first and arrive here on the next publish.
+
 ## What it isn't
 
 Not an app, not a SaaS, not a UI. There is no backend, no auth, no database. Bring your own.
@@ -17,7 +28,7 @@ The reference implementation is the supplier portal at [nisd2.eu](https://nisd2.
 
 - **59 fields** across 6 sections (`profile`, `security_practices`, `saas_technical`, `on_prem_technical`, `pro_services`, `managed_services`)
 - Each field anchored to an **EU-level** primary source: NIS2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance v1.0, GDPR Art. 28, or the Cyber Resilience Act
-- Two locales: English and German
+- Nine locales: English, German, French, Italian, Spanish, Polish, Czech, Portuguese and Romanian
 - Published as a Zod schema (TypeScript), a JSON artefact, and a JSON Schema for non-TS consumers
 
 ## What's deliberately out of scope

--- a/scripts/push-questionnaire-schema.sh
+++ b/scripts/push-questionnaire-schema.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Push packages/nis2-supply-chain-questionnaire-schema/ to
+# github.com:NISD2/nis2-supply-chain-questionnaire-schema
+# with all AI co-author lines stripped from commit messages.
+#
+# The monorepo copy is the source of truth: it is what the supplier portal
+# imports (workspace:*), so it is the version that is actually exercised.
+# The standalone repo is a publication mirror for the people the format is
+# meant for, who adopt or fork it without running our platform.
+#
+# Without this script there was no way to publish at all, and the mirror sat
+# two months behind: the v3.1.0 AI SBOM fields and seven added locales existed
+# only in the monorepo. Run this after a change worth publishing.
+#
+# Usage: bash scripts/push-questionnaire-schema.sh [--dry-run]
+
+set -euo pipefail
+
+PREFIX="packages/nis2-supply-chain-questionnaire-schema"
+REMOTE_URL="git@github.com:NISD2/nis2-supply-chain-questionnaire-schema.git"
+REMOTE_BRANCH="main"
+SPLIT_BRANCH="questionnaire-schema-split-$$"
+DRY_RUN="${1:-}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -d "$PREFIX" ]; then
+  echo "error: $PREFIX not found at repo root" >&2
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo "error: working tree has uncommitted changes; filter-branch will refuse to run" >&2
+  echo "       commit or stash before pushing:" >&2
+  git status --short >&2
+  exit 1
+fi
+
+export FILTER_BRANCH_SQUELCH_WARNING=1
+
+echo "→ Splitting $PREFIX into $SPLIT_BRANCH"
+git subtree split --prefix="$PREFIX" -b "$SPLIT_BRANCH" >/dev/null
+
+echo "→ Stripping AI co-author lines"
+FILTER_LOG=$(mktemp)
+if ! git filter-branch --force --msg-filter '
+  sed -e "/^Co-Authored-By: Claude/d" \
+      -e "/^Co-authored-by: Claude/d" \
+      -e "/^🤖 Generated with/d"
+' --tag-name-filter cat -- "$SPLIT_BRANCH" >"$FILTER_LOG" 2>&1; then
+  echo "error: filter-branch failed:" >&2
+  cat "$FILTER_LOG" >&2
+  rm -f "$FILTER_LOG"
+  git branch -D "$SPLIT_BRANCH" >/dev/null 2>&1 || true
+  exit 1
+fi
+rm -f "$FILTER_LOG"
+
+git update-ref -d "refs/original/refs/heads/$SPLIT_BRANCH" 2>/dev/null || true
+
+CLEAN_HEAD=$(git rev-parse "$SPLIT_BRANCH")
+REMAINING=$(git log "$SPLIT_BRANCH" --format=%B | grep -c "Co-Authored-By: Claude" || true)
+
+if [ "$REMAINING" -ne 0 ]; then
+  echo "error: $REMAINING Claude line(s) remain after rewrite; aborting" >&2
+  git branch -D "$SPLIT_BRANCH" >/dev/null 2>&1 || true
+  exit 1
+fi
+
+echo "→ Clean split head: $CLEAN_HEAD ($REMAINING Claude lines)"
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+  echo "→ Dry run; not pushing. Inspect branch: $SPLIT_BRANCH"
+  exit 0
+fi
+
+echo "→ Force-pushing $SPLIT_BRANCH → $REMOTE_URL $REMOTE_BRANCH"
+git push --force "$REMOTE_URL" "$SPLIT_BRANCH:$REMOTE_BRANCH"
+
+echo "→ Cleaning up local split branch"
+git branch -D "$SPLIT_BRANCH" >/dev/null 2>&1 || true
+
+echo "✓ done. Verify at https://github.com/NISD2/nis2-supply-chain-questionnaire-schema/commits/main"


### PR DESCRIPTION
## Why

The questionnaire package had no way to reach its public repo. `grc-data-model` and `incident-notification-schema` each ship a `scripts/push-*.sh`; this one did not. The result is visible: [NISD2/nis2-supply-chain-questionnaire-schema](https://github.com/NISD2/nis2-supply-chain-questionnaire-schema) last moved on **11 June**, while the monorepo copy gained the v3.1.0 AI SBOM fields and seven more locales. Nothing was watching, because nothing could push.

The ambiguity mattered beyond staleness: with two copies and no stated direction, a contributor could reasonably have edited either one.

## What

**`scripts/push-questionnaire-schema.sh`** — same subtree-split and co-author-stripping flow as the two existing scripts, so publishing is one command.

**Names the arrangement in the package README** rather than leaving it implied. The monorepo copy is the source of truth because it is what the supplier portal imports over `workspace:*`, so it is the copy that is actually exercised. The standalone repo is a publication mirror for the procurement teams the format is written for, who adopt it without running our platform. Readers are told to expect fixes to land in the monorepo first.

**Corrects the README's locale claim.** It said "Two locales: English and German". The package ships nine: `en, de, fr, it, es, pl, cs, pt, ro`. The field and section counts it claims, 59 and 6, are accurate and unchanged.

## Verification

`--dry-run` produces a clean split head with 0 AI co-author lines. Nothing is published by this PR; the script is run deliberately.

No code changes: one new script, one README. The schema, fields and locales are untouched.

## Note for a follow-up

Its CIR citations were re-verified against the OJ text during yesterday's legal audit and are all semantically correct, including the `5.1.4(b)-(h)` and `5.1.2(a)-(b)` sub-point mapping. The questionnaire was more accurate than the platform data was before #56.