### PR TITLE
fix(gdpr): bound PII redaction to word edges, and disclose what it skips

### DIFF
--- a/lib/gdpr/erase-user.ts
+++ b/lib/gdpr/erase-user.ts
@@ -25,6 +25,7 @@
  */
 import { createHash, createHmac } from "node:crypto";
 import { and, eq, gte, inArray, isNotNull, lt, or, sql } from "drizzle-orm";
+import { redactPiiInJson } from "./redact-pii";
 import type { InferSelectModel } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
@@ -107,35 +108,6 @@ function hashEmail(email: string): string {
     return createHmac("sha256", "dev-only-erasure-key").update(email.trim().toLowerCase()).digest("hex");
   }
   return createHmac("sha256", key).update(email.trim().toLowerCase()).digest("hex");
-}
-
-/** Recursively replace occurrences of the subject's email/name inside the
- *  string leaves of a JSON value. Walks the PARSED structure (not the
- *  serialized text), so values containing quotes, backslashes, or unicode are
- *  still matched — string-replacing over JSON text would miss their escaped
- *  encodings. Literal free-text PII redaction, not code/structure parsing. */
-function redactPiiInJson<T>(value: T, needles: string[]): T {
-  const patterns = needles
-    .map((n) => n?.trim())
-    .filter((n): n is string => !!n && n.length >= 3)
-    .map((n) => new RegExp(n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi"));
-  if (patterns.length === 0) return value;
-  const walk = (v: unknown): unknown => {
-    if (typeof v === "string") {
-      let out = v;
-      for (const re of patterns) out = out.replace(re, "[erased]");
-      return out;
-    }
-    if (Array.isArray(v)) return v.map(walk);
-    if (v && typeof v === "object") {
-      const src = v as Record<string, unknown>;
-      const next: Record<string, unknown> = {};
-      for (const k of Object.keys(src)) next[k] = walk(src[k]);
-      return next;
-    }
-    return v;
-  };
-  return walk(value) as T;
 }
 
 export interface ErasureRequestMeta {
@@ -444,6 +416,12 @@ async function erasePerson(
 ): Promise<void> {
   const { userId, email, name, companyId } = person;
 
+  // A name too short to bound safely is not redacted. That is the right call
+  // (see redact-pii.ts), but it must be disclosed: an erasure certificate that
+  // silently leaves the subject's name in free text overstates what happened.
+  const skippedNeedles: string[] = [];
+  const redact = <T,>(v: T) => redactPiiInJson(v, [email, name], { skipped: skippedNeedles });
+
   // Purely-personal rows.
   await del("gap_assessment", () => tx.delete(gapAssessment).where(eq(gapAssessment.userId, userId)).returning());
   await del("training_lesson_progress", () => tx.delete(trainingLessonProgress).where(eq(trainingLessonProgress.userId, userId)).returning());
@@ -460,7 +438,7 @@ async function erasePerson(
   if (soRows.length) {
     const tid = await tombstone();
     for (const r of soRows) {
-      const redacted = redactPiiInJson(r.snapshot, [email, name]);
+      const redacted = redact(r.snapshot);
       await tx.update(signOffHistory).set({ signedOffBy: tid, snapshot: redacted }).where(eq(signOffHistory.id, r.id));
     }
     scope.anonymized["sign_off_history"] = (scope.anonymized["sign_off_history"] ?? 0) + soRows.length;
@@ -501,7 +479,7 @@ async function erasePerson(
     let redactedCount = 0;
     for (const r of snapRows) {
       if (!r.snapshot) continue;
-      const redacted = redactPiiInJson(r.snapshot, [email, name]);
+      const redacted = redact(r.snapshot);
       // Only write where something actually changed, so an erasure does not
       // rewrite every signed requirement in the company.
       if (JSON.stringify(redacted) === JSON.stringify(r.snapshot)) continue;
@@ -520,6 +498,17 @@ async function erasePerson(
       );
     }
   }
+
+  if (skippedNeedles.length > 0) {
+    const unique = [...new Set(skippedNeedles)];
+    scope.residualNotes.push(
+      `The name${unique.length === 1 ? "" : "s"} ${unique.join(", ")} ` +
+        `${unique.length === 1 ? "was" : "were"} too short to redact safely from free text ` +
+        "and may remain in narrative fields; redacting on a fragment that short would " +
+        "have corrupted unrelated records. Structured attribution was cleared as normal.",
+    );
+  }
+
 
   // Remaining NOT-NULL attribution reassigned to the tombstone.
   const invitedByRows = await tx.select({ id: companyInvite.id }).from(companyInvite).where(eq(companyInvite.invitedBy, userId));
@@ -577,8 +566,8 @@ async function erasePerson(
       .update(auditLog)
       .set({
         userId: null,
-        previousValue: redactPiiInJson(r.previousValue, [email, name]),
-        newValue: redactPiiInJson(r.newValue, [email, name]),
+        previousValue: redact(r.previousValue),
+        newValue: redact(r.newValue),
       })
       .where(eq(auditLog.id, r.id));
   }

--- a/lib/gdpr/redact-pii.test.ts
+++ b/lib/gdpr/redact-pii.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The redaction helper decides what survives a GDPR erasure, and since it is
+ * now applied to every frozen sign-off snapshot in a company, an over-match
+ * rewrites a different employee's compliance evidence. A snapshot is meant to
+ * be the immutable record of what was signed, so these cases are about what it
+ * must NOT touch as much as what it must.
+ */
+import { describe, expect, test } from "bun:test";
+import { redactPiiInJson } from "./redact-pii";
+
+describe("redactPiiInJson", () => {
+  test("redacts the subject's own name and email", () => {
+    expect(
+      redactPiiInJson({ cisoName: "Anna Muster", mail: "anna@kunde.de" }, [
+        "Anna Muster",
+        "anna@kunde.de",
+      ]),
+    ).toEqual({ cisoName: "[erased]", mail: "[erased]" });
+  });
+
+  // The regression: a bare substring match on a short common name.
+  test("leaves unrelated words containing the name alone", () => {
+    const untouched = { ort: "Bottrop", teil: "Schrott", firma: "Ottomotor GmbH" };
+    expect(redactPiiInJson(untouched, ["Otto"])).toEqual(untouched);
+  });
+
+  test("still matches that name where it stands on its own", () => {
+    expect(
+      redactPiiInJson({ owner: "Otto Kern", note: "von Otto geprüft" }, ["Otto"]),
+    ).toEqual({ owner: "[erased] Kern", note: "von [erased] geprüft" });
+  });
+
+  // \b is ASCII-only in JS, so it treats "ü" as a boundary and "Müller" would
+  // fail to match itself. The explicit letter class is why.
+  test("handles German umlauts at the word edges", () => {
+    expect(redactPiiInJson({ a: "Müller", b: "Zimmermüller" }, ["Müller"])).toEqual({
+      a: "[erased]",
+      b: "Zimmermüller",
+    });
+  });
+
+  test("reports names too short to bound instead of applying them", () => {
+    const skipped: string[] = [];
+    expect(redactPiiInJson({ x: "Bo war hier" }, ["Bo"], { skipped })).toEqual({
+      x: "Bo war hier",
+    });
+    expect(skipped).toEqual(["Bo"]);
+  });
+
+  test("emails have no length floor and match mid-string", () => {
+    expect(redactPiiInJson({ s: "kontakt:a@b.de;" }, ["a@b.de"])).toEqual({
+      s: "kontakt:[erased];",
+    });
+  });
+
+  test("walks nested structures and arrays", () => {
+    expect(
+      redactPiiInJson({ team: [{ lead: "Anna Muster" }, { lead: "Bernd Schwieger" }] }, [
+        "Anna Muster",
+      ]),
+    ).toEqual({ team: [{ lead: "[erased]" }, { lead: "Bernd Schwieger" }] });
+  });
+});

--- a/lib/gdpr/redact-pii.ts
+++ b/lib/gdpr/redact-pii.ts
@@ -1,0 +1,72 @@
+/**
+ * Free-text PII redaction for GDPR erasure.
+ *
+ * Its own module because it is a pure function and importing erase-user.ts
+ * pulls in environment validation, which made it untestable — and this is the
+ * code that decides what survives an erasure, so it is exactly the code that
+ * should have tests.
+ */
+/** Shortest name we will redact on. Below this a name is more likely to be a
+ *  fragment of an unrelated word than a match, and over-redaction silently
+ *  damages other people's compliance evidence. Emails have no floor: they are
+ *  distinctive enough that a substring hit is a real hit. */
+const MIN_NAME_NEEDLE = 4;
+
+/** Word-boundary wrapper for a name. \b is ASCII-only in JS, which is wrong for
+ *  German: it treats "ü" as a boundary, so "Müller" would not match itself.
+ *  Lookarounds on an explicit letter class handle the umlauts and ß. */
+const NAME_EDGE = "[A-Za-zÄÖÜäöüßÀ-ÿ0-9_]";
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Recursively replace occurrences of the subject's email/name inside the
+ *  string leaves of a JSON value. Walks the PARSED structure (not the
+ *  serialized text), so values containing quotes, backslashes, or unicode are
+ *  still matched — string-replacing over JSON text would miss their escaped
+ *  encodings. Literal free-text PII redaction, not code/structure parsing.
+ *
+ *  Names match on word boundaries, emails anywhere. A bare substring match on a
+ *  name is how erasing one person corrupts another's records: since this is now
+ *  applied to every frozen sign-off snapshot in the company, a subject called
+ *  "Ott" would rewrite "Bottrop", "Schrott" and "Ottomotor" inside a different
+ *  employee's evidence, and a snapshot is meant to be the immutable record of
+ *  what was signed. Names too short to bound safely are reported as
+ *  not-auto-redacted rather than applied. */
+export function redactPiiInJson<T>(
+  value: T,
+  needles: string[],
+  opts?: { skipped?: string[] },
+): T {
+  const patterns = needles
+    .map((n) => n?.trim())
+    .filter((n): n is string => !!n)
+    .flatMap((n) => {
+      if (n.includes("@")) return [new RegExp(escapeRe(n), "gi")];
+      if (n.length < MIN_NAME_NEEDLE) {
+        opts?.skipped?.push(n);
+        return [];
+      }
+      return [
+        new RegExp(`(?<!${NAME_EDGE})${escapeRe(n)}(?!${NAME_EDGE})`, "gi"),
+      ];
+    });
+  if (patterns.length === 0) return value;
+  const walk = (v: unknown): unknown => {
+    if (typeof v === "string") {
+      let out = v;
+      for (const re of patterns) out = out.replace(re, "[erased]");
+      return out;
+    }
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === "object") {
+      const src = v as Record<string, unknown>;
+      const next: Record<string, unknown> = {};
+      for (const k of Object.keys(src)) next[k] = walk(src[k]);
+      return next;
+    }
+    return v;
+  };
+  return walk(value) as T;
+}


### PR DESCRIPTION
**My own regression from #78**, found by the repo-wide audit.

## What I broke

`redactPiiInJson` matches a name as a bare case-insensitive substring with a three-character floor. That was tolerable while it only touched rows the subject had signed. **#78 applied it company-wide to every frozen sign-off snapshot** — and that changed what a bad match costs.

A subject called "Otto" would rewrite `Bottrop`, `Schrott` and `Ottomotor` inside **a different employee's evidence**. A sign-off snapshot is meant to be the immutable record of what was signed, so erasing one person by corrupting another's records fails in both directions at once.

I widened the blast radius of a matcher I never examined.

## The fix

**Names match on word boundaries; emails still match anywhere** — an email is distinctive enough that a substring hit is a real hit.

The boundary is an explicit letter class, not `\b`. `\b` is ASCII-only in JavaScript and treats `ü` as a word boundary, so `\bMüller\b` does not match `"Müller"` — not a promising property for a German compliance product. There's a test for exactly that.

**Names below four characters are no longer applied**, and are now reported in the erasure certificate's residual notes rather than silently dropped. An erasure record claiming completeness it doesn't have is worse than one that names its gap.

## Extracted so it could be tested

`redactPiiInJson` moved to `lib/gdpr/redact-pii.ts`. It was untestable where it sat: importing `erase-user.ts` pulls in environment validation, so **the function that decides what survives a GDPR erasure was the one function in that file nothing could exercise**. That is roughly the worst candidate for being untestable in this codebase.

Seven tests now cover the regression case, the umlaut boundary, the short-name floor, the nested walk, and that the subject's own name and email are still redacted.

| Case | Behaviour |
|---|---|
| `"Anna Muster"` / `anna@kunde.de` | redacted |
| `"Otto"` vs `Bottrop`, `Schrott`, `Ottomotor` | **untouched** |
| `"Otto"` vs `"Otto Kern"`, `"von Otto geprüft"` | redacted |
| `"Müller"` vs `Müller` / `Zimmermüller` | first redacted, second untouched |
| `"Bo"` (below floor) | not applied, reported in residual notes |
| `a@b.de` mid-string | redacted |

`typecheck`, `test:unit` (67 tests) all clean.

## Still open on this file, from the same audit

Erasure redacts the *frozen copies* of the subject's name and email in `sign_off_history.snapshot` and `sign_off_snapshot`, but never the **live source columns** on `company` (`cisoName`, `bsiContactName`, `bsiContactEmail`). And the snapshot sweep is scoped to the subject's *current* company, so a user who changed employers leaves their name in their former tenant's snapshots while the certificate reports the erasure complete. Both are separate changes; both belong in the same follow-up.