### PR TITLE
Surface NIS 2 only, keep every other framework's data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ scripts/i18n/_info-chunks/
 e2e/.auth/
 test-results/
 playwright-report/
+e2e/screenshots/
+e2e/screenshots-before/

--- a/app/api/cron/deadlines/route.ts
+++ b/app/api/cron/deadlines/route.ts
@@ -26,6 +26,7 @@ import {
   user,
   notification,
 } from "@/schema";
+import { nis2StatusScope } from "@/server/trpc/helpers/nis2-scope";
 import { logAudit } from "@/lib/audit";
 import { env } from "@/lib/env";
 import { verifyCronBearer } from "@/lib/cron/auth";
@@ -89,6 +90,7 @@ export async function GET(req: NextRequest) {
 
     const overdueStatuses = await db.query.companyRequirementStatus.findMany({
       where: and(
+        nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} <= ${today}`,
         inArray(companyRequirementStatus.status, ["completed", "approved", "not_applicable"]),
       ),
@@ -114,6 +116,7 @@ export async function GET(req: NextRequest) {
     // -----------------------------------------------------------------------
     const missingDeadlines = await db.query.companyRequirementStatus.findMany({
       where: and(
+        nis2StatusScope(db),
         isNull(companyRequirementStatus.nextReviewDate),
         inArray(companyRequirementStatus.status, ["not_started", "in_progress"]),
       ),
@@ -158,6 +161,7 @@ export async function GET(req: NextRequest) {
     // Find items with nextReviewDate within 90 days that don't have pending notifications
     const upcomingStatuses = await db.query.companyRequirementStatus.findMany({
       where: and(
+        nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} IS NOT NULL`,
         sql`${companyRequirementStatus.nextReviewDate} <= ${toDateString(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000))}`,
         inArray(companyRequirementStatus.status, ["completed", "approved", "needs_review", "not_applicable"]),
@@ -271,6 +275,7 @@ export async function GET(req: NextRequest) {
     // -----------------------------------------------------------------------
     const overdueForEscalation = await db.query.companyRequirementStatus.findMany({
       where: and(
+        nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} < ${today}`,
         inArray(companyRequirementStatus.status, ["needs_review", "completed", "approved"]),
       ),

--- a/app/api/export/csv/route.ts
+++ b/app/api/export/csv/route.ts
@@ -5,6 +5,7 @@ import { companyAssessment } from "@/schema";
 import { eq } from "drizzle-orm";
 import { loadReportData } from "@/lib/pdf/load-report-data";
 import { rateLimit } from "@/lib/rate-limit";
+import { getNis2FrameworkId } from "@/server/trpc/helpers/nis2-scope";
 
 export async function GET(request: NextRequest) {
   const session = await getSession();
@@ -21,10 +22,18 @@ export async function GET(request: NextRequest) {
     return new Response("Missing assessmentId", { status: 400 });
   }
 
+  // NIS 2 only. The UI no longer offers a non-NIS 2 assessment here, but the
+  // id arrives from the query string, so an old bookmark or a hand-built URL
+  // would still produce a GDPR / AI Act / CRA export for a tenant who owns it.
+  const nis2FrameworkId = await getNis2FrameworkId(db);
   const assessment = await db.query.companyAssessment.findFirst({
     where: eq(companyAssessment.id, assessmentId),
   });
-  if (!assessment || assessment.companyId !== session.companyId) {
+  if (
+    !assessment ||
+    assessment.companyId !== session.companyId ||
+    assessment.frameworkId !== nis2FrameworkId
+  ) {
     return new Response("Forbidden", { status: 403 });
   }
 

--- a/app/api/export/report/route.ts
+++ b/app/api/export/report/route.ts
@@ -8,6 +8,7 @@ import { loadReportData } from "@/lib/pdf/load-report-data";
 import { pdfLocale } from "@/lib/pdf/format";
 import { ComplianceReport } from "@/lib/pdf/compliance-report";
 import { rateLimit } from "@/lib/rate-limit";
+import { getNis2FrameworkId } from "@/server/trpc/helpers/nis2-scope";
 
 export async function GET(request: NextRequest) {
   const session = await getSession();
@@ -27,10 +28,18 @@ export async function GET(request: NextRequest) {
   }
 
   // Authorization: must belong to the same company as the assessment
+  // NIS 2 only. The UI no longer offers a non-NIS 2 assessment here, but the
+  // id arrives from the query string, so an old bookmark or a hand-built URL
+  // would still produce a GDPR / AI Act / CRA export for a tenant who owns it.
+  const nis2FrameworkId = await getNis2FrameworkId(db);
   const assessment = await db.query.companyAssessment.findFirst({
     where: eq(companyAssessment.id, assessmentId),
   });
-  if (!assessment || assessment.companyId !== session.companyId) {
+  if (
+    !assessment ||
+    assessment.companyId !== session.companyId ||
+    assessment.frameworkId !== nis2FrameworkId
+  ) {
     return new Response("Forbidden", { status: 403 });
   }
 

--- a/drizzle/0012_nis2_only_active_framework.sql
+++ b/drizzle/0012_nis2_only_active_framework.sql
@@ -1,0 +1,69 @@
+-- Custom data migration: NIS 2 is the only framework the product surfaces.
+--
+-- WHY. compliance_framework.is_active drives two things at once:
+-- getAllActiveCategories (lib/compliance/access.ts) builds the portal sidebar
+-- and both /compliance pages from it, and createAssessmentsForFrameworks
+-- (server/trpc/helpers/setup-helpers.ts) provisions one company_assessment plus
+-- one company_requirement_status row per requirement for EVERY active
+-- framework at signup. Nothing filtered to NIS 2 and nothing asked the user.
+--
+-- The result, measured on production 2026-08-25: tenants carry 56, 101 or 103
+-- requirement rows where the product only has 49.
+--   56  = 49 nis2 + 7 gdpr                          (oldest cohort)
+--   101 = 49 nis2 + 7 gdpr + 24 eu_ai_act + 21 eu_cra
+--   103 = 49 nis2 + 9 gdpr + 24 eu_ai_act + 21 eu_cra  (after the two GDPR
+--         requirements added in PR #72)
+-- So every progress percentage on the admin dashboard was computed against a
+-- denominator roughly twice the real one, and a tenant who finished all of
+-- NIS 2 would have read 49/101 = 48%.
+--
+-- WHAT THIS IS NOT. No rows are deleted. Existing GDPR / EU AI Act / EU CRA
+-- assessments and their company_requirement_status rows, sign-offs, evidence
+-- and history all stay exactly as they are. This only flips a visibility flag,
+-- and it is reversible by setting is_active back to true.
+--
+-- Reference data for the inactive frameworks is deliberately left in place:
+-- requirement_satisfaction pairs resolve against requirement rows, so
+-- propagateSatisfaction keeps crediting the linked GDPR or ISO 27001
+-- requirement when a NIS 2 requirement is signed off. That cross-framework
+-- mapping is the reason the other frameworks were modelled at all, and it
+-- keeps working with them hidden.
+--
+-- Queries that COUNT or LIST a tenant's requirements had to be scoped in the
+-- same change (server/trpc/helpers/nis2-scope.ts), because this flag alone
+-- cannot fix them: the rows it hides are still in the database by design.
+
+UPDATE compliance_framework
+SET is_active = false
+WHERE code <> 'nis2'
+  AND is_active = true;
+
+-- NIS 2 itself must be active for the journey, the sidebar and new signups.
+-- Asserted rather than assumed: an inactive NIS 2 would render an empty
+-- product, and this is the one row the whole application depends on.
+UPDATE compliance_framework
+SET is_active = true
+WHERE code = 'nis2'
+  AND is_active = false;
+
+-- Pending reminder / escalation notifications already queued against a now
+-- hidden framework's requirements. Left alone, the next cron run mails the
+-- user "Reminder: DSGVO-3.1 review due" with a link to a page that no longer
+-- resolves.
+--
+-- Cancelled, not deleted: 'cancelled' is an existing notification_status value
+-- (packages/isms-schema/src/enums.ts:101), the rows stay auditable, and the
+-- change is reversible. Only 'pending' rows are touched, so anything already
+-- sent keeps its delivery record intact.
+UPDATE notification n
+SET status = 'cancelled'
+WHERE n.status = 'pending'
+  AND n.entity_type = 'requirement'
+  AND EXISTS (
+    SELECT 1
+      FROM requirement r
+      JOIN requirement_category rc ON rc.id = r.category_id
+      JOIN compliance_framework f ON f.id = rc.framework_id
+     WHERE r.id = n.entity_id
+       AND f.code <> 'nis2'
+  );

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787566931136,
       "tag": "0011_backfill_signoff_evidence",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1787566932136,
+      "tag": "0012_nis2_only_active_framework",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/seed-aiact-cra.ts
+++ b/drizzle/seed-aiact-cra.ts
@@ -35,6 +35,7 @@ async function main() {
     effectiveDate: "2024-08-01",
     codePrefix: "AI-",
     sidebarLabel: "aiact",
+    isActive: false,
     categories: euAiActCategories,
     getRequirements: getEuAiActRequirementsForCategory,
   });
@@ -46,6 +47,7 @@ async function main() {
     effectiveDate: "2024-12-10",
     codePrefix: "CRA-",
     sidebarLabel: "cra",
+    isActive: false,
     categories: euCraCategories,
     getRequirements: getEuCraRequirementsForCategory,
   });

--- a/drizzle/seed-gdpr.ts
+++ b/drizzle/seed-gdpr.ts
@@ -57,6 +57,7 @@ async function seed() {
     effectiveDate: "2018-05-25",
     codePrefix: "DSGVO-",
     sidebarLabel: "dsgvo",
+    isActive: false,
     categories: gdprCategories,
     getRequirements: getGdprRequirementsForCategory,
   });

--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -377,7 +377,11 @@ async function seed() {
       code: "iso27001",
       version: "2022",
       effectiveDate: "2022-10-25",
-      isActive: true,
+      // NIS 2 is the only framework the product surfaces. ISO 27001 reference
+      // data is still seeded so the NIS2 <-> ISO satisfaction pairs resolve,
+      // but inactive keeps it out of the sidebar, out of /compliance, and out
+      // of what createAssessmentsForFrameworks provisions for a new signup.
+      isActive: false,
       codePrefix: "ISO27001-",
       sidebarLabel: "iso27001",
     })
@@ -386,7 +390,7 @@ async function seed() {
       set: {
         version: "2022",
         effectiveDate: "2022-10-25",
-        isActive: true,
+        isActive: false,
       },
     })
     .returning();

--- a/e2e/l0/nis2-scope.test.ts
+++ b/e2e/l0/nis2-scope.test.ts
@@ -1,0 +1,56 @@
+/**
+ * L0: the NIS 2 scope predicates compile to correct SQL.
+ *
+ * `nis2StatusScope` is consumed by the nightly deadline cron
+ * (app/api/cron/deadlines/route.ts) inside Drizzle's RELATIONAL query builder.
+ * RQB rewrites every Column chunk of a raw `sql` template to the root table
+ * alias, so a predicate that reads correctly in source can still compile to
+ * columns that do not exist. That is not hypothetical: written as sql`...` this
+ * emitted `"companyRequirementStatus"."code"` and
+ * `"companyRequirementStatus"."framework_id"`, Postgres raised 42703, and
+ * phases 1 to 5 of the cron aborted behind a single audit row.
+ *
+ * The browser suite never requests that route, so nothing else catches this.
+ * These assertions are the guard.
+ */
+import { describe, test, expect } from "bun:test";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { and, isNull } from "drizzle-orm";
+import * as schema from "@/schema";
+import { companyRequirementStatus } from "@/schema";
+import { nis2StatusScope } from "@/server/trpc/helpers/nis2-scope";
+
+const db = drizzle.mock({ schema });
+
+const compiled = db.query.companyRequirementStatus
+  .findMany({
+    where: and(
+      nis2StatusScope(db),
+      isNull(companyRequirementStatus.nextReviewDate),
+    ),
+    columns: { id: true },
+  })
+  .toSQL();
+
+describe("nis2StatusScope inside the relational query builder", () => {
+  test("scopes on the joined framework, not the root table", () => {
+    expect(compiled.sql).toContain('"compliance_framework"."code"');
+    expect(compiled.sql).toContain(
+      '"compliance_framework"."id" = "company_assessment"."framework_id"',
+    );
+  });
+
+  test("never attributes a joined column to company_requirement_status", () => {
+    // The exact shape of the 42703 failure this test exists to prevent.
+    expect(compiled.sql).not.toContain('"companyRequirementStatus"."code"');
+    expect(compiled.sql).not.toContain('"companyRequirementStatus"."framework_id"');
+  });
+
+  test("still constrains the root table's assessment_id", () => {
+    expect(compiled.sql).toContain('"companyRequirementStatus"."assessment_id" in');
+  });
+
+  test("binds nis2 as the framework code", () => {
+    expect(compiled.params).toContain("nis2");
+  });
+});

--- a/e2e/nis2-only-screenshots.ts
+++ b/e2e/nis2-only-screenshots.ts
@@ -1,0 +1,110 @@
+/**
+ * Capture the surfaces that used to show a non-NIS 2 framework, so the
+ * "NIS 2 only in the UI" change can be eyeballed rather than trusted.
+ *
+ * Run against a served e2e state (bun run e2e:serve), which holds the Dev GmbH
+ * tenant. Writes PNGs to e2e/screenshots/.
+ *
+ *   bun run e2e/nis2-only-screenshots.ts
+ */
+import { chromium, type Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { assertE2eTargets } from "./lib/env";
+import { signInViaForm } from "./lib/signin";
+
+const OUT_DIR = join(process.cwd(), "e2e", "screenshots");
+const BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3410";
+const ADMIN_EMAIL = "dev@nis2.local";
+
+const SHOTS = [
+  { name: "01-journey", path: "/de/journey", waitFor: "Ihr Weg" },
+  { name: "02-compliance-index", path: "/de/compliance", waitFor: null },
+  { name: "03-dashboard-stats", path: "/de/dashboard/stats", waitFor: null },
+  { name: "04-export", path: "/de/export", waitFor: null },
+  { name: "05-review", path: "/de/review", waitFor: null },
+  { name: "06-team", path: "/de/team", waitFor: null },
+] as const;
+
+/** Category slugs that must NOT resolve any more, one per hidden framework. */
+const HIDDEN_CATEGORY_SLUGS = [
+  "gdpr-toms",
+  "aiact-literacy",
+  "cra-sbom",
+  "isms-clauses",
+] as const;
+
+async function shoot(page: Page, name: string, path: string, waitFor: string | null) {
+  await page.goto(`${BASE_URL}${path}`, { waitUntil: "networkidle" });
+  if (waitFor) {
+    await page.getByText(waitFor, { exact: false }).first().waitFor({ timeout: 30_000 });
+  }
+  await page.screenshot({ path: join(OUT_DIR, `${name}.png`), fullPage: true });
+  const body = await page.locator("body").innerText();
+  const sidebar = page.locator('[data-slot="sidebar"]').first();
+  const sidebarText = (await sidebar.count()) > 0 ? await sidebar.innerText() : "";
+  return { body, sidebarText };
+}
+
+/**
+ * Two different checks, because the two surfaces fail differently.
+ *
+ * The sidebar renders one group per active framework, labelled with the
+ * framework's name, so a name appearing there means the group is rendering.
+ * Page bodies need the stricter test: NIS 2 requirement prose legitimately
+ * cites "ISO 27001" and "DSGVO" as references, so only a requirement CODE
+ * prefix proves a foreign requirement is actually being listed.
+ */
+const FORBIDDEN_IN_SIDEBAR = ["DSGVO", "GDPR", "AI Act", "Cyber Resilience", "ISO 27001"] as const;
+const FORBIDDEN_CODE_PREFIXES = ["DSGVO-", "AI-", "CRA-", "ISO27001-"] as const;
+
+async function main() {
+  assertE2eTargets();
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const browser = await chromium.launch();
+  // baseURL: lib/signin.ts navigates to the relative "/de/auth/signin", which
+  // Playwright only resolves against a context baseURL.
+  const context = await browser.newContext({
+    baseURL: BASE_URL,
+    locale: "de-DE",
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await context.newPage();
+
+  await signInViaForm(page, ADMIN_EMAIL);
+
+  const findings: string[] = [];
+
+  for (const shot of SHOTS) {
+    const { body, sidebarText } = await shoot(page, shot.name, shot.path, shot.waitFor);
+    const hits = [
+      ...FORBIDDEN_IN_SIDEBAR.filter((f) => sidebarText.includes(f)).map((f) => `sidebar:${f}`),
+      ...FORBIDDEN_CODE_PREFIXES.filter((f) => body.includes(f)).map((f) => `body:${f}`),
+    ];
+    console.log(`  ${shot.name.padEnd(22)} ${shot.path.padEnd(24)} ${hits.length ? `LEAK: ${hits.join(", ")}` : "clean"}`);
+    if (hits.length) findings.push(`${shot.path}: ${hits.join(", ")}`);
+  }
+
+  // Direct-URL probe: a hidden framework's category page must not render.
+  for (const slug of HIDDEN_CATEGORY_SLUGS) {
+    const url = `${BASE_URL}/de/compliance/${slug}`;
+    const res = await page.goto(url, { waitUntil: "networkidle" });
+    const status = res?.status() ?? 0;
+    const body = await page.locator("body").innerText();
+    // notFound() renders the 404 boundary; either a 404 status or the absence
+    // of a requirement table counts as hidden.
+    const rendered = status === 200 && !/nicht gefunden|not found|404/i.test(body);
+    console.log(`  probe /de/compliance/${slug.padEnd(16)} status=${status} ${rendered ? "STILL RENDERS" : "hidden"}`);
+    if (rendered) findings.push(`${url} still renders (status ${status})`);
+    await page.screenshot({ path: join(OUT_DIR, `probe-${slug}.png`), fullPage: true });
+  }
+
+  await browser.close();
+
+  console.log(findings.length === 0 ? "\nAll captured surfaces clean." : `\n${findings.length} leak(s):`);
+  for (const f of findings) console.log(`  - ${f}`);
+  process.exit(findings.length === 0 ? 0 : 1);
+}
+
+await main();

--- a/lib/compliance/digest.ts
+++ b/lib/compliance/digest.ts
@@ -18,6 +18,7 @@ import type { Database } from "@/lib/db";
 import type { DigestItem } from "@/lib/mail";
 import { daysUntilDeadline } from "./deadlines";
 import { getAppUrl } from "@/lib/utils";
+import { getNis2FrameworkId } from "@/server/trpc/helpers/nis2-scope";
 import requirementsEn from "@/messages/requirements/en.json";
 
 // ---------------------------------------------------------------------------
@@ -79,9 +80,18 @@ export async function compileDailyDigest(
 
   if (!recipient || !companyRow) return null;
 
-  // Get all assessments for this company
+  // NIS 2 only. Summing totalRequirements across every assessment made the
+  // headline percentage in this email a fraction over 101 or 103 requirements
+  // instead of 49, and put DSGVO / AI-Act / CRA requirement codes in the item
+  // list of a digest the reader treats as their NIS 2 status.
+  const nis2FrameworkId = await getNis2FrameworkId(db);
+  if (!nis2FrameworkId) return null;
+
   const assessments = await db.query.companyAssessment.findMany({
-    where: eq(companyAssessment.companyId, companyId),
+    where: and(
+      eq(companyAssessment.companyId, companyId),
+      eq(companyAssessment.frameworkId, nis2FrameworkId),
+    ),
     columns: { id: true, compliancePercentage: true, completedRequirements: true, totalRequirements: true },
   });
 
@@ -190,8 +200,16 @@ export async function compileManagementDigest(
 
   if (!recipient || !companyRow) return null;
 
+  // NIS 2 only, same reason as compileDailyDigest above. This one is the
+  // management digest, which the reader may file as Art. 20 / section 38 evidence.
+  const nis2FrameworkId = await getNis2FrameworkId(db);
+  if (!nis2FrameworkId) return null;
+
   const assessments = await db.query.companyAssessment.findMany({
-    where: eq(companyAssessment.companyId, companyId),
+    where: and(
+      eq(companyAssessment.companyId, companyId),
+      eq(companyAssessment.frameworkId, nis2FrameworkId),
+    ),
     columns: { id: true, compliancePercentage: true, completedRequirements: true, totalRequirements: true },
   });
 

--- a/lib/compliance/module-recheck.ts
+++ b/lib/compliance/module-recheck.ts
@@ -12,6 +12,7 @@ import { eq, and, sql, inArray } from "drizzle-orm";
 import {
   companyAssessment,
   companyRequirementStatus,
+  complianceFramework,
   requirement,
 } from "@/schema";
 import { logAudit } from "@/lib/audit";
@@ -58,10 +59,22 @@ async function revertSignOffs(
   moduleRef: string,
   ctx: RevertContext,
 ): Promise<void> {
+  // NIS 2 only. Unscoped, an operational-module edit reverted hidden GDPR /
+  // AI Act / CRA sign-offs too and wrote their codes into the audit-log entry
+  // the user reads on /audit ("reverted 7 requirement(s): NIS2-2.1, DSGVO-30, ...").
   const assessments = await db
     .select({ id: companyAssessment.id })
     .from(companyAssessment)
-    .where(eq(companyAssessment.companyId, ctx.companyId));
+    .innerJoin(
+      complianceFramework,
+      eq(complianceFramework.id, companyAssessment.frameworkId),
+    )
+    .where(
+      and(
+        eq(companyAssessment.companyId, ctx.companyId),
+        eq(complianceFramework.code, "nis2"),
+      ),
+    );
 
   if (assessments.length === 0) return;
 

--- a/packages/grc-data-model/src/seed.ts
+++ b/packages/grc-data-model/src/seed.ts
@@ -28,6 +28,8 @@
  *     effectiveDate: "2024-08-01",
  *     codePrefix: "AI-",
  *     sidebarLabel: "aiact",
+ *     // Seed the reference data, keep it out of the UI. Only NIS 2 is active.
+ *     isActive: false,
  *     categories: euAiActCategories,
  *     getRequirements: getEuAiActRequirementsForCategory,
  *   });
@@ -72,6 +74,16 @@ export interface FrameworkSeedSpec {
   codePrefix: string;
   /** Sidebar label / i18n key, e.g. "aiact". */
   sidebarLabel: string;
+  /**
+   * Drives every framework-scoped surface: the sidebar and /compliance pages
+   * (`getAllActiveCategories`) and what a new signup is provisioned
+   * (`createAssessmentsForFrameworks`). Declared per framework rather than
+   * hardcoded here, because the upsert below re-asserts it on every rerun: a
+   * hardcoded `true` silently reactivated a framework someone had switched off.
+   * Reference data for an inactive framework is still seeded, so satisfaction
+   * pairs keep resolving and existing tenants keep their rows.
+   */
+  isActive: boolean;
   categories: FrameworkCategory[];
   getRequirements: (slug: string) => FrameworkRequirement[];
 }
@@ -110,7 +122,7 @@ export async function seedFramework<TSchema extends Record<string, unknown>>(
       code: spec.code,
       version: spec.version,
       effectiveDate: spec.effectiveDate,
-      isActive: true,
+      isActive: spec.isActive,
       codePrefix: spec.codePrefix,
       sidebarLabel: spec.sidebarLabel,
     })
@@ -119,7 +131,7 @@ export async function seedFramework<TSchema extends Record<string, unknown>>(
       set: {
         version: spec.version,
         effectiveDate: spec.effectiveDate,
-        isActive: true,
+        isActive: spec.isActive,
         codePrefix: spec.codePrefix,
         sidebarLabel: spec.sidebarLabel,
       },

--- a/server/trpc/helpers/nis2-scope.ts
+++ b/server/trpc/helpers/nis2-scope.ts
@@ -1,0 +1,99 @@
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  companyAssessment,
+  companyRequirementStatus,
+  complianceFramework,
+} from "@/schema";
+import type { Database } from "@/lib/db";
+
+/**
+ * NIS 2 is the only framework the product surfaces.
+ *
+ * Tenants provisioned before this rule still hold GDPR / EU AI Act / EU CRA
+ * assessments and their `company_requirement_status` rows: deactivating a
+ * framework hides it, it does not delete anything. So every query that COUNTS
+ * or LISTS a tenant's requirements for display has to scope itself, or those
+ * rows keep leaking into the UI. That is how the admin dashboard came to read
+ * 101 requirements per company (49 NIS2 + 7 GDPR + 24 AI Act + 21 CRA) when
+ * only the 49 are the product.
+ *
+ * Deliberately NOT used by:
+ *   - `propagateSatisfaction` (assessment-helpers.ts), which must span every
+ *     assessment so signing a NIS2 requirement still credits the linked GDPR
+ *     or ISO 27001 one. That cross-framework credit is the point of the
+ *     mapping, and scoping it would silently break it.
+ *   - the `assessmentId` ownership checks in evidence.ts / review.ts, which
+ *     are tenancy guards. They must keep matching any row the tenant owns.
+ */
+export const NIS2_FRAMEWORK_CODE = "nis2" as const;
+
+/** The NIS 2 framework row id, or null when it has not been seeded. */
+export async function getNis2FrameworkId(
+  db: Database,
+): Promise<string | null> {
+  const framework = await db.query.complianceFramework.findFirst({
+    where: eq(complianceFramework.code, NIS2_FRAMEWORK_CODE),
+    columns: { id: true },
+  });
+  return framework?.id ?? null;
+}
+
+/**
+ * A company's NIS 2 assessment ids. Empty when the framework is unseeded or
+ * the tenant has no NIS 2 assessment, which callers must treat as "no data"
+ * rather than "no filter": an empty `inArray` matches nothing, which is the
+ * safe direction.
+ */
+export async function getNis2AssessmentIds(
+  db: Database,
+  companyId: string,
+): Promise<string[]> {
+  const frameworkId = await getNis2FrameworkId(db);
+  if (!frameworkId) return [];
+
+  const rows = await db
+    .select({ id: companyAssessment.id })
+    .from(companyAssessment)
+    .where(
+      and(
+        eq(companyAssessment.companyId, companyId),
+        eq(companyAssessment.frameworkId, frameworkId),
+      ),
+    );
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Predicate restricting `company_requirement_status` rows to NIS 2 assessments
+ * across EVERY tenant at once.
+ *
+ * The nightly deadline cron sweeps globally rather than per company, so it
+ * cannot use `getNis2AssessmentIds`. Without this it flips hidden GDPR / AI Act
+ * / CRA rows to needs_review, backfills review dates onto them, and mails the
+ * user reminders naming requirement codes like DSGVO-3.1 for a framework the
+ * product no longer shows.
+ *
+ * Must stay a subquery BUILDER, not a raw `sql` template. The cron calls this
+ * inside Drizzle's relational query builder, which rewrites every Column chunk
+ * of a raw template to the ROOT table alias: the same predicate written as
+ * sql`...` compiled to `"companyRequirementStatus"."code"` and
+ * `"companyRequirementStatus"."framework_id"`, neither of which exists on that
+ * table, so Postgres raised 42703 and phases 1-5 of the cron aborted. A
+ * builder survives the remapping. `bun run e2e/l0/nis2-scope.test.ts` pins the
+ * compiled SQL; the browser suite never hits this route.
+ */
+export function nis2StatusScope(db: Database) {
+  return inArray(
+    companyRequirementStatus.assessmentId,
+    db
+      .select({ id: companyAssessment.id })
+      .from(companyAssessment)
+      .innerJoin(
+        complianceFramework,
+        and(
+          eq(complianceFramework.id, companyAssessment.frameworkId),
+          eq(complianceFramework.code, NIS2_FRAMEWORK_CODE),
+        ),
+      ),
+  );
+}

--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -37,6 +37,7 @@ import {
 } from "../helpers/sign-off-completion";
 
 import type { Database } from "@/lib/db";
+import { getNis2FrameworkId } from "../helpers/nis2-scope";
 
 const DONE_STATUSES = new Set(["completed", "approved", "not_applicable"]);
 
@@ -127,10 +128,19 @@ export const assessmentRouter = router({
   // Assessment queries
   // ---------------------------------------------------------------------------
 
+  // The compliance pages read this to resolve "the" assessment. Unscoped and
+  // unordered it returned whichever row Postgres happened to hand back, so a
+  // tenant provisioned with GDPR / AI Act / CRA assessments alongside NIS 2
+  // could render a NIS 2 category against a GDPR assessment.
   getActiveAssessment: protectedProcedure.query(async ({ ctx }) => {
     if (!ctx.companyId) return null;
+    const frameworkId = await getNis2FrameworkId(ctx.db);
+    if (!frameworkId) return null;
     const assessment = await ctx.db.query.companyAssessment.findFirst({
-      where: eq(companyAssessment.companyId, ctx.companyId),
+      where: and(
+        eq(companyAssessment.companyId, ctx.companyId),
+        eq(companyAssessment.frameworkId, frameworkId),
+      ),
     });
     return assessment ?? null;
   }),
@@ -153,10 +163,17 @@ export const assessmentRouter = router({
       return assessment ?? null;
     }),
 
+  // Feeds the portal sidebar and the export page, so it is NIS 2 only. A
+  // tenant's GDPR / AI Act / CRA assessment rows are kept, just not surfaced.
   listAssessments: protectedProcedure.query(async ({ ctx }) => {
     if (!ctx.companyId) return [];
+    const frameworkId = await getNis2FrameworkId(ctx.db);
+    if (!frameworkId) return [];
     return ctx.db.query.companyAssessment.findMany({
-      where: eq(companyAssessment.companyId, ctx.companyId),
+      where: and(
+        eq(companyAssessment.companyId, ctx.companyId),
+        eq(companyAssessment.frameworkId, frameworkId),
+      ),
       with: {
         framework: {
           columns: { id: true, code: true, version: true },
@@ -287,7 +304,19 @@ export const assessmentRouter = router({
               .set({ entityTypeAtAssessment: input.entityType, updatedAt: new Date() })
               .where(eq(companyAssessment.companyId, companyId));
             frameworkAssessmentMap = new Map(seeded.map((a) => [a.frameworkId, a.id]));
-            firstAssessmentId = seeded[0].id;
+            // This id is returned to the client and decides where activation
+            // lands the user. A legacy draft carries one assessment per
+            // framework that was active at draft time, so seeded[0] could hand
+            // them their GDPR assessment. Prefer NIS 2, fall back only if the
+            // draft genuinely has none.
+            const nis2Framework = await tx.query.complianceFramework.findFirst({
+              where: eq(complianceFramework.code, "nis2"),
+              columns: { id: true },
+            });
+            const nis2Seeded = nis2Framework
+              ? seeded.find((a) => a.frameworkId === nis2Framework.id)
+              : undefined;
+            firstAssessmentId = (nis2Seeded ?? seeded[0]).id;
           }
         } else {
           // No draft (edge / legacy path) — create, own, seed, activate in one.

--- a/server/trpc/routers/dashboard.ts
+++ b/server/trpc/routers/dashboard.ts
@@ -14,7 +14,6 @@ import {
   patchRecord,
   internalAudit,
   improvementItem,
-  companyAssessment,
   companyRequirementStatus,
   requirement,
   requirementCategory,
@@ -29,6 +28,7 @@ import {
   type Priority,
   type Importance,
 } from "@/lib/compliance/deadlines";
+import { getNis2AssessmentIds } from "../helpers/nis2-scope";
 import requirementsEn from "@/messages/requirements/en.json";
 
 export const dashboardRouter = router({
@@ -179,12 +179,7 @@ export const dashboardRouter = router({
   }),
 
   complianceProgress: companyProcedure.query(async ({ ctx }) => {
-    const assessments = await ctx.db
-      .select({ id: companyAssessment.id })
-      .from(companyAssessment)
-      .where(eq(companyAssessment.companyId, ctx.companyId));
-
-    const assessmentIds = assessments.map((a) => a.id);
+    const assessmentIds = await getNis2AssessmentIds(ctx.db, ctx.companyId);
     if (assessmentIds.length === 0) return { completed: 0, total: 0 };
 
     const [completedRows, totalRows] = await Promise.all([
@@ -214,13 +209,7 @@ export const dashboardRouter = router({
   }),
 
   deadlines: companyProcedure.query(async ({ ctx }) => {
-    // Get all assessments for this company
-    const assessments = await ctx.db
-      .select({ id: companyAssessment.id })
-      .from(companyAssessment)
-      .where(eq(companyAssessment.companyId, ctx.companyId));
-
-    const assessmentIds = assessments.map((a) => a.id);
+    const assessmentIds = await getNis2AssessmentIds(ctx.db, ctx.companyId);
     if (assessmentIds.length === 0) return null;
 
     // Get all status rows with nextReviewDate, joined with requirement and category

--- a/server/trpc/routers/llm.ts
+++ b/server/trpc/routers/llm.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure, companyProcedure } from "../init";
 import { extractFromText } from "@/lib/forms/llm-prefill-action";
@@ -9,6 +9,7 @@ import { loadReportData } from "@/lib/pdf/load-report-data";
 import { evaluateSection as evalSection } from "@/lib/eval/evaluate-section";
 import { evaluateAssessment } from "@/lib/eval/evaluate-assessment";
 import { BSIG_SECTIONS } from "@/lib/eval/bsig-sections";
+import { getNis2FrameworkId } from "../helpers/nis2-scope";
 
 /**
  * Hard-fail any LLM call when the company has opted out of AI data sharing.
@@ -77,9 +78,18 @@ export const llmRouter = router({
       // Honor the aiDataSharing="none" opt-out before loading sign-off snapshots.
       await requireAiEnabled(ctx.db, ctx.companyId);
 
-      const assessment = await ctx.db.query.companyAssessment.findFirst({
-        where: eq(companyAssessment.companyId, ctx.companyId),
-      });
+      // NIS 2 only. Unscoped this graded whichever assessment Postgres
+      // returned first, so /audit-readiness could score a tenant's GDPR
+      // assessment and report it as their NIS 2 readiness.
+      const nis2FrameworkId = await getNis2FrameworkId(ctx.db);
+      const assessment = nis2FrameworkId
+        ? await ctx.db.query.companyAssessment.findFirst({
+            where: and(
+              eq(companyAssessment.companyId, ctx.companyId),
+              eq(companyAssessment.frameworkId, nis2FrameworkId),
+            ),
+          })
+        : null;
       if (!assessment) {
         throw new TRPCError({ code: "NOT_FOUND", message: "No assessment found" });
       }
@@ -108,9 +118,18 @@ export const llmRouter = router({
       // Honor the aiDataSharing="none" opt-out before loading sign-off snapshots.
       await requireAiEnabled(ctx.db, ctx.companyId);
 
-      const assessment = await ctx.db.query.companyAssessment.findFirst({
-        where: eq(companyAssessment.companyId, ctx.companyId),
-      });
+      // NIS 2 only. Unscoped this graded whichever assessment Postgres
+      // returned first, so /audit-readiness could score a tenant's GDPR
+      // assessment and report it as their NIS 2 readiness.
+      const nis2FrameworkId = await getNis2FrameworkId(ctx.db);
+      const assessment = nis2FrameworkId
+        ? await ctx.db.query.companyAssessment.findFirst({
+            where: and(
+              eq(companyAssessment.companyId, ctx.companyId),
+              eq(companyAssessment.frameworkId, nis2FrameworkId),
+            ),
+          })
+        : null;
       if (!assessment) {
         throw new TRPCError({ code: "NOT_FOUND", message: "No assessment found" });
       }

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -18,6 +18,7 @@ import {
   company,
   companyAssessment,
   companyRequirementStatus,
+  complianceFramework,
   trainingLessonProgress,
   supplier,
   notification,
@@ -31,6 +32,7 @@ import { logAudit } from "@/lib/audit";
 import { eraseUser, previewUserErasure } from "@/lib/gdpr/erase-user";
 import { buildErasureCertificate, erasureCertificateFilename } from "@/lib/gdpr/certificate";
 import { rateLimit } from "@/lib/rate-limit";
+import { NIS2_FRAMEWORK_CODE } from "../helpers/nis2-scope";
 
 // Character set (not a secret) for human-friendly share passwords —
 // confusable chars (0, O, I, l, 1) intentionally excluded so the password
@@ -162,8 +164,14 @@ export const platformAdminRouter = router({
         activatedAt: company.activatedAt,
         createdAt: company.createdAt,
         userCount: sql<number>`(SELECT count(*)::int FROM "user" WHERE "user"."company_id" = ${company.id})`,
+        // NIS 2 only. LIMIT 1 with no ORDER BY and no framework predicate
+        // returned an arbitrary framework's percentage for the Companies tab.
         compliancePct: sql<string>`COALESCE(
-          (SELECT ca.compliance_percentage FROM company_assessment ca WHERE ca.company_id = ${company.id} LIMIT 1),
+          (SELECT ca.compliance_percentage
+             FROM company_assessment ca
+             JOIN compliance_framework cf ON cf.id = ca.framework_id
+            WHERE ca.company_id = ${company.id} AND cf.code = 'nis2'
+            LIMIT 1),
           '0'
         )`,
       })
@@ -191,6 +199,17 @@ export const platformAdminRouter = router({
       .from(companyRequirementStatus)
       .innerJoin(companyAssessment, eq(companyRequirementStatus.assessmentId, companyAssessment.id))
       .innerJoin(company, eq(companyAssessment.companyId, company.id))
+      // NIS 2 only. Without this the totals read 101 or 103 per company -- the
+      // sum of every framework a tenant was ever provisioned -- and understate
+      // real NIS 2 progress by roughly half. Inline rather than via
+      // getNis2AssessmentIds because this query spans all companies at once.
+      .innerJoin(
+        complianceFramework,
+        and(
+          eq(companyAssessment.frameworkId, complianceFramework.id),
+          eq(complianceFramework.code, NIS2_FRAMEWORK_CODE),
+        ),
+      )
       .groupBy(company.id, company.name)
       .orderBy(desc(sql`count(*) FILTER (WHERE ${companyRequirementStatus.status} IN ('completed', 'approved'))`));
 

--- a/server/trpc/routers/requirement.ts
+++ b/server/trpc/routers/requirement.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, asc } from "drizzle-orm";
+import { eq, and, asc } from "drizzle-orm";
 import { router, publicProcedure } from "../init";
 import {
   complianceFramework,
@@ -20,7 +20,12 @@ export const requirementRouter = router({
           ctx.db
             .select({ id: complianceFramework.id })
             .from(complianceFramework)
-            .where(eq(complianceFramework.code, input.frameworkCode as FrameworkCode))
+            .where(
+              and(
+                eq(complianceFramework.code, input.frameworkCode as FrameworkCode),
+                eq(complianceFramework.isActive, true),
+              ),
+            )
             .limit(1)
         ),
         orderBy: asc(requirementCategory.sortOrder),
@@ -58,12 +63,19 @@ export const requirementRouter = router({
               nationalUrl: true,
             },
             with: {
-              framework: { columns: { code: true } },
+              framework: { columns: { code: true, isActive: true } },
             },
           },
         },
       });
-      return req ?? null;
+      // These are publicProcedures keyed on a bare code / slug, so a bookmark,
+      // a digest-email link or a hand-typed URL reaches them directly. Without
+      // this gate /compliance/gdpr-toms/DSGVO-3.1 renders a complete, fully
+      // translated GDPR requirement page for a product that only sells NIS 2.
+      // Gating on isActive rather than on code === "nis2" keeps one switch:
+      // the same flag the sidebar and /compliance already read.
+      if (!req || !req.category.framework.isActive) return null;
+      return req;
     }),
 
   listByCategorySlug: publicProcedure
@@ -73,11 +85,13 @@ export const requirementRouter = router({
         where: eq(requirementCategory.slug, input.slug),
         with: {
           framework: {
-            columns: { code: true, codePrefix: true, sidebarLabel: true },
+            columns: { code: true, codePrefix: true, sidebarLabel: true, isActive: true },
           },
         },
       });
-      if (!category) return { category: null, requirements: [] };
+      if (!category || !category.framework.isActive) {
+        return { category: null, requirements: [] };
+      }
 
       const requirements = await ctx.db.query.requirement.findMany({
         where: eq(requirement.categoryId, category.id),

--- a/server/trpc/routers/review.ts
+++ b/server/trpc/routers/review.ts
@@ -12,19 +12,14 @@ import {
 import { sendMail, reviewDecisionEmail } from "@/lib/mail";
 import { scheduleDeadlineReminders } from "@/lib/compliance/schedule-notifications";
 import type { Database } from "@/lib/db";
+import { getNis2AssessmentIds } from "../helpers/nis2-scope";
 
 export const reviewRouter = router({
   /** All submission statuses for the reviewer's company */
   list: reviewerProcedure.query(async ({ ctx }) => {
     if (!ctx.companyId) return [];
 
-    // Get all assessment IDs for the company
-    const assessments = await ctx.db
-      .select({ id: companyAssessment.id })
-      .from(companyAssessment)
-      .where(eq(companyAssessment.companyId, ctx.companyId));
-
-    const assessmentIds = assessments.map((a) => a.id);
+    const assessmentIds = await getNis2AssessmentIds(ctx.db, ctx.companyId);
     if (assessmentIds.length === 0) return [];
 
     // Fetch all statuses with relational joins
@@ -162,12 +157,7 @@ export const reviewRouter = router({
   countPending: reviewerProcedure.query(async ({ ctx }) => {
     if (!ctx.companyId) return 0;
 
-    const assessments = await ctx.db
-      .select({ id: companyAssessment.id })
-      .from(companyAssessment)
-      .where(eq(companyAssessment.companyId, ctx.companyId));
-
-    const assessmentIds = assessments.map((a) => a.id);
+    const assessmentIds = await getNis2AssessmentIds(ctx.db, ctx.companyId);
     if (assessmentIds.length === 0) return 0;
 
     const [result] = await ctx.db

--- a/server/trpc/routers/team.ts
+++ b/server/trpc/routers/team.ts
@@ -19,6 +19,7 @@ import { ALL_ROLE_KEYS } from "@/lib/compliance/role-mapping";
 import { resolveRoleAssignments } from "../helpers/resolve-role-assignments";
 import { discardDraftCompany } from "../helpers/setup-helpers";
 import { verifyAssessmentOwnership } from "../guards";
+import { getNis2AssessmentIds } from "../helpers/nis2-scope";
 
 const INVITE_EXPIRY_DAYS = 7;
 
@@ -43,12 +44,9 @@ export const teamRouter = router({
       },
     });
 
-    // Fetch all category-level assignments for this company's assessments
-    const assessments = await ctx.db.query.companyAssessment.findMany({
-      where: eq(companyAssessment.companyId, ctx.companyId),
-      columns: { id: true },
-    });
-    const assessmentIds = assessments.map((a) => a.id);
+    // Category-level assignments, NIS 2 only: the /team page listed member
+    // assignments carrying DSGVO / AI-Act / CRA category codes otherwise.
+    const assessmentIds = await getNis2AssessmentIds(ctx.db, ctx.companyId);
 
     if (assessmentIds.length === 0) {
       return members.map((m) => ({ ...m, assignments: [] as Array<{ categoryCode: string; categoryName: string }> }));


### PR DESCRIPTION
## Why

`createAssessmentsForFrameworks` (`server/trpc/helpers/setup-helpers.ts:116`) provisioned one assessment plus one status row per requirement for **every** framework with `is_active = true`, with no NIS 2 filter and no user choice.

Measured on production 2026-08-25, tenants carry 56, 101 or 103 requirement rows where the product only has 49:

| Total | Decomposition | Cohort |
|---|---|---|
| 56 | 49 nis2 + 7 gdpr | oldest |
| 101 | 49 nis2 + 7 gdpr + 24 eu_ai_act + 21 eu_cra | main |
| 103 | 49 nis2 + **9** gdpr + 24 eu_ai_act + 21 eu_cra | after #72 |

Every progress percentage was computed against a denominator roughly twice the real one. A tenant who finished all of NIS 2 read 49/101 = 48%.

## Two halves, because neither works alone

**The flag.** `is_active` is now declared per framework instead of hardcoded `true` in `seedFramework`'s insert *and* its `onConflictDoUpdate`. That hardcoded `true` is why the flag could never stick: any seed rerun silently reactivated the framework it had just been switched off. Migration `0012` carries the flip to existing databases.

**The queries.** The flag alone cannot fix the counts, because the rows it hides stay in the database by design. Every query that counts or lists a tenant's requirements for display is now scoped through `server/trpc/helpers/nis2-scope.ts`.

The one that mattered most was not the flag: `requirement.getByCode` and `listByCategorySlug` are `publicProcedure`s keyed on a bare code, so `/compliance/gdpr-toms` rendered a complete, fully translated, sign-off-capable GDPR page to anyone who typed the URL. Both are now gated on `framework.isActive` rather than a second hardcoded `"nis2"`, so the switch stays in one place.

`getActiveAssessment` also had no ordering. For a tenant holding four assessments it returned an arbitrary one, so all three `/compliance` pages could bind to the GDPR assessment and render every NIS 2 requirement as `not_started`.

## Deliberately not scoped

`propagateSatisfaction` must keep spanning every assessment so signing a NIS 2 requirement still credits the linked GDPR or ISO 27001 one. That cross-framework credit is the reason the other frameworks were modelled at all. Same for the `assessmentId` ownership checks in `evidence.ts` and `review.ts`, which are tenancy guards.

## Nothing is deleted

Verified on a rebuilt production-shaped tenant (5 active frameworks, 219 status rows):

| | before | after |
|---|---|---|
| `company_requirement_status` | 219 | **219** |
| `company_assessment` | 5 | **5** |
| `requirement_satisfaction` | 38 | **38** |
| platform-admin total for the tenant | 219 | **49** |

Pending reminders queued against a hidden framework are set to `cancelled`, an existing status value, so the next cron does not mail "Reminder: DSGVO-3.1 review due". Already-sent rows keep their delivery record.

## A bug this PR introduced and then caught

`nis2StatusScope` is a subquery **builder**, not a raw `sql` template, and `e2e/l0/nis2-scope.test.ts` pins that.

Written as `` sql`...` `` it compiled inside Drizzle's relational query builder to `"companyRequirementStatus"."code"` and `"companyRequirementStatus"."framework_id"`, neither of which exists on that table. Postgres 42703, and phases 1 to 5 of the nightly cron aborting behind a single audit row: no review transitions, no deadline backfill, no reminders, no escalation, no digests.

**Two full green e2e runs did not catch it**, because no spec requests `/api/cron/deadlines`. The new L0 test fails 3 of 4 assertions against the broken version.

## Verification

- 84/84 e2e, 114/114 L0, typecheck clean, migration journals consistent
- Cron returns 200 against a 5-framework tenant and leaves all 170 non-NIS 2 rows untouched (the 9 `not_started` GDPR rows with NULL review dates are exactly phase 2's target and were correctly skipped)
- No slug or code collisions across all five frameworks, verified by executing the category arrays
- Before/after screenshots captured via `e2e/nis2-only-screenshots.ts`; all six surfaces clean, all four hidden category URLs return "Kategorie nicht gefunden"

## Deploy note

Merging redeploys via Coolify. `runtime-migrate.mjs` applies `0012` at container start, so existing tenants' dashboards change on first boot: totals drop from 101/103 to 49 and percentages roughly double.