### PR TITLE
fix(db): recover sign-off evidence the intake path never wrote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       # test file added at the root was never executed by CI. Kept to the two
       # directories with no database dependency; e2e/ runs in its own workflow.
       - run: bun run test:unit
+      # A .sql file that is not in its journal never runs. drizzle/ carried
+      # one for months: 0016_aberrant_devos, a duplicate of DDL that had moved
+      # into the isms-schema chain. Harmless there, but the next one might be
+      # a migration somebody believes is live.
+      - name: migration journals match their .sql files
+        run: bun run check:migrations
 
       # REFERENCE.md is generated from the framework data and is published as
       # the public reference. It silently went stale after a correction pass,

--- a/drizzle/0011_backfill_signoff_evidence.sql
+++ b/drizzle/0011_backfill_signoff_evidence.sql
@@ -13,12 +13,22 @@
 -- gates its template-version and operational-data lines on the same field. The
 -- affected rows render as signed but show no sign-off detail anywhere.
 --
--- WHAT THIS IS NOT. Nothing here invents evidence. Every value is copied from
--- that row's own sign_off_history entry, which is the append-only record
--- written at the moment of signing. derived_data is left empty because it was
--- genuinely never captured for these rows, and the report already hides that
--- block when it is empty. Claiming asset and risk counts we do not have would
--- be the dishonest option.
+-- WHAT THIS IS NOT. Nothing here invents evidence. templateVersion is copied
+-- from that row's own sign_off_history entry, the append-only record written
+-- at the moment of signing. derivedData is left empty because it was genuinely
+-- never captured for these rows, and both consumers already hide that block
+-- when it is empty. Claiming asset and risk counts we do not have would be the
+-- dishonest option.
+--
+-- companyProfile is deliberately left empty too, for a different reason. The
+-- chain entry has one, but it holds cisoName, bsiContactName and
+-- bsiContactEmail: personal data. lib/gdpr/erase-user.ts redacts
+-- sign_off_history.snapshot and does NOT sweep
+-- company_requirement_status.sign_off_snapshot, so copying the profile across
+-- would plant names and an email address in a column the erasure routine does
+-- not reach, on the majority of rows rather than a minority. Nothing renders
+-- it: SignOffDisplay reads templateVersion and derivedData only, and so does
+-- the PDF. Copying it would add erasure debt and display nothing.
 --
 -- PRODUCTION SAFETY.
 --   * No DELETE, TRUNCATE, DROP or ALTER. One UPDATE.
@@ -28,8 +38,22 @@
 --   * template_version is the only sign-off column touched besides the
 --     snapshot, and only where it is NULL, so no sign-off is invalidated.
 --   * Idempotent: after one run the predicates match nothing.
---   * Scoped to rows that are terminal AND signed AND have a chain entry, so
---     an unsigned or in-progress row cannot be promoted by it.
+--   * Gated on signed_off_by, not signed_off_at. Those differ: erase-user.ts
+--     nulls signed_off_by and leaves signed_off_at set, so a row whose signer
+--     exercised their Art 17 right still carries a timestamp. Keying on the
+--     timestamp would hand that row a sign-off panel attributing an
+--     attestation to nobody. signed_off_by is the codebase's own test for
+--     "signed" (see drizzle/seed-gdpr.ts, which skips a source row lacking it).
+--   * The template version must be an integer literal. ->> returns text and
+--     IS NOT NULL only excludes an absent key or JSON null, so '3.0' or 'v3'
+--     would raise and abort. runtime-migrate rethrows, and the Dockerfile CMD
+--     runs it before `exec node server.js`, so an abort is a container that
+--     never boots and is restarted into the same failure. The regexp turns
+--     that into one skipped row.
+--   * The subquery is filtered to qualifying statuses rather than ranking
+--     every chain row in the database. Unfiltered, it sorts the whole of
+--     sign_off_history, detoasting each snapshot as sort payload, inside the
+--     boot transaction while the healthcheck start period runs.
 --
 -- NOT ADDRESSED HERE, deliberately. Rows carrying a sign_off_snapshot with NO
 -- sign_off_history entry are the signature of the unguarded seed-gdpr backfill
