### PR TITLE
fix(schema): stop a tenant minting supplier-portal bearer tokens

### DIFF
--- a/schema/mass-assignment.test.ts
+++ b/schema/mass-assignment.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Update schemas are the only thing standing between a caller-supplied object
+ * and a row write. These pin the fields that must never survive parsing.
+ *
+ * Zod strips unknown keys by default, so "rejected" here means the key is
+ * absent from the parsed output — the router then cannot write it.
+ */
+import { describe, expect, test } from "bun:test";
+import { supplierUpdateSchema, trainingUpdateSchema } from "./validators";
+
+describe("supplierUpdateSchema", () => {
+  // unsubscribeToken is the portal's bearer credential: holding it grants read
+  // access to the supplier's data and the right to revoke the relationship.
+  test("drops the portal bearer token", () => {
+    const parsed = supplierUpdateSchema.parse({
+      name: "Acme",
+      unsubscribeToken: "a".repeat(64),
+    });
+    expect(parsed).not.toHaveProperty("unsubscribeToken");
+    expect(parsed.name).toBe("Acme");
+  });
+
+  test("drops both sides of the relationship identity", () => {
+    const parsed = supplierUpdateSchema.parse({
+      name: "Acme",
+      supplierCompanyId: "11111111-1111-1111-1111-111111111111",
+      customerCompanyId: "22222222-2222-2222-2222-222222222222",
+    });
+    expect(parsed).not.toHaveProperty("supplierCompanyId");
+    expect(parsed).not.toHaveProperty("customerCompanyId");
+  });
+
+  // A customer able to set these can undo a revocation the supplier performed.
+  test("drops the supplier-controlled lifecycle", () => {
+    const parsed = supplierUpdateSchema.parse({
+      name: "Acme",
+      status: "active",
+      confirmedAt: new Date(),
+      unsubscribedAt: null,
+    });
+    for (const k of ["status", "confirmedAt", "unsubscribedAt"]) {
+      expect(parsed).not.toHaveProperty(k);
+    }
+  });
+
+  test("still accepts the fields a supplier edit actually posts", () => {
+    const parsed = supplierUpdateSchema.parse({ name: "Acme", isCritical: true });
+    expect(parsed).toEqual({ name: "Acme", isCritical: true });
+  });
+});
+
+describe("trainingUpdateSchema", () => {
+  test("drops companyId", () => {
+    const parsed = trainingUpdateSchema.parse({
+      title: "NIS2 Basics",
+      companyId: "33333333-3333-3333-3333-333333333333",
+    });
+    expect(parsed).not.toHaveProperty("companyId");
+    expect(parsed.title).toBe("NIS2 Basics");
+  });
+});

--- a/schema/validators.ts
+++ b/schema/validators.ts
@@ -500,14 +500,33 @@ export const supplierInsertSchema = createInsertSchema(supplier, {
   incidentSlaHours: z.number().int().positive().max(168).nullish(),
 });
 export const supplierSelectSchema = createSelectSchema(supplier);
-export const supplierUpdateSchema = supplierInsertSchema
-  .partial()
-  .omit({
-    id: true,
-    createdAt: true,
-    updatedAt: true,
-    customerCompanyId: true,
-  });
+/**
+ * Note what is omitted beyond the usual meta, and why.
+ *
+ * `unsubscribeToken` is the supplier portal's bearer credential: holding it
+ * grants read access to that supplier's data and the right to revoke the
+ * relationship, with no account. Leaving it writable let the customer-side
+ * tenant mint or overwrite it through an ordinary supplier edit.
+ *
+ * `supplierCompanyId` is the identity the relationship points at, and `status`
+ * / `unsubscribedAt` / `confirmedAt` are the lifecycle the supplier controls
+ * from their side — a customer able to set them can undo a revocation the
+ * supplier performed.
+ *
+ * None of these are fields a form posts; they were reachable only because the
+ * omit list named individual columns and stopped at the obvious ones.
+ * omitTenantMeta does not apply here: the supplier row is bilateral and has no
+ * companyId, which is exactly why it slipped past the convention.
+ */
+export const supplierUpdateSchema = supplierInsertSchema.partial().omit({
+  ...omitMeta,
+  customerCompanyId: true,
+  supplierCompanyId: true,
+  unsubscribeToken: true,
+  status: true,
+  confirmedAt: true,
+  unsubscribedAt: true,
+});
 
 /**
  * Layer 2 — Per-customer contract clauses (supplier portal).
@@ -545,7 +564,13 @@ export const trainingInsertSchema = createInsertSchema(trainingRecord, {
   durationMinutes: z.number().int().positive().nullish(),
 });
 export const trainingSelectSchema = createSelectSchema(trainingRecord);
-export const trainingUpdateSchema = trainingInsertSchema.partial().omit(omitAudit);
+// companyId must be stripped here too. omitAudit alone leaves it in the
+// input, and training.update writes it straight to the row — the
+// mass-assignment omitTenantMeta exists to prevent. omitTenantMeta itself
+// does not fit: training_record has no updatedAt column for it to omit.
+export const trainingUpdateSchema = trainingInsertSchema
+  .partial()
+  .omit({ ...omitAudit, companyId: true });
 
 // ============================================================================
 // Notifications


### PR DESCRIPTION
Third HIGH from the audit. Independent of #81 and #82.

## What was writable

`supplierUpdateSchema` omitted `id`, `createdAt`, `updatedAt`, `customerCompanyId` — and stopped.

That left **`unsubscribeToken`** writable through an ordinary supplier edit. It is the supplier portal's bearer credential: holding it grants read access to that supplier's data and the right to revoke the relationship, **with no account**. The customer-side tenant could mint one, or overwrite the one the supplier already holds.

Also writable: `supplierCompanyId` (the identity the relationship points at), and `status` / `confirmedAt` / `unsubscribedAt` — the lifecycle the supplier controls from their side. A customer able to set those can **undo a revocation the supplier performed**.

`trainingUpdateSchema` had the plainer version: built with `omitAudit`, which strips only `id` and `createdAt`, so `companyId` survived into `training.update`'s input and was written to the row.

## Why the convention missed both

This file already has the fix and a comment demanding it:

> *Strip tenant-isolation field. Use for EVERY tenant-scoped `*UpdateSchema` to prevent mass-assignment attacks…*

14 schemas use `omitTenantMeta`. These two couldn't, for opposite reasons — and that's the interesting part:

- **supplier** is bilateral and has **no `companyId`**, so the helper's shape didn't fit and it fell outside the discipline too
- **training_record** has **no `updatedAt`**, so `omitTenantMeta` over-omits

Both were typechecker-caught when I tried the obvious fix, which is a decent sign the shapes are genuinely different rather than sloppy.

## Now

Both list what they strip and say why, deriving from `omitMeta` / `omitAudit` plus the explicit credential and lifecycle fields.

Five tests assert the dangerous keys are absent after parsing — Zod strips unknown keys, so "rejected" means the router cannot write it — and that an ordinary supplier edit still passes through untouched.

`typecheck` and `test:unit` (68 tests) clean.