### PR TITLE
fix(scripts): refuse a non-local database in every destructive script

### DIFF
--- a/docs/coolify-deployment.md
+++ b/docs/coolify-deployment.md
@@ -131,6 +131,10 @@ Then open http://localhost:3000 and http://localhost:3000/api/health.
 ## Things that intentionally do NOT happen in Docker
 
 - `bun run db:migrate` — handled by Coolify pre-deploy hook, not the Dockerfile
-- `bun run db:seed` — manual, only for fresh databases
+- `bun run db:seed` — **local databases only**. It is not tenant-scoped: it
+  deletes every company's evidence, requirement statuses and intake answers
+  before reseeding, so it refuses any non-localhost `DATABASE_URL`. A fresh
+  production database needs no seed: framework reference data ships as a
+  migration and is applied at container start.
 - Source-map upload to error tracker — separate CI step if/when added
 - AWS credentials rotation — managed in Coolify, not baked into image

--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -1,3 +1,5 @@
+import { assertLocalDatabase } from "../scripts/lib/assert-local-database";
+
 /**
  * Seed script — Populates the database with NIS2 framework data.
  *
@@ -11,15 +13,25 @@
  *
  * Idempotent: clears existing data before inserting.
  */
-// Hard-fail in production — the seed script truncates and re-creates dev data,
-// which would be catastrophic against a live database. NODE_ENV is the cheapest
-// guard we can apply at module-load time, before any imports run side effects.
-if (process.env.NODE_ENV === "production") {
-  throw new Error(
-    "drizzle/seed.ts must not run in production (NODE_ENV=production). " +
-      "This script truncates dev data.",
-  );
-}
+// Refuse anything but a local database.
+//
+// This previously checked NODE_ENV === "production", which is inverted in both
+// directions: `bun run` leaves NODE_ENV undefined, so it never fired under the
+// invocation this file documents, and the Dockerfile sets it to "production",
+// so it fired only where the script never runs. The guard was decorative while
+// docs/coolify-deployment.md listed `bun run db:seed` as a manual production
+// step.
+//
+// It matters because cleanFramework below is not tenant-scoped: it resolves its
+// delete set from the GLOBAL requirement catalog, so it removes evidence,
+// requirement assignments, requirement statuses, category assignments and
+// intake answers for EVERY company in the database. Untransacted, so a
+// mid-way foreign-key abort leaves the earlier deletes committed.
+assertLocalDatabase(
+  process.env.DATABASE_URL ?? "",
+  "drizzle/seed.ts deletes every tenant's evidence, requirement statuses and " +
+    "intake answers before reseeding.",
+);
 
 import { drizzle } from "drizzle-orm/node-postgres";
 import { eq, and, inArray, sql } from "drizzle-orm";

--- a/scripts/apply-migration.ts
+++ b/scripts/apply-migration.ts
@@ -1,5 +1,15 @@
 import { readFile } from "node:fs/promises";
 import { db } from "@/lib/db";