@@ -46,13 +70,20 @@
 --
 -- If that is non-zero, the remediation is a decision about the affected
 -- tenants' evidence, not a migration.
+--
+-- KNOCK-ON, worth knowing before anyone runs seed-gdpr again. Its propagation
+-- loop skips a source row whose sign_off_snapshot is NULL. Every row this
+-- migration repairs stops being skipped. That propagation is opt-in and
+-- role-gated since #76, but it would now copy these snapshots onto linked
+-- GDPR requirements, carrying the empty derivedData with them.
 
 UPDATE "company_requirement_status" AS s
--- The same COALESCE feeds the column and the snapshot, so the two can never
+-- The same COALESCE feeds the column and the snapshot, so the two cannot
 -- disagree. Writing the chain's version into the snapshot while COALESCE kept
--- an existing column value would manufacture the precise inconsistency this
--- series exists to remove: invalidation reads the snapshot, review.ts reads
--- the column, and a row where they differ escapes review while looking signed.
+-- an existing column value would manufacture an inconsistency: the sign-off
+-- invalidation in the dev router reads
+-- sign_off_snapshot->>'templateVersion', so a row whose snapshot claims a
+-- version its own requirement never had escapes review while looking signed.
 SET "signed_off_template_version" = COALESCE(
       s."signed_off_template_version",
       (h."snapshot" ->> 'templateVersion')::int
@@ -62,16 +93,24 @@ SET "signed_off_template_version" = COALESCE(
         s."signed_off_template_version",
         (h."snapshot" ->> 'templateVersion')::int
       ),
-      'companyProfile', COALESCE(h."snapshot" -> 'companyProfile', '{}'::jsonb),
+      'companyProfile', '{}'::jsonb,
       'derivedData', '{}'::jsonb
     )
 FROM (
-  SELECT DISTINCT ON ("status_id") "status_id", "snapshot"
-    FROM "sign_off_history"
-   ORDER BY "status_id", "version" DESC
+  SELECT DISTINCT ON (h2."status_id") h2."status_id", h2."snapshot"
+    FROM "sign_off_history" h2
+   WHERE EXISTS (
+     SELECT 1
+       FROM "company_requirement_status" s2
+      WHERE s2."id" = h2."status_id"
+        AND s2."sign_off_snapshot" IS NULL
+        AND s2."signed_off_by" IS NOT NULL
+        AND s2."status" IN ('completed', 'approved')
+   )
+   ORDER BY h2."status_id", h2."version" DESC
 ) AS h
 WHERE h."status_id" = s."id"
   AND s."sign_off_snapshot" IS NULL
-  AND s."signed_off_at" IS NOT NULL
+  AND s."signed_off_by" IS NOT NULL
   AND s."status" IN ('completed', 'approved')
-  AND (h."snapshot" ->> 'templateVersion') IS NOT NULL;
+  AND h."snapshot" ->> 'templateVersion' ~ '^[0-9]+$';

