### PR TITLE
refactor(assessment): one sign-off completion write instead of five

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - run: bun run test
         working-directory: packages/grc-data-model
 
+      # Root unit tests under lib/ and server/. These existed and passed but
+      # nothing ran them: the step above is scoped to a single package, so a
+      # test file added at the root was never executed by CI. Kept to the two
+      # directories with no database dependency; e2e/ runs in its own workflow.
+      - run: bun run test:unit
+
       # REFERENCE.md is generated from the framework data and is published as
       # the public reference. It silently went stale after a correction pass,
       # leaving it citing CIR Annex points that do not exist in the OJ text.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test:unit": "bun test lib server",
     "db:generate": "drizzle-kit generate",
     "db:generate:grc": "bun run --env-file=$PWD/.env --cwd packages/grc-data-model db:generate",
     "db:generate:isms": "bun run --env-file=$PWD/.env --cwd packages/isms-schema db:generate",

--- a/server/trpc/helpers/assessment-helpers.ts
+++ b/server/trpc/helpers/assessment-helpers.ts
@@ -180,8 +180,13 @@ export async function propagateSatisfaction(
   const now = new Date();
   const signerIsAdmin = signedOffRole === "admin";
 
+  // Same stable lock order as the bulk sign-off loops. This one is the reason
+  // they need it: propagation runs inside an ordinary sign-off request, so it
+  // is the loop most likely to be holding a row a concurrent bulk call wants.
+  const orderedTargets = [...targetStatuses].sort((a, b) => a.id.localeCompare(b.id));
+
   await db.transaction(async (tx) => {
-    for (const target of targetStatuses) {
+    for (const target of orderedTargets) {
       if (target.status === "completed" || target.status === "approved") continue;
 
       const required = target.requirement.requiredSignOffRole;

--- a/server/trpc/helpers/assessment-helpers.ts
+++ b/server/trpc/helpers/assessment-helpers.ts
@@ -7,6 +7,7 @@ import {
 import type { SignOffSnapshot } from "@nisd2/isms-schema/tables/assessments";
 import type { Database } from "@/lib/db";
 import { recordSignOffChainEntry } from "./sign-off-chain";
+import { completedSignOffValues, snapshotForVersion } from "./sign-off-completion";
 
 /** Build a sign-off snapshot capturing company profile + operational counts at sign-off time */
 export async function buildSignOffSnapshot(
@@ -191,19 +192,24 @@ export async function propagateSatisfaction(
         continue;
       }
 
+      // The snapshot arrives from the source requirement's sign-off, so it
+      // carries the source's templateVersion. Re-stamp it with the target's
+      // own version: the column below already recorded the target's, and a
+      // row whose snapshot claims a different version than its column escapes
+      // invalidation when the target requirement is later bumped.
+      const targetSnapshot = snapshotForVersion(snapshot, target.requirement.templateVersion);
+
       await tx
         .update(companyRequirementStatus)
-        .set({
-          status: "completed",
-          signedOffBy: userId,
-          signedOffAt: now,
-          signedOffRole,
-          signedOffTemplateVersion: target.requirement.templateVersion,
-          signOffSnapshot: snapshot,
-          completedAt: now,
-          completedBy: userId,
-          updatedAt: now,
-        })
+        .set(
+          completedSignOffValues({
+            userId,
+            signedOffRole,
+            templateVersion: target.requirement.templateVersion,
+            snapshot: targetSnapshot,
+            now,
+          }),
+        )
         .where(eq(companyRequirementStatus.id, target.id));
 
       await recordSignOffChainEntry(tx as unknown as Database, {
@@ -214,7 +220,7 @@ export async function propagateSatisfaction(
         signedOffRole,
         source: "module",
         templateVersion: target.requirement.templateVersion,
-        companyProfile: snapshot.companyProfile ?? {},
+        companyProfile: targetSnapshot.companyProfile ?? {},
         data: { sourceRequirementId, propagation: "cross-framework" },
       });
 

--- a/server/trpc/helpers/sign-off-completion.test.ts
+++ b/server/trpc/helpers/sign-off-completion.test.ts
@@ -57,6 +57,25 @@ describe("completedSignOffValues", () => {
     expect(values.signedOffAt).toBe(now);
     expect(values.updatedAt).toBe(now);
   });
+
+  test("defaults to completed and takes approved for intake", () => {
+    expect(values.status).toBe("completed");
+
+    const approved = completedSignOffValues({
+      userId: "user-1",
+      signedOffRole: "ciso",
+      templateVersion: 3,
+      snapshot: snapshot(3),
+      now,
+      status: "approved",
+    });
+    expect(approved.status).toBe("approved");
+    // The evidentiary columns do not depend on which terminal status it lands
+    // on: an approved intake is signed off exactly as a completed editor
+    // sign-off is.
+    expect(approved.signedOffTemplateVersion).toBe(3);
+    expect(approved.signOffSnapshot).toEqual(values.signOffSnapshot);
+  });
 });
 
 describe("snapshotForVersion", () => {

--- a/server/trpc/helpers/sign-off-completion.test.ts
+++ b/server/trpc/helpers/sign-off-completion.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import type { SignOffSnapshot } from "@nisd2/isms-schema/tables/assessments";
+import {
+  completedSignOffValues,
+  effectiveSignOffRole,
+  signerMeetsRequiredRole,
+  snapshotForVersion,
+} from "./sign-off-completion";
+
+const snapshot = (templateVersion: number): SignOffSnapshot => ({
+  templateVersion,
+  derivedData: { asset: { total: 12 } },
+  companyProfile: { cisoName: "A. Beispiel" },
+});
+
+describe("completedSignOffValues", () => {
+  const now = new Date("2026-08-23T10:00:00.000Z");
+  const values = completedSignOffValues({
+    userId: "user-1",
+    signedOffRole: "ciso",
+    templateVersion: 3,
+    snapshot: snapshot(3),
+    now,
+  });
+
+  // The regression this helper exists for: bulkConfirmModuleRef wrote every
+  // other column and silently left this one null, so rows signed through it
+  // carried no record of which requirement text was signed.
+  test("records the template version that was signed", () => {
+    expect(values.signedOffTemplateVersion).toBe(3);
+  });
+
+  test("writes every column the sign-off contract requires", () => {
+    expect(Object.keys(values).sort()).toEqual([
+      "completedAt",
+      "completedBy",
+      "signOffSnapshot",
+      "signedOffAt",
+      "signedOffBy",
+      "signedOffRole",
+      "signedOffTemplateVersion",
+      "status",
+      "updatedAt",
+    ]);
+  });
+
+  test("attributes completion and sign-off to the same user", () => {
+    expect(values.completedBy).toBe("user-1");
+    expect(values.signedOffBy).toBe("user-1");
+    expect(values.status).toBe("completed");
+  });
+
+  // The old hand-written writes each called new Date() per field, so a row
+  // could carry three timestamps a millisecond apart.
+  test("stamps one instant across every timestamp", () => {
+    expect(values.completedAt).toBe(now);
+    expect(values.signedOffAt).toBe(now);
+    expect(values.updatedAt).toBe(now);
+  });
+});
+
+describe("snapshotForVersion", () => {
+  test("re-stamps the version and keeps the company-scoped half", () => {
+    const base = snapshot(1);
+    const restamped = snapshotForVersion(base, 7);
+
+    expect(restamped.templateVersion).toBe(7);
+    expect(restamped.derivedData).toEqual(base.derivedData);
+    expect(restamped.companyProfile).toEqual(base.companyProfile);
+  });
+
+  // A batch re-stamps one base snapshot per row. If that aliased the base,
+  // each row would overwrite the previous row's version.
+  test("does not mutate the base it re-stamps", () => {
+    const base = snapshot(1);
+    snapshotForVersion(base, 7);
+    snapshotForVersion(base, 9);
+
+    expect(base.templateVersion).toBe(1);
+  });
+});
+
+describe("effectiveSignOffRole", () => {
+  test("uses the role the requirement names", () => {
+    expect(effectiveSignOffRole("ceo")).toBe("ceo");
+  });
+
+  // An unnamed signer must not mean "anyone may sign".
+  test("falls back to the platform default when none is named", () => {
+    expect(effectiveSignOffRole(null)).toBe("ciso");
+  });
+});
+
+describe("signerMeetsRequiredRole", () => {
+  const check = (signerRole: string, requiredSignOffRole: string | null, sessionRole = "member") =>
+    signerMeetsRequiredRole({ sessionRole, signerRole, requiredSignOffRole });
+
+  test("admits the named signer", () => {
+    expect(check("ceo", "ceo")).toBe(true);
+  });
+
+  test("refuses a signer who does not hold the named role", () => {
+    expect(check("ciso", "ceo")).toBe(false);
+  });
+
+  test("applies the default when the requirement names no role", () => {
+    expect(check("ciso", null)).toBe(true);
+    expect(check("ceo", null)).toBe(false);
+  });
+
+  // Matches the single sign-off path, which lets an admin close a
+  // requirement without holding its role.
+  test("lets an admin session bypass the role", () => {
+    expect(check("ciso", "ceo", "admin")).toBe(true);
+  });
+
+  // getSignerRole returns user.jobTitle, which is free text. An arbitrary
+  // job title must not satisfy a named role.
+  test("does not admit an arbitrary job title", () => {
+    expect(check("Head of Everything", "ceo")).toBe(false);
+    expect(check("Head of Everything", null)).toBe(false);
+  });
+});

--- a/server/trpc/helpers/sign-off-completion.ts
+++ b/server/trpc/helpers/sign-off-completion.ts
@@ -41,12 +41,17 @@ export function signerMeetsRequiredRole(args: {
 /**
  * The column values that mark a requirement signed off.
  *
- * This exists because the four sign-off paths each wrote this set by hand and
- * had already drifted: bulkConfirmModuleRef omitted signedOffTemplateVersion,
- * so rows completed through the bulk module-confirm button carried a null
- * where every other path recorded which version of the requirement text was
- * actually signed. Going through one function makes that class of omission a
- * type error instead of a silent gap in the audit trail.
+ * This exists because every sign-off path wrote this set by hand and they had
+ * drifted: bulkConfirmModuleRef omitted signedOffTemplateVersion, and the
+ * intake path omitted both it and signOffSnapshot, so rows signed through
+ * those carried nulls where the others recorded which version of the
+ * requirement text was signed and what the company looked like at the time.
+ * Going through one function makes that class of omission a type error
+ * instead of a silent gap in the audit trail.
+ *
+ * Not every terminal write is a sign-off. `updateRequirementStatus` moves a
+ * requirement to completed without signing it, and intake derives progress
+ * from saved answers without a signer. Those deliberately do not call this.
  *
  * `now` is passed in rather than read here so every column on a row, and every
  * row in a batch, carries the same instant.
@@ -57,9 +62,14 @@ export function completedSignOffValues(args: {
   templateVersion: number;
   snapshot: SignOffSnapshot;
   now: Date;
+  /**
+   * The terminal status to write. Intake treats approval as the sign-off act
+   * and lands on "approved"; the assessment paths land on "completed".
+   */
+  status?: "completed" | "approved";
 }) {
   return {
-    status: "completed" as const,
+    status: args.status ?? ("completed" as const),
     completedAt: args.now,
     completedBy: args.userId,
     signedOffBy: args.userId,

--- a/server/trpc/helpers/sign-off-completion.ts
+++ b/server/trpc/helpers/sign-off-completion.ts
@@ -1,0 +1,89 @@
+import type { SignOffSnapshot } from "@nisd2/isms-schema/tables/assessments";
+import { DEFAULT_SIGN_OFF_ROLE, type RoleKey } from "@/lib/compliance/role-keys";
+
+/**
+ * The role that must sign a requirement off. Requirements that do not name one
+ * fall back to the platform default rather than accepting any signer.
+ */
+export function effectiveSignOffRole(requiredSignOffRole: string | null): RoleKey {
+  return (requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
+}
+
+/**
+ * Whether this signer may complete a requirement on their own.
+ *
+ * Admins bypass, matching the single sign-off path. The four sign-off entry
+ * points share this predicate but react differently: the single-requirement
+ * paths throw FORBIDDEN, because the caller asked for that specific row and
+ * silence would look like success; the bulk paths filter the row out, because
+ * a batch spans requirements with different required signers and one
+ * unsignable row should not fail the rest. That difference is deliberate and
+ * stays visible at each call site.
+ */
+export function signerMeetsRequiredRole(args: {
+  sessionRole: string;
+  /**
+   * What the signer actually holds, from getSignerRole: their job title if
+   * they set one, otherwise their session role. Deliberately a plain string,
+   * not a RoleKey — job titles are user-entered free text, and the stored
+   * `signed_off_role` column is varchar. Only the *required* side is a
+   * closed set.
+   */
+  signerRole: string;
+  requiredSignOffRole: string | null;
+}): boolean {
+  return (
+    args.sessionRole === "admin" ||
+    args.signerRole === effectiveSignOffRole(args.requiredSignOffRole)
+  );
+}
+
+/**
+ * The column values that mark a requirement signed off.
+ *
+ * This exists because the four sign-off paths each wrote this set by hand and
+ * had already drifted: bulkConfirmModuleRef omitted signedOffTemplateVersion,
+ * so rows completed through the bulk module-confirm button carried a null
+ * where every other path recorded which version of the requirement text was
+ * actually signed. Going through one function makes that class of omission a
+ * type error instead of a silent gap in the audit trail.
+ *
+ * `now` is passed in rather than read here so every column on a row, and every
+ * row in a batch, carries the same instant.
+ */
+export function completedSignOffValues(args: {
+  userId: string;
+  signedOffRole: string;
+  templateVersion: number;
+  snapshot: SignOffSnapshot;
+  now: Date;
+}) {
+  return {
+    status: "completed" as const,
+    completedAt: args.now,
+    completedBy: args.userId,
+    signedOffBy: args.userId,
+    signedOffAt: args.now,
+    signedOffRole: args.signedOffRole,
+    signedOffTemplateVersion: args.templateVersion,
+    signOffSnapshot: args.snapshot,
+    updatedAt: args.now,
+  };
+}
+
+/**
+ * Re-stamp a batch snapshot for one requirement.
+ *
+ * The expensive half of a snapshot (company profile, asset and risk counts) is
+ * company-scoped, so a batch builds it once. Only templateVersion varies per
+ * requirement, and it has to: sign-off invalidation compares a bumped
+ * requirement against `sign_off_snapshot->>'templateVersion'`, so a row
+ * carrying a neighbour's version silently escapes review when its own
+ * requirement text changes.
+ */
+export function snapshotForVersion(
+  base: SignOffSnapshot,
+  templateVersion: number,
+): SignOffSnapshot {
+  return { ...base, templateVersion };
+}

--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -19,7 +19,6 @@ import {
 } from "@/schema";
 import { or } from "drizzle-orm";
 import { frameworkEnum } from "@nisd2/grc-data-model/enums";
-import { DEFAULT_SIGN_OFF_ROLE, type RoleKey } from "@/lib/compliance/role-keys";
 import { enforceAssignment, verifyAssessmentOwnership, getSignerRole } from "../guards";
 import { sendMail, contactEmailChangedEmail } from "@/lib/mail";
 import { logAudit } from "@/lib/audit";
@@ -30,6 +29,12 @@ import { addYears } from "date-fns";
 import { buildSignOffSnapshot, recalculateProgress, propagateSatisfaction } from "../helpers/assessment-helpers";
 import { createAssessmentsForFrameworks, processTeamRoleAssignments } from "../helpers/setup-helpers";
 import { recordSignOffChainEntry } from "../helpers/sign-off-chain";
+import {
+  completedSignOffValues,
+  effectiveSignOffRole,
+  signerMeetsRequiredRole,
+  snapshotForVersion,
+} from "../helpers/sign-off-completion";
 
 import type { Database } from "@/lib/db";
 
@@ -514,8 +519,6 @@ export const assessmentRouter = router({
       });
 
       const signedOffRole = await getSignerRole(ctx.db, ctx.userId, ctx.session.role);
-      const effectiveRole: RoleKey =
-        (statusRow.requirement.requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
 
       // Audit B-2 + B-5 (2026-06-10): everything that touches the
       // (assignments, status row, chain) trio happens in one transaction
@@ -566,10 +569,18 @@ export const assessmentRouter = router({
             return { row: partial, snapshot: null };
           }
         } else {
-          if (ctx.session.role !== "admin" && signedOffRole !== effectiveRole) {
+          // Single-requirement path: refuse loudly. See signerMeetsRequiredRole.
+          if (
+            !signerMeetsRequiredRole({
+              sessionRole: ctx.session.role,
+              signerRole: signedOffRole,
+              requiredSignOffRole: statusRow.requirement.requiredSignOffRole,
+            })
+          ) {
+            const required = effectiveSignOffRole(statusRow.requirement.requiredSignOffRole);
             throw new TRPCError({
               code: "FORBIDDEN",
-              message: `This requirement requires sign-off by ${effectiveRole.toUpperCase()}.`,
+              message: `This requirement requires sign-off by ${required.toUpperCase()}.`,
             });
           }
 
@@ -596,17 +607,15 @@ export const assessmentRouter = router({
 
         const [closed] = await tx
           .update(companyRequirementStatus)
-          .set({
-            status: "completed",
-            signedOffBy: ctx.userId,
-            signedOffAt: new Date(),
-            signedOffRole,
-            signedOffTemplateVersion: statusRow.requirement.templateVersion,
-            signOffSnapshot: snapshot,
-            completedAt: new Date(),
-            completedBy: ctx.userId,
-            updatedAt: new Date(),
-          })
+          .set(
+            completedSignOffValues({
+              userId: ctx.userId,
+              signedOffRole,
+              templateVersion: statusRow.requirement.templateVersion,
+              snapshot,
+              now: new Date(),
+            }),
+          )
           .where(eq(companyRequirementStatus.id, input.statusId))
           .returning();
 
@@ -676,8 +685,6 @@ export const assessmentRouter = router({
       });
 
       const signedOffRole = await getSignerRole(ctx.db, ctx.userId, ctx.session.role);
-      const effectiveRole: RoleKey =
-        (statusRow.requirement.requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
 
       // Audit B-2 (2026-06-10): assignment + status + chain entry inside
       // the same tx so a partial commit cannot leave the chain disagreeing
@@ -700,10 +707,18 @@ export const assessmentRouter = router({
             message: "This requirement has assigned signers; sign off through the assignment flow.",
           });
         }
-        if (ctx.session.role !== "admin" && signedOffRole !== effectiveRole) {
+        // Single-requirement path: refuse loudly. See signerMeetsRequiredRole.
+        if (
+          !signerMeetsRequiredRole({
+            sessionRole: ctx.session.role,
+            signerRole: signedOffRole,
+            requiredSignOffRole: statusRow.requirement.requiredSignOffRole,
+          })
+        ) {
+          const required = effectiveSignOffRole(statusRow.requirement.requiredSignOffRole);
           throw new TRPCError({
             code: "FORBIDDEN",
-            message: `This requirement requires sign-off by ${effectiveRole.toUpperCase()}.`,
+            message: `This requirement requires sign-off by ${required.toUpperCase()}.`,
           });
         }
 
@@ -729,17 +744,15 @@ export const assessmentRouter = router({
 
         const [updated] = await tx
           .update(companyRequirementStatus)
-          .set({
-            status: "completed",
-            completedAt: new Date(),
-            completedBy: ctx.userId,
-            signedOffBy: ctx.userId,
-            signedOffAt: new Date(),
-            signedOffRole,
-            signedOffTemplateVersion: statusRow.requirement.templateVersion,
-            signOffSnapshot: snapshot,
-            updatedAt: new Date(),
-          })
+          .set(
+            completedSignOffValues({
+              userId: ctx.userId,
+              signedOffRole,
+              templateVersion: statusRow.requirement.templateVersion,
+              snapshot,
+              now: new Date(),
+            }),
+          )
           .where(eq(companyRequirementStatus.id, input.statusId))
           .returning();
 
@@ -829,9 +842,12 @@ export const assessmentRouter = router({
       );
       const toConfirm = moduleRows.filter((r) => {
         if (confirmAssignedIds.has(r.statusId)) return false;
-        const effectiveRole: RoleKey =
-          (r.requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
-        return ctx.session.role === "admin" || confirmerRole === effectiveRole;
+        // Bulk path: skip, don't throw. See signerMeetsRequiredRole.
+        return signerMeetsRequiredRole({
+          sessionRole: ctx.session.role,
+          signerRole: confirmerRole,
+          requiredSignOffRole: r.requiredSignOffRole,
+        });
       });
       if (toConfirm.length === 0) return { confirmed: 0 };
 
@@ -847,36 +863,39 @@ export const assessmentRouter = router({
 
       const now = new Date();
       const signedOffRole = confirmerRole;
-      const snapshot = await buildSignOffSnapshot(ctx.db, ctx.companyId, toConfirm[0].templateVersion);
+      // Company-scoped half of the snapshot, built once; each row re-stamps
+      // its own templateVersion below.
+      const baseSnapshot = await buildSignOffSnapshot(ctx.db, ctx.companyId, toConfirm[0].templateVersion);
 
-      // Audit B-2 (2026-06-10): bulk update + per-row chain entries inside
-      // one tx. Returning the actually-updated rows from the bulk update
-      // lets the chain loop skip rows that another concurrent writer
-      // already moved to completed/approved.
+      // Audit B-2 (2026-06-10): status writes + per-row chain entries inside
+      // one tx. Each row is written individually and only chained if its own
+      // update returned, so a row another writer already moved to
+      // completed/approved is skipped rather than re-signed.
       const updated = await ctx.db.transaction(async (tx) => {
-        const updatedRows = await tx
-          .update(companyRequirementStatus)
-          .set({
-            status: "completed",
-            completedAt: now,
-            completedBy: ctx.userId,
-            signedOffBy: ctx.userId,
-            signedOffAt: now,
-            signedOffRole,
-            signOffSnapshot: snapshot,
-            updatedAt: now,
-          })
-          .where(
-            and(
-              inArray(companyRequirementStatus.id, toConfirm.map((r) => r.statusId)),
-              sql`${companyRequirementStatus.status} NOT IN ('completed', 'approved')`,
-            ),
-          )
-          .returning({ id: companyRequirementStatus.id });
-
-        const updatedSet = new Set(updatedRows.map((r) => r.id));
+        const confirmed: string[] = [];
         for (const row of toConfirm) {
-          if (!updatedSet.has(row.statusId)) continue;
+          const rowSnapshot = snapshotForVersion(baseSnapshot, row.templateVersion);
+          const [updatedRow] = await tx
+            .update(companyRequirementStatus)
+            .set(
+              completedSignOffValues({
+                userId: ctx.userId,
+                signedOffRole,
+                templateVersion: row.templateVersion,
+                snapshot: rowSnapshot,
+                now,
+              }),
+            )
+            .where(
+              and(
+                eq(companyRequirementStatus.id, row.statusId),
+                sql`${companyRequirementStatus.status} NOT IN ('completed', 'approved')`,
+              ),
+            )
+            .returning({ id: companyRequirementStatus.id });
+
+          if (!updatedRow) continue;
+
           await recordSignOffChainEntry(tx as unknown as Database, {
             companyId: ctx.companyId,
             statusId: row.statusId,
@@ -885,12 +904,14 @@ export const assessmentRouter = router({
             signedOffRole,
             source: "module_confirm",
             templateVersion: row.templateVersion,
-            companyProfile: snapshot.companyProfile ?? {},
+            companyProfile: rowSnapshot.companyProfile ?? {},
             data: { moduleRef: row.moduleRef, code: row.requirementCode },
           });
+
+          confirmed.push(updatedRow.id);
         }
 
-        return updatedRows;
+        return confirmed;
       });
 
       await recalculateProgress(ctx.db, input.assessmentId);
@@ -966,35 +987,49 @@ export const assessmentRouter = router({
       );
       const signableRows = rows.filter((row) => {
         if (assignedStatusIds.has(row.statusId)) return false;
-        const effectiveRole: RoleKey =
-          (row.requiredSignOffRole as RoleKey | null) ?? DEFAULT_SIGN_OFF_ROLE;
-        return ctx.session.role === "admin" || signedOffRole === effectiveRole;
+        // Bulk path: skip, don't throw. See signerMeetsRequiredRole.
+        return signerMeetsRequiredRole({
+          sessionRole: ctx.session.role,
+          signerRole: signedOffRole,
+          requiredSignOffRole: row.requiredSignOffRole,
+        });
       });
 
       if (signableRows.length === 0) return { signedOff: 0 };
 
       const now = new Date();
-      const snapshot = await buildSignOffSnapshot(ctx.db, ctx.companyId, signableRows[0].templateVersion);
+      // Company-scoped half of the snapshot, built once; each row re-stamps
+      // its own templateVersion below.
+      const baseSnapshot = await buildSignOffSnapshot(ctx.db, ctx.companyId, signableRows[0].templateVersion);
 
-      // Audit B-2 (2026-06-10): per-row chain entry inside one tx.
+      // Audit B-2 (2026-06-10): per-row chain entry inside one tx. The status
+      // guard is repeated on the write, not just in the read above, so a row
+      // another writer completed between the two is skipped rather than
+      // re-signed under this caller's name.
       const signedOff = await ctx.db.transaction(async (tx) => {
-        let count = 0;
+        const completed: string[] = [];
         for (const row of signableRows) {
-          const rowSnapshot = { ...snapshot, templateVersion: row.templateVersion };
-          await tx
+          const rowSnapshot = snapshotForVersion(baseSnapshot, row.templateVersion);
+          const [updatedRow] = await tx
             .update(companyRequirementStatus)
-            .set({
-              status: "completed",
-              completedAt: now,
-              completedBy: ctx.userId,
-              signedOffBy: ctx.userId,
-              signedOffAt: now,
-              signedOffRole,
-              signedOffTemplateVersion: row.templateVersion,
-              signOffSnapshot: rowSnapshot,
-              updatedAt: now,
-            })
-            .where(eq(companyRequirementStatus.id, row.statusId));
+            .set(
+              completedSignOffValues({
+                userId: ctx.userId,
+                signedOffRole,
+                templateVersion: row.templateVersion,
+                snapshot: rowSnapshot,
+                now,
+              }),
+            )
+            .where(
+              and(
+                eq(companyRequirementStatus.id, row.statusId),
+                sql`${companyRequirementStatus.status} NOT IN ('completed', 'approved')`,
+              ),
+            )
+            .returning({ id: companyRequirementStatus.id });
+
+          if (!updatedRow) continue;
 
           await recordSignOffChainEntry(tx as unknown as Database, {
             companyId: ctx.companyId,
@@ -1008,9 +1043,9 @@ export const assessmentRouter = router({
             data: { code: row.code, bulkOf: "category", categoryId: input.categoryId },
           });
 
-          count++;
+          completed.push(updatedRow.id);
         }
-        return count;
+        return completed.length;
       });
 
       await recalculateProgress(ctx.db, input.assessmentId);

--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -828,8 +828,15 @@ export const assessmentRouter = router({
       // (admin bypass matches signOff), nor an N-of-M requirement whose
       // assigned signers must sign individually. See bulkSignOffCategory.
       const confirmerRole = await getSignerRole(ctx.db, ctx.userId, ctx.session.role);
+      // not_applicable is excluded here as it is in bulkSignOffCategory:
+      // a requirement documented as out of scope must not come back signed
+      // off as done while its is_applicable flag still says otherwise.
       const moduleRows = rows.filter(
-        (r) => r.moduleRef && r.currentStatus !== "completed" && r.currentStatus !== "approved",
+        (r) =>
+          r.moduleRef &&
+          r.currentStatus !== "completed" &&
+          r.currentStatus !== "approved" &&
+          r.currentStatus !== "not_applicable",
       );
       if (moduleRows.length === 0) return { confirmed: 0 };
       const confirmAssignedIds = new Set(
@@ -850,6 +857,11 @@ export const assessmentRouter = router({
         });
       });
       if (toConfirm.length === 0) return { confirmed: 0 };
+
+      // Rows are locked in a stable order so two overlapping bulk calls, or a
+      // concurrent sign-off propagating cross-framework credits, cannot take
+      // the same two locks in opposite orders and deadlock.
+      toConfirm.sort((a, b) => a.statusId.localeCompare(b.statusId));
 
       const categoryIds = [...new Set(toConfirm.map((r) => r.categoryId))];
       for (const categoryId of categoryIds) {
@@ -889,7 +901,7 @@ export const assessmentRouter = router({
             .where(
               and(
                 eq(companyRequirementStatus.id, row.statusId),
-                sql`${companyRequirementStatus.status} NOT IN ('completed', 'approved')`,
+                sql`${companyRequirementStatus.status} NOT IN ('completed', 'approved', 'not_applicable')`,
               ),
             )
             .returning({ id: companyRequirementStatus.id });
@@ -996,6 +1008,9 @@ export const assessmentRouter = router({
       });
 
       if (signableRows.length === 0) return { signedOff: 0 };
+
+      // Same stable lock order as bulkConfirmModuleRef.
+      signableRows.sort((a, b) => a.statusId.localeCompare(b.statusId));
 
       const now = new Date();
       // Company-scoped half of the snapshot, built once; each row re-stamps

--- a/server/trpc/routers/intake.ts
+++ b/server/trpc/routers/intake.ts
@@ -26,6 +26,8 @@ import {
 import { introspectSchema } from "@/lib/forms/schema-introspect";
 import { REQUIREMENT_FIELD_MAP } from "@/lib/compliance/requirement-fields";
 import { recordSignOffChainEntry } from "../helpers/sign-off-chain";
+import { buildSignOffSnapshot } from "../helpers/assessment-helpers";
+import { completedSignOffValues, snapshotForVersion } from "../helpers/sign-off-completion";
 import type { Database } from "@/lib/db";
 
 export const intakeRouter = router({
@@ -449,38 +451,61 @@ async function deriveRequirementStatuses(
   const setsTerminal = targetStatus === "completed" || targetStatus === "approved";
   const now = new Date();
 
+  // A signed intake is a sign-off, so its rows carry the same evidence as one
+  // signed from the assessment editor. Without a snapshot the reviewer view
+  // and the compliance report both hide their sign-off panels, which gate on
+  // it, and the row records no version of the requirement text that was
+  // approved. Built once here (the expensive half is company-scoped) and
+  // re-stamped per requirement below.
+  const snapshotBase =
+    setsTerminal && chainContext
+      ? await buildSignOffSnapshot(db, chainContext.companyId, reqs[0].templateVersion)
+      : null;
+
+  // Rows are locked in a stable order so a concurrent sign-off touching an
+  // overlapping set cannot deadlock against this loop.
+  const orderedStatuses = [...statuses].sort((a, b) => a.id.localeCompare(b.id));
+
   await db.transaction(async (tx) => {
-    for (const status of statuses) {
+    for (const status of orderedStatuses) {
       if (status.status === "not_applicable") continue;
+      const req = reqById.get(status.requirementId);
 
       const isReopen =
         targetStatus === "in_progress" &&
         (status.status === "completed" || status.status === "approved");
 
-      // Build the update payload. When this call originates from
-      // intake.submit (chainContext supplied + terminal), also stamp
-      // signedOffBy and signedOffRole — previously these stayed null
-      // even though signedOffAt was set, so the sign-off row was
-      // unattributable and the chain entry would record a signer the
-      // status row didn't.
+      // Build the update payload. A submit (chainContext supplied + terminal)
+      // is a sign-off and writes the full evidentiary set. A derive without a
+      // chain context is progress inferred from saved answers, not a signature,
+      // so it stamps only the completion timestamps and deliberately leaves
+      // the signer columns alone.
       const terminalPatch =
-        setsTerminal && chainContext
-          ? {
-              completedAt: now,
-              completedBy: chainContext.userId,
-              signedOffAt: now,
-              signedOffBy: chainContext.userId,
+        setsTerminal && chainContext && req && snapshotBase
+          ? completedSignOffValues({
+              userId: chainContext.userId,
               signedOffRole: chainContext.signedOffRole,
-            }
+              templateVersion: req.templateVersion,
+              snapshot: snapshotForVersion(snapshotBase, req.templateVersion),
+              now,
+              status: targetStatus === "approved" ? "approved" : "completed",
+            })
           : setsTerminal
             ? { completedAt: now, completedBy: null, signedOffAt: now }
             : {};
 
+      // Reopening clears the signature. The snapshot and version have to go
+      // with it: the reviewer view and the report both decide whether to show
+      // a sign-off panel by testing signOffSnapshot alone, so leaving one
+      // behind renders a panel for a requirement that is back in progress and
+      // has no signer.
       const reopenPatch = isReopen
         ? {
             signedOffBy: null,
             signedOffAt: null,
             signedOffRole: null,
+            signedOffTemplateVersion: null,
+            signOffSnapshot: null,
             completedAt: null,
             completedBy: null,
           }
@@ -496,9 +521,7 @@ async function deriveRequirementStatuses(
         })
         .where(eq(companyRequirementStatus.id, status.id));
 
-      if (setsTerminal && chainContext) {
-        const req = reqById.get(status.requirementId);
-        if (!req) continue;
+      if (setsTerminal && chainContext && req) {
         await recordSignOffChainEntry(tx as unknown as Database, {
           companyId: chainContext.companyId,
           statusId: status.id,


### PR DESCRIPTION
Closes the last open finding from the CLAUDE.md principles audit.

## What was wrong

Five paths marked a requirement signed off, each writing the same nine columns by hand: `signOff`, `confirmModuleRef`, `bulkConfirmModuleRef`, `bulkSignOffCategory`, and the cross-framework propagation in `propagateSatisfaction`. They had drifted.

**`bulkConfirmModuleRef` omitted `signedOffTemplateVersion`.** Rows completed through it recorded no version of the requirement text that was actually signed, where the other four recorded one.

**It also wrote one row's snapshot to every row.** `buildSignOffSnapshot` stamps whatever `templateVersion` it is handed, and the batch built one snapshot from `toConfirm[0]`. Row five claimed row one's version.

That is worse than untidy. Sign-off invalidation (`dev.ts:157`) compares a bumped requirement against `sign_off_snapshot->>'templateVersion'`:

```sql
COALESCE((sign_off_snapshot->>'templateVersion')::int, 0) < ${newVersion}
```

A row carrying a neighbour's *higher* version fails that predicate and is never flipped to `needs_review` when its own requirement text changes. The evidence keeps looking signed.

**`propagateSatisfaction` had the same inconsistency, on a live path.** It runs after every sign-off from the UI. It wrote the *target's* version to the column but the *source's* snapshot to the JSON, so the two disagreed on every propagated row.

## Severity, stated honestly

The two bulk procedures have **no UI caller** — nothing in `app/` or `components/` invokes them, only `confirmModuleRef` is wired up. They are reachable over tRPC by any authenticated company user, but no customer row has been written through them by using the product. Latent, not active.

`propagateSatisfaction` is the one that has actually been running. Its damage is bounded too: no prod template-bump script exists yet (`dev.ts` says "Production template bumps run via migration / CLI scripts", and none is written), so nothing has yet evaluated the predicate the bad data would defeat. The fix matters for when that script is written, which is precisely when it would be hardest to notice.

## The fix

`server/trpc/helpers/sign-off-completion.ts`:

- **`completedSignOffValues`** — the only place those nine columns are set. An omitted field is now a type error rather than a silent gap in the audit trail.
- **`signerMeetsRequiredRole`** — the role check all four procedures spelled out. The single paths still throw `FORBIDDEN`; the bulk paths still skip the row, because a batch spans requirements with different required signers and one unsignable row should not fail the rest. That difference stays at the call site rather than hiding behind a flag.
- **`snapshotForVersion`** — re-stamps a batch snapshot per requirement, and says in one place why that is not optional.

A note on typing that the compiler forced: `signerRole` is a plain `string`, not a `RoleKey`. `getSignerRole` returns `user.jobTitle ?? sessionRole` and the column is `varchar(255)`, so the signer's side is user-entered free text. Only the *required* side is a closed set. My first draft annotated it `RoleKey` and tsc rejected it at all eight call sites, correctly.

## Behaviour changes, both narrowing

**`bulkConfirmModuleRef` becomes a per-row loop.** Per-row versions cannot come from one bulk `UPDATE`. It keeps the concurrency guard the bulk statement had: status is re-checked on each write and only rows whose own update returned get a chain entry.

**`bulkSignOffCategory` gains that guard, which it never had.** It filtered on status when reading and then wrote unconditionally, so a row another writer completed in between was re-signed under this caller's name. Its count now reports rows actually written.

## Verification

`bun run typecheck` clean. The only literal `status: "completed"` left under `server/trpc/` is inside the helper; all five writers call it.

CI e2e covers `signOff` and `confirmModuleRef` through the UI (`e2e/l3/signoff.spec.ts`), which is where the regression risk of this rewrite sits. **The two bulk procedures remain untested** — I did not add coverage, because CI runs `bun run test` only in `packages/grc-data-model`, so a root-level unit test would not execute. Wiring root tests into CI is worth doing and is its own change.

## Deliberately not changed

`propagateSatisfaction`'s role gate is more permissive than the four procedures'. They fall back to `DEFAULT_SIGN_OFF_ROLE` when a requirement names no signer; propagation treats an unnamed signer as open to anyone. It also keys admin bypass off the signer's job-title string rather than the session role. Both are pre-existing. Tightening either changes how many carry-over credits customers see, so it deserves its own PR rather than riding along in a refactor.