+import { assertLocalDatabase } from "./lib/assert-local-database";
+
+// Executes whatever SQL it is handed, statement by statement, with no
+// transaction and no journal entry — so against production it is an unlogged,
+// half-applyable schema change with no record that it happened.
+assertLocalDatabase(
+  process.env.DATABASE_URL ?? "",
+  "scripts/apply-migration.ts executes arbitrary SQL with no transaction and " +
+    "records nothing in the migration journal.",
+);
 
 const sqlPath = process.argv[2];
 if (!sqlPath) {

--- a/scripts/eval-panel.ts
+++ b/scripts/eval-panel.ts
@@ -18,6 +18,16 @@ import type { FormatMode } from "@/lib/eval/format-category";
 import type { MergedCategoryEvaluation, PanelEvaluationResult, Verdict } from "@/lib/eval/panel-schema";
 
 // ANSI colors
+import { assertLocalDatabase } from "./lib/assert-local-database";
+
+// Picks a tenant with an unfiltered findFirst and sends that company's
+// compliance report to an external model. Whoever's row comes back first is
+// whose data leaves the building, so it must never see a real database.
+assertLocalDatabase(
+  process.env.DATABASE_URL ?? "",
+  "scripts/eval-panel.ts sends the first company it finds to an external LLM.",
+);
+
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
 const RED = "\x1b[31m";

--- a/scripts/lib/assert-local-database.ts
+++ b/scripts/lib/assert-local-database.ts
@@ -1,0 +1,49 @@
+/**
+ * Refuse to run against anything but a local database.
+ *
+ * For scripts that destroy or overwrite data. Connection-shaped rather than a
+ * boolean env flag, and that distinction is the whole point: a flag gets set
+ * once, lands in .env next to the production DATABASE_URL, and is then quietly
+ * true for every run afterwards including the one nobody meant to make. A host
+ * cannot be set and forgotten, because it IS the thing being pointed at.
+ *
+ * NODE_ENV is worse than useless here, which is why this exists. `bun run`
+ * leaves it undefined, so a `NODE_ENV === "production"` check never fires under
+ * the invocation these scripts document; and the Dockerfile sets it to
+ * "production", so the same check fires only inside the image, the one place
+ * the scripts never run. Inverted in both directions.
+ *
+ * Honest about its limit: this stops an accident, not a determined foot-gun. A
+ * production database fronted by `ssh -L` or a local proxy presents as
+ * localhost and passes.
+ *
+ * Extracted from scripts/smoke-supplier-portal.ts, which had it right.
+ */
+const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+export function assertLocalDatabase(databaseUrl: string, whatItDoes: string): void {
+  // Parse defensively: a malformed connection string makes URL throw with the
+  // whole string, password included, attached to the error — and callers log
+  // errors to the console.
+  const url = (() => {
+    try {
+      return new URL(databaseUrl);
+    } catch {
+      throw new Error("Refusing to run: DATABASE_URL is not a valid connection URL.");
+    }
+  })();
+
+  // pg-connection-string, which is what pg actually parses this with, gives the
+  // `host` query parameter priority over the URL authority. So
+  // `postgres://u:p@localhost/db?host=prod.internal` reads as local here while
+  // connecting to prod. Check the host pg will really use, not the pretty one.
+  const effectiveHost = url.searchParams.get("host") ?? url.hostname;
+
+  if (!LOCAL_DB_HOSTS.has(effectiveHost)) {
+    throw new Error(
+      `Refusing to run: DATABASE_URL host "${effectiveHost}" is not a local database.\n` +
+        `${whatItDoes}\n` +
+        "Point DATABASE_URL at a local database and re-run.",
+    );
+  }
+}

--- a/scripts/smoke-supplier-portal.ts
+++ b/scripts/smoke-supplier-portal.ts
@@ -20,50 +20,21 @@ import { createCallerFactory, type TRPCContext } from "@/server/trpc/init";
 import { appRouter } from "@/server/trpc/router";
 import { db as appDb } from "@/lib/db";
 import { env } from "@/lib/env";
+import { assertLocalDatabase as assertLocalDatabaseFor } from "./lib/assert-local-database";
 
 const TEST_CUSTOMER_EMAIL = "smoke-test-ciso@example.test";
 
-const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
-
 /**
- * Step 2 overwrites the seed company's legal identity, address, BSI
- * registration id and security-practice flags with test values, and
- * cleanupTestData restores none of it. Pointed at production that is silent
- * customer-data corruption, so refuse anything that is not a local database.
- *
- * Connection-shaped rather than a boolean env flag, for the same reason as
- * assertE2eTargets() in e2e/lib/env.ts: a flag can be set once and forgotten,
- * a host cannot. Unlike that guard this cannot also require a database-name
- * suffix, because the smoke test runs against the ordinary dev DATABASE_URL
- * rather than a dedicated `_e2e` database. So it stops an accident, not a
- * determined foot-gun: a prod database deliberately fronted by a local proxy
- * or `ssh -L` tunnel still presents as localhost and would pass.
+ * Overwrites the first company row it finds and restores none of it, so it must
+ * never see a real database. Shared guard: see scripts/lib/assert-local-database.ts
+ * for why this is connection-shaped rather than an env flag.
  */
 function assertLocalDatabase(): void {
-  // Parse defensively: a malformed connection string makes URL throw with the
-  // whole string (password included) attached to the error, and the caller
-  // logs errors to the console.
-  const url = (() => {
-    try {
-      return new URL(env.DATABASE_URL);
-    } catch {
-      throw new Error("Refusing to run: DATABASE_URL is not a valid connection URL.");
-    }
-  })();
-
-  // pg-connection-string, which is what pg actually parses this with, gives the
-  // `host` query parameter priority over the URL authority. So
-  // `postgres://u:p@localhost/db?host=prod.internal` reads as local here while
-  // connecting to prod. Check the host pg will really use, not the pretty one.
-  const effectiveHost = url.searchParams.get("host") ?? url.hostname;
-
-  if (!LOCAL_DB_HOSTS.has(effectiveHost)) {
-    throw new Error(
-      `Refusing to run: DATABASE_URL host "${effectiveHost}" is not a local database. ` +
-        `This script overwrites the first company row it finds and does not restore it. ` +
-        `Point DATABASE_URL at a local dev database and re-run.`,
-    );
-  }
+  assertLocalDatabaseFor(
+    env.DATABASE_URL,
+    "scripts/smoke-supplier-portal.ts overwrites the first company row it " +
+      "finds and does not restore it.",
+  );
 }
 
 async function getSeedUser() {


### PR DESCRIPTION
Closes the CRITICAL finding from the repo-wide audit. **This is the one to look at first.**

## What the audit found

`drizzle/seed.ts`'s `cleanFramework()` resolves its delete set from the **global** requirement catalog — `requirementCategory` → `requirement` → `companyRequirementStatus`. `requirement` has no `companyId`, and tenancy on those tables runs through `assessmentId → companyAssessment.companyId`, which the function never joins.

**The word `companyId` does not appear in it.** Verified: zero occurrences in the function body.

So it deletes `evidence`, `requirement_assignment`, `company_requirement_status`, `category_assignment` and `company_category_intake` for **every company in the database**. No transaction — and `sign_off_history` references `company_requirement_status` with `ON DELETE no action`, so on any database carrying one real sign-off it commits the evidence and assignment deletes, then aborts on a foreign key. Two tenanted tables destroyed, nothing reseeded, nothing rolled back.

## Why the guard didn't stop it

It checked `NODE_ENV === "production"`, which is inverted **in both directions**:

- `bun run` leaves `NODE_ENV` undefined → never fires under the invocation the file documents (`bun run drizzle/seed.ts`, `bun db:seed`)
- The Dockerfile sets `ENV NODE_ENV=production` → fires only inside the image, the one place the script never runs

And `docs/coolify-deployment.md:134` listed `bun run db:seed` as a manual production step.

This is the third time today this exact env-var-as-guard shape has produced a real hole. It is not a good guard in this repo.

## The fix

**The repo already had the right pattern and hadn't applied it where it mattered.** `scripts/smoke-supplier-portal.ts` checks the connection itself — including the `?host=` query parameter that `pg-connection-string` prioritises over the URL authority, so `postgres://u:p@localhost/db?host=prod.internal` reads as local while connecting to prod.

Lifted to `scripts/lib/assert-local-database.ts` and applied to the three scripts that lacked it:

| Script | What it does unguarded |
|---|---|
| `drizzle/seed.ts` | deletes every tenant's evidence and statuses |
| `scripts/apply-migration.ts` | executes arbitrary SQL, no transaction, no journal entry — an unlogged, half-applyable schema change |
| `scripts/eval-panel.ts` | picks a tenant with an unfiltered `findFirst()` and sends that company's compliance report to an external LLM |

The smoke script now imports the shared helper instead of keeping its own copy.

**Connection-shaped rather than an env flag, deliberately.** A flag gets set once, lands in `.env` beside the production `DATABASE_URL`, and is quietly true for every run afterwards. A host cannot be set and forgotten, because it *is* the thing being pointed at. The helper states its own limit: a prod database fronted by `ssh -L` presents as localhost and passes. It stops an accident, not a determined foot-gun.

## Verified

```
drizzle/seed.ts                  refuses remote: YES
scripts/apply-migration.ts       refuses remote: YES
scripts/eval-panel.ts            refuses remote: YES
scripts/smoke-supplier-portal.ts refuses remote: YES
```

Plus: `?host=prod.internal` behind a `localhost` authority is still caught, and a genuinely local URL passes. Typecheck, `check:migrations` and `test:unit` all clean.

## Deliberately not in this PR

`cleanFramework` should not delete tenant rows **at all**. Reference data wants the upsert-by-natural-key path that `seedFramework`, `seed-gdpr.ts` and `scripts/generate-framework-migration.ts` already use. That is a restructure of the seed, and it shouldn't ride along with a change whose entire purpose is reducing blast radius today.

The audit produced 42 confirmed findings (3 critical, 15 high, 11 medium). The other two criticals are the same `cleanFramework` bug reported by different lenses. The highs — a CSP frozen at build time from runtime env, whole-row egress on the unauthenticated supplier-portal endpoints, `supplierUpdateSchema` leaving `unsubscribeToken` writable, and intake answers going to xAI with a named contact and email against an in-product claim that they don't — are separate PRs.