### PR TITLE
fix(supplier-portal): project the two selects that shipped whole rows

### DIFF
--- a/server/trpc/routers/supplier-portal/projection.test.ts
+++ b/server/trpc/routers/supplier-portal/projection.test.ts
@@ -1,0 +1,39 @@
+/**
+ * getByToken is reachable with a 64-hex token and no account. These assert the
+ * two joined selects stay projected: a `select({ incident })` spread would put
+ * the supplier's post-mortem — root cause, countermeasures, financial damage —
+ * in front of every token holder, and a `select({ asset })` spread would hand
+ * out their internal hostnames and unpatched-host dates.
+ *
+ * Reading the source is the point. The alternative is an integration test that
+ * only fails once someone has already shipped the leak.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("./public.ts", import.meta.url), "utf8");
+
+const NEVER_EXPOSED = [
+  "rootCause", "countermeasures", "estimatedFinancialDamage",
+  "affectedUsersCount", "affectedSystemsCount", "gdprNotifiedAt", "internalRef",
+  "ipAddress", "hostname", "operatingSystem", "softwareVersion",
+  "lastPatchDate", "lastVulnScanDate", "privilegedAccountCount",
+];
+
+describe("supplier-portal getByToken projection", () => {
+  test("neither joined select spreads a whole table", () => {
+    expect(SRC).not.toContain("select({ incident: incident");
+    expect(SRC).not.toContain("select({ asset: asset");
+  });
+
+  test("no sensitive column is named in the file at all", () => {
+    const named = NEVER_EXPOSED.filter((c) => SRC.includes(`incident.${c}`) || SRC.includes(`asset.${c}`));
+    expect(named).toEqual([]);
+  });
+
+  test("the customer-facing columns are still selected", () => {
+    for (const c of ["incident.title", "incident.severity", "asset.name", "asset.hasMfa"]) {
+      expect(SRC).toContain(c);
+    }
+  });
+});

--- a/server/trpc/routers/supplier-portal/public.ts
+++ b/server/trpc/routers/supplier-portal/public.ts
@@ -125,8 +125,34 @@ export const supplierPublicRouter = router({
 
       // Assets the supplier offers to THIS customer — service profile lives
       // in asset_supplier_offering, joined to the generic asset row.
+      //
+      // Columns are listed, not spread. This endpoint is reached with a 64-hex
+      // token and no account, and the generic asset row carries the supplier's
+      // own internal estate: ipAddress, hostname, operatingSystem,
+      // softwareVersion, lastPatchDate, lastVulnScanDate, privilegedAccountCount.
+      // Handing a customer a live inventory of their supplier's unpatched hosts
+      // is a gift to whoever phishes that customer next. What belongs here is
+      // what the supplier is declaring ABOUT the service, which is the point of
+      // the portal — the same reasoning the `company` select above already
+      // applies to itself.
       const offeringRows = await ctx.db
-        .select({ asset: asset, offering: assetSupplierOffering })
+        .select({
+          asset: {
+            id: asset.id,
+            name: asset.name,
+            type: asset.type,
+            description: asset.description,
+            isCritical: asset.isCritical,
+            hasMfa: asset.hasMfa,
+            encryptionAtRest: asset.encryptionAtRest,
+            encryptionInTransit: asset.encryptionInTransit,
+            hasBackup: asset.hasBackup,
+            rto: asset.rto,
+            rpo: asset.rpo,
+            processesPersonalData: asset.processesPersonalData,
+          },
+          offering: assetSupplierOffering,
+        })
         .from(asset)
         .innerJoin(assetSupplierOffering, eq(assetSupplierOffering.assetId, asset.id))
         .where(
@@ -140,8 +166,28 @@ export const supplierPublicRouter = router({
 
       // Recent incidents addressed to THIS relationship — broadcast metadata
       // lives in incident_broadcast.
+      //
+      // Same treatment, and this one matters more. The incident row is the
+      // supplier's internal post-mortem: rootCause, countermeasures,
+      // estimatedFinancialDamage, affectedUsersCount, affectedSystemsCount,
+      // gdprNotifiedAt, internalRef. A supply-chain broadcast is a notification
+      // that something happened and what the customer should do about it, not
+      // a copy of the supplier's breach file. Anyone holding the token was
+      // receiving all 33 columns.
       const broadcastRows = await ctx.db
-        .select({ incident: incident, broadcast: incidentBroadcast })
+        .select({
+          incident: {
+            id: incident.id,
+            title: incident.title,
+            description: incident.description,
+            severity: incident.severity,
+            situationColor: incident.situationColor,
+            discoveredAt: incident.discoveredAt,
+            resolvedAt: incident.resolvedAt,
+            createdAt: incident.createdAt,
+          },
+          broadcast: incidentBroadcast,
+        })
         .from(incident)
         .innerJoin(incidentBroadcast, eq(incidentBroadcast.incidentId, incident.id))
         .where(


### PR DESCRIPTION
Second HIGH from the repo-wide audit. Independent of #81.

## The asymmetry

`getByToken` is reached with a **64-hex token and no account**. Within one function it:

- applies an explicit column whitelist to `company` — with comments marking "Public identity"
- selects certifications with a comment saying *"cert metadata only — no S3 storage keys"*
- and then spreads **two whole table rows**

```ts
.select({ incident: incident, broadcast: incidentBroadcast })   // all 33 columns
.select({ asset: asset, offering: assetSupplierOffering })      // the whole estate
```

The author knew to whitelist. These two just didn't get it.

## What was leaving

**Incidents** — `rootCause`, `countermeasures`, `estimatedFinancialDamage`, `affectedUsersCount`, `affectedSystemsCount`, `gdprNotifiedAt`, `internalRef`. That's the supplier's internal post-mortem. A supply-chain broadcast is a notification that something happened and what the customer should do; it is not a copy of the breach file. Now eight columns: identity, severity, situation colour, the two timestamps.

**Assets** — `ipAddress`, `hostname`, `operatingSystem`, `softwareVersion`, `lastPatchDate`, `lastVulnScanDate`, `privilegedAccountCount`. A live inventory of the supplier's unpatched hosts, handed to every customer holding a token. That is a gift to whoever phishes that customer next. Now the declarations the portal exists to publish: MFA, encryption at rest and in transit, backup, RTO/RPO, whether personal data is processed.

## Why it survived review

**Nothing renders either payload.** The page maps only `supplierCompany`; `managedAssets` appears once, in a comment. And both spreads sat under comments describing what they were *for* rather than what they *contained* — so reading the function tells you the intent and not the exposure.

## Tests read the source, on purpose

The failure mode here is someone reintroducing a spread. An integration test only catches that once the leak has shipped, so these assert on `public.ts` directly: no `select({ incident: incident`, no sensitive column named anywhere in the file, and the customer-facing columns still present.

`typecheck` and `test:unit` (70 tests) clean.

## Note

`situationColor` rather than `status` — the incident table has no `status` column, which the typechecker caught when I assumed otherwise.