--- a/drizzle/0011_backfill_signoff_evidence.sql
+++ b/drizzle/0011_backfill_signoff_evidence.sql
@@ -97,6 +97,11 @@ SET "signed_off_template_version" = COALESCE(
       'derivedData', '{}'::jsonb
     )
 FROM (
+  -- The EXISTS mirrors the outer WHERE so the ranking never runs over chain
+  -- rows that cannot qualify. The two predicate lists must stay in step: the
+  -- outer one decides what is updated, this one only decides what is ranked,
+  -- so making this one stricter would silently drop rows the outer would have
+  -- repaired.
   SELECT DISTINCT ON (h2."status_id") h2."status_id", h2."snapshot"
     FROM "sign_off_history" h2
    WHERE EXISTS (
@@ -105,12 +110,18 @@ FROM (
       WHERE s2."id" = h2."status_id"
         AND s2."sign_off_snapshot" IS NULL
         AND s2."signed_off_by" IS NOT NULL
+        AND s2."signed_off_at" IS NOT NULL
         AND s2."status" IN ('completed', 'approved')
    )
    ORDER BY h2."status_id", h2."version" DESC
 ) AS h
 WHERE h."status_id" = s."id"
   AND s."sign_off_snapshot" IS NULL
+  -- Both halves of the signature, matching the guard seed-gdpr applies before
+  -- treating a row as a source worth copying. No current writer produces a
+  -- signer without a timestamp, but a snapshot on such a row would render a
+  -- sign-off panel with a blank date.
   AND s."signed_off_by" IS NOT NULL
+  AND s."signed_off_at" IS NOT NULL
   AND s."status" IN ('completed', 'approved')
   AND h."snapshot" ->> 'templateVersion' ~ '^[0-9]+$';

--- a/drizzle/0011_backfill_signoff_evidence.sql
+++ b/drizzle/0011_backfill_signoff_evidence.sql
@@ -48,12 +48,20 @@
 -- tenants' evidence, not a migration.
 
 UPDATE "company_requirement_status" AS s
+-- The same COALESCE feeds the column and the snapshot, so the two can never
+-- disagree. Writing the chain's version into the snapshot while COALESCE kept
+-- an existing column value would manufacture the precise inconsistency this
+-- series exists to remove: invalidation reads the snapshot, review.ts reads
+-- the column, and a row where they differ escapes review while looking signed.
 SET "signed_off_template_version" = COALESCE(
       s."signed_off_template_version",
       (h."snapshot" ->> 'templateVersion')::int
     ),
     "sign_off_snapshot" = jsonb_build_object(
-      'templateVersion', (h."snapshot" ->> 'templateVersion')::int,
+      'templateVersion', COALESCE(
+        s."signed_off_template_version",
+        (h."snapshot" ->> 'templateVersion')::int
+      ),
       'companyProfile', COALESCE(h."snapshot" -> 'companyProfile', '{}'::jsonb),
       'derivedData', '{}'::jsonb
     )

--- a/drizzle/0011_backfill_signoff_evidence.sql
+++ b/drizzle/0011_backfill_signoff_evidence.sql
@@ -1,0 +1,69 @@
+-- Custom data migration: recover sign-off evidence that was captured in the
+-- chain but never written to the status row.
+--
+-- WHY. Until PR #75, intake.submit stamped signed_off_by / signed_off_at /
+-- signed_off_role on a requirement it approved, and omitted
+-- signed_off_template_version and sign_off_snapshot. It did append a
+-- sign_off_history row carrying both. So for every requirement approved
+-- through the intake form the evidence exists, it just never reached the
+-- column the product reads.
+--
+-- That is customer-visible, not merely an audit nicety: ReviewDashboard gates
+-- the whole sign-off panel on sign_off_snapshot, and the compliance report PDF
+-- gates its template-version and operational-data lines on the same field. The
+-- affected rows render as signed but show no sign-off detail anywhere.
+--
+-- WHAT THIS IS NOT. Nothing here invents evidence. Every value is copied from
+-- that row's own sign_off_history entry, which is the append-only record
+-- written at the moment of signing. derived_data is left empty because it was
+-- genuinely never captured for these rows, and the report already hides that
+-- block when it is empty. Claiming asset and risk counts we do not have would
+-- be the dishonest option.
+--
+-- PRODUCTION SAFETY.
+--   * No DELETE, TRUNCATE, DROP or ALTER. One UPDATE.
+--   * Fills NULLs only. Every WHERE clause requires the target column to be
+--     NULL, so a row that already carries a snapshot is never rewritten and no
+--     existing value can be lost.
+--   * template_version is the only sign-off column touched besides the
+--     snapshot, and only where it is NULL, so no sign-off is invalidated.
+--   * Idempotent: after one run the predicates match nothing.
+--   * Scoped to rows that are terminal AND signed AND have a chain entry, so
+--     an unsigned or in-progress row cannot be promoted by it.
+--
+-- NOT ADDRESSED HERE, deliberately. Rows carrying a sign_off_snapshot with NO
+-- sign_off_history entry are the signature of the unguarded seed-gdpr backfill
+-- (fixed in #76). Those cannot be repaired this way: their snapshot belongs to
+-- a different requirement, and the honest record of what happened is the
+-- absent chain row. Fabricating chain entries retroactively would mean
+-- computing checksums for events that never occurred, which is worse than the
+-- gap. Detect them with:
+--
+--   SELECT count(*) FROM company_requirement_status s
+--    WHERE s.status IN ('completed','approved')
+--      AND s.sign_off_snapshot IS NOT NULL
+--      AND NOT EXISTS (SELECT 1 FROM sign_off_history h WHERE h.status_id = s.id);
+--
+-- If that is non-zero, the remediation is a decision about the affected
+-- tenants' evidence, not a migration.
+
+UPDATE "company_requirement_status" AS s
+SET "signed_off_template_version" = COALESCE(
+      s."signed_off_template_version",
+      (h."snapshot" ->> 'templateVersion')::int
+    ),
+    "sign_off_snapshot" = jsonb_build_object(
+      'templateVersion', (h."snapshot" ->> 'templateVersion')::int,
+      'companyProfile', COALESCE(h."snapshot" -> 'companyProfile', '{}'::jsonb),
+      'derivedData', '{}'::jsonb
+    )
+FROM (
+  SELECT DISTINCT ON ("status_id") "status_id", "snapshot"
+    FROM "sign_off_history"
+   ORDER BY "status_id", "version" DESC
+) AS h
+WHERE h."status_id" = s."id"
+  AND s."sign_off_snapshot" IS NULL
+  AND s."signed_off_at" IS NOT NULL
+  AND s."status" IN ('completed', 'approved')
+  AND (h."snapshot" ->> 'templateVersion') IS NOT NULL;

--- a/drizzle/0016_aberrant_devos.sql
+++ b/drizzle/0016_aberrant_devos.sql
@@ -1,4 +1,0 @@
-ALTER TABLE "gap_assessment" ADD COLUMN "share_token" uuid;--> statement-breakpoint
-ALTER TABLE "gap_assessment" ADD COLUMN "share_password_hash" text;--> statement-breakpoint
-ALTER TABLE "gap_assessment" ADD COLUMN "shared_at" timestamp;--> statement-breakpoint
-CREATE UNIQUE INDEX "idx_gap_assessment_share_token" ON "gap_assessment" USING btree ("share_token");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787324976259,
       "tag": "0010_framework_data_sync",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787566931136,
+      "tag": "0011_backfill_signoff_evidence",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test:unit": "bun test lib server",
+    "check:migrations": "bun scripts/check-migration-journals.ts",
     "db:generate": "drizzle-kit generate",
     "db:generate:grc": "bun run --env-file=$PWD/.env --cwd packages/grc-data-model db:generate",
     "db:generate:isms": "bun run --env-file=$PWD/.env --cwd packages/isms-schema db:generate",

--- a/scripts/check-migration-journals.ts
+++ b/scripts/check-migration-journals.ts
@@ -30,12 +30,23 @@ type FolderReport = {
   orphans: readonly string[];
   missing: readonly string[];
   outOfOrder: readonly string[];
+  noJournal: boolean;
 };
 
 function inspect(folder: string): FolderReport {
+  const base = { folder, orphans: [], missing: [], outOfOrder: [] };
   const journalPath = `${folder}/meta/_journal.json`;
+
+  // A folder with .sql files but no journal is the loudest version of the
+  // failure this script exists to catch: runtime-migrate logs "no journal —
+  // skipping" and every migration in that chain silently never runs. Reporting
+  // it as consistent would be worse than not checking at all. A folder with no
+  // journal AND no .sql files is simply not a migration folder.
   if (!existsSync(journalPath)) {
-    return { folder, orphans: [], missing: [], outOfOrder: [] };
+    const strays = existsSync(folder)
+      ? readdirSync(folder).filter((f) => f.endsWith(".sql"))
+      : [];
+    return { ...base, noJournal: strays.length > 0 };
   }
 
   const journal = JSON.parse(readFileSync(journalPath, "utf-8")) as Journal;
@@ -58,12 +69,19 @@ function inspect(folder: string): FolderReport {
     orphans: files.filter((f) => !tagSet.has(f)).sort(),
     missing: tags.filter((t) => !fileSet.has(t)).sort(),
     outOfOrder,
+    noJournal: false,
   };
 }
 
 const reports = FOLDERS.map(inspect);
 
 for (const r of reports) {
+  if (r.noJournal) {
+    console.error(
+      `${r.folder} has .sql files but no meta/_journal.json — runtime-migrate ` +
+        `skips the whole chain, so none of them will ever run.`,
+    );
+  }
   for (const o of r.orphans) {
     console.error(`${r.folder}/${o}.sql is not in the journal, so it will never run.`);
   }
@@ -76,7 +94,8 @@ for (const r of reports) {
 }
 
 const problems = reports.reduce(
-  (n, r) => n + r.orphans.length + r.missing.length + r.outOfOrder.length,
+  (n, r) =>
+    n + r.orphans.length + r.missing.length + r.outOfOrder.length + (r.noJournal ? 1 : 0),
   0,
 );
 

--- a/scripts/check-migration-journals.ts
+++ b/scripts/check-migration-journals.ts
@@ -1,0 +1,90 @@
+/**
+ * Every .sql file in a migration folder must appear in that folder's journal,
+ * and every journal entry must have its file.
+ *
+ * scripts/runtime-migrate.mjs drives off the journal, not the directory
+ * listing. So a .sql sitting there un-journaled simply never runs, silently
+ * and forever. drizzle/ carried one for months: 0016_aberrant_devos, a
+ * duplicate of DDL that had already moved into the isms-schema chain. It was
+ * harmless because the columns arrived by the other route, but reading the
+ * directory made it look like production had run it.
+ *
+ * The reverse, a journal entry whose file is missing, is the louder failure:
+ * runtime-migrate throws on boot and the container will not start.
+ *
+ * Usage: bun scripts/check-migration-journals.ts
+ */
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+
+/** Kept in step with the folder list in scripts/runtime-migrate.mjs. */
+const FOLDERS = [
+  "packages/grc-data-model/drizzle",
+  "packages/isms-schema/drizzle",
+  "drizzle",
+] as const;
+
+type Journal = { entries: Array<{ idx: number; when: number; tag: string }> };
+
+type FolderReport = {
+  folder: string;
+  orphans: readonly string[];
+  missing: readonly string[];
+  outOfOrder: readonly string[];
+};
+
+function inspect(folder: string): FolderReport {
+  const journalPath = `${folder}/meta/_journal.json`;
+  if (!existsSync(journalPath)) {
+    return { folder, orphans: [], missing: [], outOfOrder: [] };
+  }
+
+  const journal = JSON.parse(readFileSync(journalPath, "utf-8")) as Journal;
+  const tags = journal.entries.map((e) => e.tag);
+  const tagSet = new Set(tags);
+  const files = readdirSync(folder)
+    .filter((f) => f.endsWith(".sql"))
+    .map((f) => f.replace(/\.sql$/, ""));
+  const fileSet = new Set(files);
+
+  // runtime-migrate applies entries with `when` greater than the last applied
+  // timestamp, so a non-increasing `when` would skip the entry on a database
+  // that is already past it.
+  const outOfOrder = journal.entries
+    .filter((e, i) => i > 0 && e.when <= journal.entries[i - 1].when)
+    .map((e) => `${e.tag} (when=${e.when} not greater than its predecessor)`);
+
+  return {
+    folder,
+    orphans: files.filter((f) => !tagSet.has(f)).sort(),
+    missing: tags.filter((t) => !fileSet.has(t)).sort(),
+    outOfOrder,
+  };
+}
+
+const reports = FOLDERS.map(inspect);
+
+for (const r of reports) {
+  for (const o of r.orphans) {
+    console.error(`${r.folder}/${o}.sql is not in the journal, so it will never run.`);
+  }
+  for (const m of r.missing) {
+    console.error(`${r.folder}/meta/_journal.json references ${m}, but the .sql is missing.`);
+  }
+  for (const w of r.outOfOrder) {
+    console.error(`${r.folder}/meta/_journal.json: ${w}`);
+  }
+}
+
+const problems = reports.reduce(
+  (n, r) => n + r.orphans.length + r.missing.length + r.outOfOrder.length,
+  0,
+);
+
+if (problems === 0) {
+  const counts = reports
+    .map((r) => `${r.folder} ok`)
+    .join(", ");
+  console.log(`Migration journals consistent: ${counts}`);
+}
+
+process.exit(problems === 0 ? 0 : 1);


### PR DESCRIPTION
Third and last of the sign-off series (#75 stopped the bleeding, #76 guarded the seed script, this one repairs what is already in the database).

## The repair

Until #75, `intake.submit` stamped `signed_off_by` / `signed_off_at` / `signed_off_role` on a requirement it approved and omitted `signed_off_template_version` and `sign_off_snapshot`. It *did* append a `sign_off_history` row carrying both. So for every requirement approved through the intake form the evidence exists — it just never reached the columns the product reads.

That is customer-visible. `ReviewDashboard` gates the entire sign-off panel on `sign_off_snapshot`, and the compliance report PDF gates its template-version and operational-data lines on the same field. Those rows render as signed while showing no sign-off detail anywhere.

`0011_backfill_signoff_evidence` copies each affected row's values from **its own chain entry** — the append-only record written at the moment of signing. Nothing is invented. `derivedData` stays empty because it was genuinely never captured for these rows, and the report already hides that block when empty. Asserting asset and risk counts we do not have would be the dishonest option.

## Safety, verified rather than argued

Tested against a scratch database copied from the e2e one, with a fixture covering all four cases. The e2e database itself was left untouched and the scratch was dropped after.

| Case | Expected | Result |
|---|---|---|
| Signed, no snapshot, **has** chain entry (v7) | repaired to v7 | 3/3 repaired, v7 in both column and snapshot |
| Signed, no snapshot, **no** chain entry | stays NULL | untouched |
| **Unsigned** row that has a chain entry (v99) | stays NULL | untouched |
| Already has a snapshot | byte-identical | checksum unchanged |
| Re-run | no-op | `UPDATE 0`, whole-table checksum unchanged |

Applied through the real `scripts/runtime-migrate.mjs` path, not by hand. One UPDATE; no DELETE, TRUNCATE, DROP or ALTER. **Fills NULLs only** — every predicate requires the target column to be NULL, so no existing value can be overwritten.

## Not repaired here, deliberately

Rows carrying a `sign_off_snapshot` with **no** chain entry are the signature of the unguarded `seed-gdpr` backfill (#76). They cannot be fixed this way: their snapshot belongs to a different requirement, and the honest record of what happened is the missing chain row. Fabricating chain entries retroactively means computing checksums for events that never occurred, which is worse than the gap. The migration header carries the detection query; if it returns non-zero on production, that is a decision about affected tenants' evidence, not a migration.

## Orphan migration removed, and guarded

`drizzle/0016_aberrant_devos.sql` was never in the journal, so `runtime-migrate` never ran it. The same DDL had already moved into `packages/isms-schema/drizzle/0002_medical_mandarin.sql` in the safer `IF NOT EXISTS` form — confirmed on a migrated database that the `gap_assessment` share columns are present without it.

Harmless in itself, but it made the directory listing look like production had run a migration it never ran. I nearly misdiagnosed prod from it myself. And the obvious "fix" — adding it to the journal — would fail on columns that already exist.

`check:migrations` makes that class loud across all three chains: every `.sql` must be in its journal, every journal entry must have its file, and `when` must strictly increase (runtime-migrate skips a non-increasing entry on a database already past that timestamp). Verified it passes on this tree and exits 1 on a reintroduced orphan. Wired into CI beside the unit tests.