### PR TITLE
Fix: platform-admin Companies tab 500s on an ambiguous column

### DIFF
--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -163,14 +163,23 @@ export const platformAdminRouter = router({
         actsAsSupplier: company.actsAsSupplier,
         activatedAt: company.activatedAt,
         createdAt: company.createdAt,
-        userCount: sql<number>`(SELECT count(*)::int FROM "user" WHERE "user"."company_id" = ${company.id})`,
+        // "company"."id" is written out rather than interpolated as
+        // ${company.id}. Drizzle only qualifies a column with its table when
+        // the outer query has a join; this one selects from `company` alone,
+        // so the interpolation renders as a bare "id". Inside these correlated
+        // subqueries that bare name binds to the SUBQUERY's own table, which
+        // silently made both of these compare a row's id to its own foreign
+        // key (always false: userCount 0, compliancePct '0' for every row),
+        // and became an outright "column reference id is ambiguous" error the
+        // moment the compliance_framework join below put a second id in scope.
+        userCount: sql<number>`(SELECT count(*)::int FROM "user" u WHERE u.company_id = "company"."id")`,
         // NIS 2 only. LIMIT 1 with no ORDER BY and no framework predicate
         // returned an arbitrary framework's percentage for the Companies tab.
         compliancePct: sql<string>`COALESCE(
           (SELECT ca.compliance_percentage
              FROM company_assessment ca
              JOIN compliance_framework cf ON cf.id = ca.framework_id
-            WHERE ca.company_id = ${company.id} AND cf.code = 'nis2'
+            WHERE ca.company_id = "company"."id" AND cf.code = 'nis2'
             LIMIT 1),
           '0'
         )`,


### PR DESCRIPTION
**Production hotfix.** The platform-admin page is down.

## What broke

#84 added `JOIN compliance_framework cf` to the `compliancePct` subquery so the Companies tab would show the NIS 2 percentage rather than an arbitrary framework's. That join put a second `id` into the subquery's scope:

```
ERROR:  column reference "id" is ambiguous
LINE 1: ... ON cf.id = ca.framework_id WHERE ca.company_id = "id" AND c...
```

## Why

Drizzle only qualifies an interpolated column with its table name when the **outer query has a join**. Confirmed with `toSQL()`:

```
.from(company) alone         ->  ca.company_id = "id"
.from(x).innerJoin(company)  ->  u.company_id = "company"."id"
```

The companies list selects from `company` with no join, so `${company.id}` rendered as a bare `"id"`. `complianceActivity` directly below it has joins, which is why its `adminEmail` subquery was always correct and why only this one tab broke.

Both subqueries now use an explicit `"company"."id"` instead of the interpolation.

## It also fixes a bug older than #84

With one table in scope, the bare `"id"` bound to the **subquery's own** table, so the conditions read `"user"."company_id" = "user"."id"` and `ca.company_id = ca.id`. Both are essentially never true. The Companies tab has been reporting **0 users and 0% compliance for every company** since that column was added. #84 did not break those numbers; it turned a wrong answer into an error.

Measured against a database where Dev GmbH has NIS 2 at 42%, ISO 27001 at 77%, and one user:

| version | users | pct | |
|---|---|---|---|
| pre-#84 | `0` | `"0"` | silently wrong |
| main (deployed) | ERROR | ERROR | page 500s |
| **this fix** | `1` | `"42.00"` | matches truth |

The `42.00` rather than `77.00` also confirms the NIS 2 scoping #84 intended is now actually working.

## Verification

Driven in a real browser against a production build. `/de/platform-admin` returns 200, and all tabs (Users, Companies, Compliance, Training, Suppliers, Emails) render with zero 4xx, 5xx or page errors.

Swept for the same pattern elsewhere: `adminEmail` is safe (its query has joins), and `dashboard.ts:171` interpolates a plain string rather than a column. No other correlated subquery interpolates a column into a join-free query.

## What I should have caught

The build, typecheck and 84/84 e2e all passed on #84. None of them exercise `/platform-admin` — it is gated behind `PLATFORM_ADMIN_EMAILS`, which the e2e harness does not set, so no spec can reach it. That gap is why a hard SQL error shipped.