### PR TITLE
fix(toms): correct published auth and monitoring claims, unhardcode the cal link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,13 @@ CRON_SECRET=
 # App URL
 NEXT_PUBLIC_APP_URL=http://localhost:3026
 
+# Cal.com booking handle behind the "book a call" surfaces on /start and the
+# applicability result. Either a bare handle (nisd2) or handle/event-type
+# (acme/intro). Leave empty and neither is rendered.
+# Never inherit someone else's handle: point this at your own calendar or
+# leave it unset.
+CAL_LINK=
+
 # Set to 1 once the deployment is HTTPS-only with a real certificate. Turns on
 # HSTS and the CSP upgrade-insecure-requests directive. Leave unset on http
 # staging URLs: HSTS pins HTTPS for two years on that hostname once anyone

--- a/app/[locale]/start/page.tsx
+++ b/app/[locale]/start/page.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { FunnelFaq } from "@/components/funnel/FunnelFaq";
 import { CalBooker } from "@/components/funnel/CalBooker";
+import { env } from "@/lib/env";
 
 const processSteps = [
   { key: "step1", icon: Clock },
@@ -47,11 +48,13 @@ export default async function FunnelPage() {
         <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
           {t("hero.subhead")}
         </p>
-        <div className="mt-8">
-          <Button asChild size="lg">
-            <a href="#book">{t("hero.cta")}</a>
-          </Button>
-        </div>
+        {env.CAL_LINK && (
+          <div className="mt-8">
+            <Button asChild size="lg">
+              <a href="#book">{t("hero.cta")}</a>
+            </Button>
+          </div>
+        )}
         <p className="mt-4 text-sm text-muted-foreground">{t("hero.trust")}</p>
         <p className="mt-3 text-sm">
           <Link
@@ -145,18 +148,21 @@ export default async function FunnelPage() {
         </div>
       </section>
 
-      {/* Book a call */}
-      <section id="book" className="mx-auto max-w-4xl scroll-mt-16 py-16 sm:py-24">
-        <h2 className="text-center text-3xl font-bold tracking-tight">
-          {t("finalCta.headline")}
-        </h2>
-        <p className="mt-4 text-center text-sm text-muted-foreground">
-          {t("finalCta.email")}
-        </p>
-        <div className="mt-8">
-          <CalBooker calLink="sorzel/work" />
-        </div>
-      </section>
+      {/* Book a call. Hidden where no calendar is configured, so a self-hosted
+          instance never embeds someone else's booking page. */}
+      {env.CAL_LINK && (
+        <section id="book" className="mx-auto max-w-4xl scroll-mt-16 py-16 sm:py-24">
+          <h2 className="text-center text-3xl font-bold tracking-tight">
+            {t("finalCta.headline")}
+          </h2>
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            {t("finalCta.email")}
+          </p>
+          <div className="mt-8">
+            <CalBooker calLink={env.CAL_LINK} />
+          </div>
+        </section>
+      )}
 
       {/* Sources */}
       <section className="mx-auto max-w-3xl">

--- a/components/applicability/ApplicabilityCheck.tsx
+++ b/components/applicability/ApplicabilityCheck.tsx
@@ -63,7 +63,7 @@ function getStepIndex(step: Step): number {
   return STEPS.indexOf(step);
 }
 
-export function ApplicabilityCheck() {
+export function ApplicabilityCheck({ calLink }: { calLink: string }) {
   const t = useTranslations("applicability");
   const locale = useLocale();
 
@@ -314,7 +314,7 @@ export function ApplicabilityCheck() {
                 <RotateCcw className="h-4 w-4" />
                 <span className="hidden sm:inline">{t("result.restart")}</span>
               </Button>
-              <CalModal>
+              <CalModal calLink={calLink}>
                 <Button
                   variant={result && result.classification !== "not_in_scope" ? "default" : "outline"}
                   className="gap-2 whitespace-normal text-right"

--- a/components/applicability/ApplicabilitySection.tsx
+++ b/components/applicability/ApplicabilitySection.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { env } from "@/lib/env";
 import { ApplicabilityCheck } from "./ApplicabilityCheck";
 import { NationalAuthorityCallout } from "./NationalAuthorityCallout";
 
@@ -24,7 +25,7 @@ export async function ApplicabilitySection({
         </p>
       </section>
 
-      <ApplicabilityCheck />
+      <ApplicabilityCheck calLink={env.CAL_LINK} />
     </div>
   );
 }

--- a/components/funnel/CalModal.tsx
+++ b/components/funnel/CalModal.tsx
@@ -3,18 +3,27 @@
 import { getCalApi } from "@calcom/embed-react";
 import { useEffect } from "react";
 
-export function CalModal({ children }: { children: React.ReactNode }) {
+interface CalModalProps {
+  calLink: string;
+  children: React.ReactNode;
+}
+
+export function CalModal({ calLink, children }: CalModalProps) {
   useEffect(() => {
+    if (!calLink) return;
+
     (async function () {
       const cal = await getCalApi({ namespace: "work" });
       cal("ui", { hideEventTypeDetails: false, layout: "month_view" });
     })();
-  }, []);
+  }, [calLink]);
+
+  if (!calLink) return null;
 
   return (
     <span
       data-cal-namespace="work"
-      data-cal-link="sorzel/work"
+      data-cal-link={calLink}
       data-cal-config='{"layout":"month_view","useSlotsViewOnSmallScreen":"true"}'
     >
       {children}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -55,6 +55,15 @@ const envSchema = z.object({
   // App URL
   NEXT_PUBLIC_APP_URL: z.string().default("https://www.nisd2.eu"),
 
+  // Cal.com booking handle behind the "book a call" surfaces. Either a bare
+  // handle ("nisd2") or handle/event-type ("acme/intro").
+  // Empty by default on purpose: a self-hosted instance must not embed someone
+  // else's calendar. Where it is unset, the booking UI is not rendered at all.
+  // Read server-side and passed down as a prop, not NEXT_PUBLIC_: the Dockerfile
+  // declares no build args, so a NEXT_PUBLIC_ value set in the deploy platform
+  // would never reach the client bundle.
+  CAL_LINK: z.string().default(""),
+
   // Standard
   NODE_ENV: z
     .enum(["development", "production", "test"])

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -703,10 +703,10 @@
         "p1": "Opatření zajišťující důvěrnost:",
         "items": {
           "physical": "Kontrola fyzického přístupu: datová centra poskytovatelů hostingu (Hetzner, AWS) mají certifikace ISO 27001",
-          "auth": "Ověřování: výhradně přes Google OAuth 2.0; na platformě se neukládají žádná hesla. MFA pro uživatele zajišťuje jejich účet Google",
+          "auth": "Ověřování: přihlášení e-mailovou adresou a heslem nebo přes Google OAuth 2.0. Hesla ukládáme výhradně jako otisk bcrypt s nákladovým faktorem 12, nikdy v otevřené podobě. Při registraci heslem se e-mailová adresa jednorázově potvrzuje jednorázovým kódem a neúspěšné pokusy o přihlášení jsou omezeny na 10 za 15 minut na instanci aplikace. Platforma nenabízí druhý faktor na heslové cestě. Kdo se přihlašuje přes Google, používá MFA vlastního účtu Google.",
           "rbac": "Oprávnění založená na rolích: admin, reviewer, member; vynucená v aplikační vrstvě přes middleware tRPC",
           "separation": "Izolace více tenantů: každý dotaz nesoucí data filtruje na databázové vrstvě podle ID společnosti ověřeného uživatele; žádné sdílené datové fondy mezi zákazníky",
-          "secrets": "Žádná hesla v otevřeném textu na platformě, ověřování probíhá výhradně přes OAuth",
+          "secrets": "Hesla nikdy neukládáme v otevřené podobě. Každé přihlášení se porovnává s otiskem bcrypt, i když k zadané adrese žádný účet neexistuje, aby z doby odpovědi nešlo odvodit, kdo je registrovaný.",
           "personnel": "Personální opatření: přístup k produkčním systémům a osobním údajům je omezen na malou, jmenovitě určenou skupinu vázanou mlčenlivostí. Přístup se řídí zásadou nejmenších oprávnění a odebírá se při ukončení role."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Ukládání důkazních dokumentů v AWS S3 se zárukami trvanlivosti objektů poskytovanými AWS",
           "rateLimit": "Omezení četnosti u pokusů o přihlášení, veřejných endpointů (kontrola působnosti, dodavatelský portál) a náročných ověřených endpointů (exporty PDF, generování certifikátů)",
           "uploadLimit": "Nahrávané soubory jsou omezeny na 50 MB na soubor",
-          "status": "Sledování dostupnosti: provozní stav platformy je průběžně sledován a veřejně viditelný na nisd2.eu/status."
+          "status": "Ukazatel dostupnosti: nisd2.eu/status při každém vyvolání ověří dostupnost databáze a výsledek veřejně zobrazí, s mezipamětí 30 sekund. Neprovozujeme průběžné sledování s automatickým alarmem."
         }
       },
       "evaluation": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -704,10 +704,10 @@
         "p1": "Maßnahmen zur Sicherstellung der Vertraulichkeit:",
         "items": {
           "physical": "Zutrittskontrolle: Rechenzentren der eingesetzten Hoster (Hetzner, AWS) verfügen über ISO 27001-Zertifizierungen",
-          "auth": "Authentifizierung: ausschließlich über Google OAuth 2.0; keine Speicherung von Passwörtern auf der Plattform. MFA für Nutzer wird über deren Google-Konto bereitgestellt",
+          "auth": "Authentifizierung: Anmeldung per E-Mail und Passwort oder über Google OAuth 2.0. Passwörter speichern wir ausschließlich als bcrypt-Hash mit Kostenfaktor 12, nie im Klartext. Bei der Registrierung per Passwort wird die E-Mail-Adresse einmalig über einen Einmalcode bestätigt, fehlgeschlagene Anmeldeversuche sind je Anwendungsinstanz auf 10 in 15 Minuten begrenzt. Eine zweite Stufe bietet die Plattform für den Passwortweg nicht an. Wer sich über Google anmeldet, nutzt die MFA des eigenen Google-Kontos.",
           "rbac": "Rollenbasierte Berechtigungen: Admin, Reviewer, Member; Trennung in der Anwendungsschicht über tRPC-Middleware",
           "separation": "Mandantentrennung: jede datentragende Abfrage filtert auf der Datenbankebene über die Company-ID des angemeldeten Nutzers; keine gemeinsamen Datenpools zwischen Kunden",
-          "secrets": "Keine Klartext-Passwörter auf der Plattform - Authentifizierung erfolgt ausschließlich über OAuth",
+          "secrets": "Passwörter werden nie im Klartext gespeichert. Der Abgleich läuft immer gegen einen bcrypt-Hash, auch wenn zu der angefragten E-Mail-Adresse kein Konto existiert, damit sich aus der Antwortzeit nicht ableiten lässt, wer registriert ist.",
           "personnel": "Personelle Maßnahmen: Zugriff auf Produktivsysteme und personenbezogene Daten ist auf einen kleinen, namentlich benannten Personenkreis beschränkt, der zur Vertraulichkeit verpflichtet ist. Zugänge folgen dem Prinzip der minimalen Rechte und werden bei Beendigung der Tätigkeit entzogen."
         }
       },
@@ -728,7 +728,7 @@
           "redundancy": "Speicherung von Nachweisdokumenten in AWS S3 mit der von AWS bereitgestellten Objekt-Haltbarkeit",
           "rateLimit": "Rate-Limiting auf Login-Versuchen, öffentlichen Endpunkten (Anwendbarkeitsprüfung, Lieferantenportal) sowie ressourcenintensiven authentifizierten Endpunkten (PDF-Exports, Zertifikat-Generierung)",
           "uploadLimit": "Hochgeladene Dateien sind auf 50 MB pro Datei begrenzt",
-          "status": "Verfügbarkeitsüberwachung: der Betriebsstatus der Plattform wird laufend überwacht und ist öffentlich unter nisd2.eu/status einsehbar."
+          "status": "Verfügbarkeitsanzeige: nisd2.eu/status prüft bei jedem Aufruf die Erreichbarkeit der Datenbank und zeigt das Ergebnis öffentlich an, zwischengespeichert für 30 Sekunden. Eine durchgehende Überwachung mit automatischer Alarmierung betreiben wir nicht."
         }
       },
       "evaluation": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -704,10 +704,10 @@
         "p1": "Measures ensuring confidentiality:",
         "items": {
           "physical": "Physical access control: data centres of the hosting providers (Hetzner, AWS) hold ISO 27001 certifications",
-          "auth": "Authentication: exclusively via Google OAuth 2.0; no passwords stored on the platform. MFA for users is provided through their Google account",
+          "auth": "Authentication: sign-in by email and password or through Google OAuth 2.0. Passwords are stored only as a bcrypt hash at cost factor 12, never in clear text. Password registrations confirm the email address once through a one-time code, and failed sign-in attempts are limited to 10 in 15 minutes per application instance. The platform offers no second factor on the password path. Users who sign in with Google rely on the MFA of their own Google account.",
           "rbac": "Role-based permissions: admin, reviewer, member; enforced in the application layer via tRPC middleware",
           "separation": "Multi-tenant isolation: every data-bearing query filters at the database layer on the company ID of the authenticated user; no shared data pools between customers",
-          "secrets": "No plaintext passwords on the platform - authentication is exclusively OAuth-based",
+          "secrets": "Passwords are never stored in clear text. Every sign-in is compared against a bcrypt hash, including when no account exists for the address supplied, so that response time cannot reveal who is registered.",
           "personnel": "Personnel measures: access to production systems and personal data is limited to a small, named group bound by confidentiality. Access follows the principle of least privilege and is revoked when a role ends."
         }
       },
@@ -728,7 +728,7 @@
           "redundancy": "Storage of evidence documents in AWS S3 with the object durability guarantees provided by AWS",
           "rateLimit": "Rate limiting on login attempts, public endpoints (applicability check, supplier portal), and resource-heavy authenticated endpoints (PDF exports, certificate generation)",
           "uploadLimit": "Uploaded files are limited to 50 MB per file",
-          "status": "Availability monitoring: the platform's operational status is continuously monitored and publicly visible at nisd2.eu/status."
+          "status": "Availability display: nisd2.eu/status checks database reachability on each request and shows the result publicly, cached for 30 seconds. We do not run continuous monitoring with automated alerting."
         }
       },
       "evaluation": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -703,10 +703,10 @@
         "p1": "Medidas que garantizan la confidencialidad:",
         "items": {
           "physical": "Control de acceso físico: los centros de datos de los proveedores de alojamiento (Hetzner, AWS) cuentan con certificaciones ISO 27001",
-          "auth": "Autenticación: exclusivamente mediante Google OAuth 2.0; no se almacenan contraseñas en la plataforma. La MFA para los usuarios se proporciona a través de su cuenta de Google",
+          "auth": "Autenticación: inicio de sesión con correo electrónico y contraseña o mediante Google OAuth 2.0. Las contraseñas se almacenan únicamente como hash bcrypt con factor de coste 12, nunca en texto claro. En el registro con contraseña, la dirección de correo se confirma una vez mediante un código de un solo uso, y los intentos fallidos de inicio de sesión se limitan a 10 en 15 minutos por instancia de la aplicación. La plataforma no ofrece un segundo factor en la vía de contraseña. Quien inicia sesión con Google utiliza la MFA de su propia cuenta de Google.",
           "rbac": "Permisos basados en roles: admin, revisor, miembro; aplicados en la capa de aplicación mediante middleware de tRPC",
           "separation": "Aislamiento multiinquilino: toda consulta que contenga datos filtra en la capa de base de datos por el ID de empresa del usuario autenticado; sin agrupaciones de datos compartidas entre clientes",
-          "secrets": "Sin contraseñas en texto plano en la plataforma: la autenticación es exclusivamente basada en OAuth",
+          "secrets": "Las contraseñas nunca se almacenan en texto claro. Cada inicio de sesión se compara con un hash bcrypt, incluso cuando no existe ninguna cuenta para la dirección indicada, de modo que el tiempo de respuesta no revele quién está registrado.",
           "personnel": "Medidas relativas al personal: el acceso a los sistemas productivos y a los datos personales se limita a un grupo reducido y nominado, sujeto a confidencialidad. El acceso sigue el principio de mínimo privilegio y se revoca cuando finaliza un rol."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Almacenamiento de documentos de prueba en AWS S3 con las garantías de durabilidad de objetos proporcionadas por AWS",
           "rateLimit": "Limitación de tasa en los intentos de inicio de sesión, los puntos finales públicos (comprobación de aplicabilidad, portal de proveedores) y los puntos finales autenticados con uso intensivo de recursos (exportaciones de PDF, generación de certificados)",
           "uploadLimit": "Los archivos cargados están limitados a 50 MB por archivo",
-          "status": "Supervisión de la disponibilidad: el estado operativo de la plataforma se supervisa de forma continua y es visible públicamente en nisd2.eu/status."
+          "status": "Indicador de disponibilidad: nisd2.eu/status comprueba en cada solicitud si la base de datos es accesible y muestra el resultado públicamente, con una caché de 30 segundos. No operamos una supervisión continua con alertas automáticas."
         }
       },
       "evaluation": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -703,10 +703,10 @@
         "p1": "Mesures garantissant la confidentialité :",
         "items": {
           "physical": "Contrôle d'accès physique : les centres de données des hébergeurs (Hetzner, AWS) détiennent des certifications ISO 27001",
-          "auth": "Authentification : exclusivement via Google OAuth 2.0 ; aucun mot de passe stocké sur la plateforme. La MFA des utilisateurs est assurée par leur compte Google",
+          "auth": "Authentification : connexion par adresse e-mail et mot de passe ou via Google OAuth 2.0. Les mots de passe sont stockés uniquement sous forme d'empreinte bcrypt avec un facteur de coût de 12, jamais en clair. Lors d'une inscription par mot de passe, l'adresse e-mail est confirmée une fois par code à usage unique, et les tentatives de connexion échouées sont limitées à 10 en 15 minutes par instance applicative. La plateforme ne propose pas de second facteur sur le parcours par mot de passe. Les personnes qui se connectent avec Google utilisent la MFA de leur propre compte Google.",
           "rbac": "Autorisations basées sur les rôles : admin, reviewer, member ; appliquées dans la couche applicative via le middleware tRPC",
           "separation": "Isolation multi-tenant : chaque requête portant sur des données filtre au niveau de la base de données sur l'identifiant d'entreprise de l'utilisateur authentifié ; aucun pool de données partagé entre clients",
-          "secrets": "Aucun mot de passe en clair sur la plateforme - l'authentification est exclusivement basée sur OAuth",
+          "secrets": "Les mots de passe ne sont jamais stockés en clair. Chaque connexion est comparée à une empreinte bcrypt, y compris lorsqu'aucun compte n'existe pour l'adresse fournie, afin que le temps de réponse ne révèle pas qui est inscrit.",
           "personnel": "Mesures relatives au personnel : l'accès aux systèmes de production et aux données à caractère personnel est limité à un groupe restreint et nommément désigné, tenu à la confidentialité. L'accès suit le principe du moindre privilège et est révoqué à la fin d'un rôle."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Stockage des documents de preuve dans AWS S3 avec les garanties de durabilité des objets fournies par AWS",
           "rateLimit": "Limitation de débit sur les tentatives de connexion, les points d'accès publics (vérification d'applicabilité, portail fournisseurs) et les points d'accès authentifiés gourmands en ressources (exports PDF, génération de certificats)",
           "uploadLimit": "Les fichiers téléversés sont limités à 50 Mo par fichier",
-          "status": "Surveillance de la disponibilité : l'état opérationnel de la plateforme est surveillé en continu et visible publiquement sur nisd2.eu/status."
+          "status": "Affichage de disponibilité : nisd2.eu/status vérifie à chaque appel l'accessibilité de la base de données et affiche le résultat publiquement, avec une mise en cache de 30 secondes. Nous n'exploitons pas de surveillance continue avec alerte automatique."
         }
       },
       "evaluation": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -703,10 +703,10 @@
         "p1": "Misure che garantiscono la riservatezza:",
         "items": {
           "physical": "Controllo degli accessi fisici: i data center dei fornitori di hosting (Hetzner, AWS) sono in possesso di certificazioni ISO 27001",
-          "auth": "Autenticazione: esclusivamente tramite Google OAuth 2.0; nessuna password memorizzata sulla piattaforma. L'MFA per gli utenti è fornita tramite il loro account Google",
+          "auth": "Autenticazione: accesso con indirizzo e-mail e password oppure tramite Google OAuth 2.0. Le password sono conservate esclusivamente come hash bcrypt con fattore di costo 12, mai in chiaro. Nella registrazione con password l'indirizzo e-mail viene confermato una volta con un codice monouso, e i tentativi di accesso falliti sono limitati a 10 in 15 minuti per istanza applicativa. La piattaforma non offre un secondo fattore sul percorso con password. Chi accede con Google utilizza la MFA del proprio account Google.",
           "rbac": "Autorizzazioni basate sui ruoli: admin, reviewer, member; applicate a livello applicativo tramite middleware tRPC",
           "separation": "Isolamento multi-tenant: ogni query che gestisce dati filtra a livello di database in base all'ID aziendale dell'utente autenticato; nessun pool di dati condiviso tra i clienti",
-          "secrets": "Nessuna password in chiaro sulla piattaforma: l'autenticazione è esclusivamente basata su OAuth",
+          "secrets": "Le password non vengono mai conservate in chiaro. Ogni accesso viene confrontato con un hash bcrypt, anche quando per l'indirizzo indicato non esiste alcun account, così che il tempo di risposta non riveli chi è registrato.",
           "personnel": "Misure relative al personale: l'accesso ai sistemi di produzione e ai dati personali è limitato a un gruppo ristretto e nominativo vincolato alla riservatezza. L'accesso segue il principio del privilegio minimo e viene revocato quando un ruolo termina."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Archiviazione dei documenti di evidenza in AWS S3 con le garanzie di durabilità degli oggetti fornite da AWS",
           "rateLimit": "Rate limiting sui tentativi di login, sugli endpoint pubblici (verifica di applicabilità, portale fornitori) e sugli endpoint autenticati ad alto consumo di risorse (esportazioni PDF, generazione di certificati)",
           "uploadLimit": "I file caricati sono limitati a 50 MB per file",
-          "status": "Monitoraggio della disponibilità: lo stato operativo della piattaforma è monitorato in continuo ed è pubblicamente visibile su nisd2.eu/status."
+          "status": "Indicatore di disponibilità: nisd2.eu/status verifica a ogni richiesta la raggiungibilità del database e mostra pubblicamente il risultato, con una cache di 30 secondi. Non gestiamo un monitoraggio continuo con allarme automatico."
         }
       },
       "evaluation": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -704,10 +704,10 @@
         "p1": "Measures ensuring confidentiality:",
         "items": {
           "physical": "Physical access control: data centres of the hosting providers (Hetzner, AWS) hold ISO 27001 certifications",
-          "auth": "Authentication: exclusively via Google OAuth 2.0; no passwords stored on the platform. MFA for users is provided through their Google account",
+          "auth": "Authenticatie: aanmelden met e-mailadres en wachtwoord of via Google OAuth 2.0. Wachtwoorden slaan wij uitsluitend op als bcrypt-hash met kostenfactor 12, nooit in leesbare vorm. Bij registratie met een wachtwoord wordt het e-mailadres eenmalig bevestigd met een eenmalige code, mislukte aanmeldpogingen zijn per applicatie-instantie beperkt tot 10 in 15 minuten. Het platform biedt geen tweede factor voor de wachtwoordroute. Wie via Google aanmeldt, gebruikt de MFA van het eigen Google-account.",
           "rbac": "Role-based permissions: admin, reviewer, member; enforced in the application layer via tRPC middleware",
           "separation": "Multi-tenant isolation: every data-bearing query filters at the database layer on the company ID of the authenticated user; no shared data pools between customers",
-          "secrets": "No plaintext passwords on the platform - authentication is exclusively OAuth-based",
+          "secrets": "Wachtwoorden worden nooit in leesbare vorm opgeslagen. Elke aanmelding wordt vergeleken met een bcrypt-hash, ook wanneer er voor het opgegeven e-mailadres geen account bestaat, zodat uit de responstijd niet valt af te leiden wie geregistreerd is.",
           "personnel": "Personnel measures: access to production systems and personal data is limited to a small, named group bound by confidentiality. Access follows the principle of least privilege and is revoked when a role ends."
         }
       },
@@ -728,7 +728,7 @@
           "redundancy": "Storage of evidence documents in AWS S3 with the object durability guarantees provided by AWS",
           "rateLimit": "Rate limiting on login attempts, public endpoints (applicability check, supplier portal), and resource-heavy authenticated endpoints (PDF exports, certificate generation)",
           "uploadLimit": "Uploaded files are limited to 50 MB per file",
-          "status": "Availability monitoring: the platform's operational status is continuously monitored and publicly visible at nisd2.eu/status."
+          "status": "Beschikbaarheidsweergave: nisd2.eu/status controleert bij elke oproep of de database bereikbaar is en toont het resultaat openbaar, 30 seconden in cache. Wij draaien geen doorlopende monitoring met automatische alarmering."
         }
       },
       "evaluation": {

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -703,10 +703,10 @@
         "p1": "Środki zapewniające poufność:",
         "items": {
           "physical": "Kontrola dostępu fizycznego: centra danych dostawców hostingu (Hetzner, AWS) posiadają certyfikaty ISO 27001",
-          "auth": "Uwierzytelnianie: wyłącznie przez Google OAuth 2.0; na platformie nie są przechowywane żadne hasła. MFA dla użytkowników zapewniane jest przez ich konto Google",
+          "auth": "Uwierzytelnianie: logowanie adresem e-mail i hasłem albo przez Google OAuth 2.0. Hasła przechowujemy wyłącznie jako skrót bcrypt ze współczynnikiem kosztu 12, nigdy w postaci jawnej. Przy rejestracji hasłem adres e-mail jest jednorazowo potwierdzany kodem jednorazowym, a nieudane próby logowania są ograniczone do 10 w ciągu 15 minut na instancję aplikacji. Platforma nie oferuje drugiego składnika na ścieżce hasłowej. Kto loguje się przez Google, korzysta z MFA własnego konta Google.",
           "rbac": "Uprawnienia oparte na rolach: admin, recenzent, członek; egzekwowane w warstwie aplikacji przez oprogramowanie pośredniczące tRPC",
           "separation": "Izolacja wielodostępowa: każde zapytanie zawierające dane filtruje w warstwie bazy danych według identyfikatora firmy uwierzytelnionego użytkownika; brak współdzielonych zbiorów danych między klientami",
-          "secrets": "Brak haseł w postaci jawnej na platformie - uwierzytelnianie odbywa się wyłącznie w oparciu o OAuth",
+          "secrets": "Hasła nigdy nie są przechowywane w postaci jawnej. Każde logowanie jest porównywane ze skrótem bcrypt, także wtedy, gdy dla podanego adresu nie istnieje żadne konto, aby z czasu odpowiedzi nie dało się wywnioskować, kto jest zarejestrowany.",
           "personnel": "Środki dotyczące personelu: dostęp do systemów produkcyjnych i danych osobowych jest ograniczony do niewielkiej, imiennie wskazanej grupy zobowiązanej do zachowania poufności. Dostęp opiera się na zasadzie najmniejszych uprawnień i jest odbierany po zakończeniu pełnienia roli."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Przechowywanie dokumentów dowodowych w AWS S3 z gwarancjami trwałości obiektów zapewnianymi przez AWS",
           "rateLimit": "Ograniczanie liczby żądań przy próbach logowania, publicznych punktach końcowych (sprawdzenie zakresu stosowania, portal dostawców) oraz zasobochłonnych uwierzytelnionych punktach końcowych (eksporty PDF, generowanie certyfikatów)",
           "uploadLimit": "Przesyłane pliki są ograniczone do 50 MB na plik",
-          "status": "Monitorowanie dostępności: status operacyjny platformy jest stale monitorowany i publicznie widoczny pod adresem nisd2.eu/status."
+          "status": "Wskaźnik dostępności: nisd2.eu/status przy każdym wywołaniu sprawdza dostępność bazy danych i publicznie pokazuje wynik, buforowany przez 30 sekund. Nie prowadzimy ciągłego monitoringu z automatycznym alarmowaniem."
         }
       },
       "evaluation": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -703,10 +703,10 @@
         "p1": "Medidas que garantem a confidencialidade:",
         "items": {
           "physical": "Controlo de acesso físico: os centros de dados dos fornecedores de alojamento (Hetzner, AWS) possuem certificações ISO 27001",
-          "auth": "Autenticação: exclusivamente via Google OAuth 2.0; nenhuma palavra-passe armazenada na plataforma. A MFA dos utilizadores é fornecida através da respetiva conta Google",
+          "auth": "Autenticação: início de sessão com endereço de e-mail e palavra-passe ou através de Google OAuth 2.0. As palavras-passe são guardadas exclusivamente como hash bcrypt com fator de custo 12, nunca em texto simples. No registo com palavra-passe, o endereço de e-mail é confirmado uma vez através de um código de utilização única, e as tentativas falhadas de início de sessão estão limitadas a 10 em 15 minutos por instância da aplicação. A plataforma não oferece um segundo fator na via da palavra-passe. Quem inicia sessão com Google utiliza a MFA da própria conta Google.",
           "rbac": "Permissões baseadas em funções: administrador, revisor, membro; aplicadas na camada de aplicação através de middleware tRPC",
           "separation": "Isolamento multilocatário: cada consulta que transporta dados filtra na camada da base de dados pelo ID da empresa do utilizador autenticado; não existem conjuntos de dados partilhados entre clientes",
-          "secrets": "Nenhuma palavra-passe em texto simples na plataforma. A autenticação é exclusivamente baseada em OAuth",
+          "secrets": "As palavras-passe nunca são guardadas em texto simples. Cada início de sessão é comparado com um hash bcrypt, mesmo quando não existe qualquer conta para o endereço indicado, para que o tempo de resposta não revele quem está registado.",
           "personnel": "Medidas relativas ao pessoal: o acesso aos sistemas de produção e aos dados pessoais está limitado a um grupo reduzido e nominal, vinculado por confidencialidade. O acesso segue o princípio do menor privilégio e é revogado quando uma função termina."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Armazenamento dos documentos de prova no AWS S3 com as garantias de durabilidade de objetos fornecidas pela AWS",
           "rateLimit": "Limitação de taxa nas tentativas de início de sessão, nos pontos de extremidade públicos (verificação de aplicabilidade, portal de fornecedores) e nos pontos de extremidade autenticados com utilização intensiva de recursos (exportações PDF, geração de certificados)",
           "uploadLimit": "Os ficheiros carregados estão limitados a 50 MB por ficheiro",
-          "status": "Monitorização da disponibilidade: o estado operacional da plataforma é monitorizado continuamente e visível publicamente em nisd2.eu/status."
+          "status": "Indicador de disponibilidade: nisd2.eu/status verifica em cada pedido a acessibilidade da base de dados e mostra o resultado publicamente, em cache durante 30 segundos. Não operamos monitorização contínua com alerta automático."
         }
       },
       "evaluation": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -703,10 +703,10 @@
         "p1": "Măsuri care asigură confidențialitatea:",
         "items": {
           "physical": "Controlul accesului fizic: centrele de date ale furnizorilor de găzduire (Hetzner, AWS) dețin certificări ISO 27001",
-          "auth": "Autentificare: exclusiv prin Google OAuth 2.0; nu se stochează parole pe platformă. MFA pentru utilizatori este asigurată prin contul lor Google",
+          "auth": "Autentificare: conectare cu adresa de e-mail și parolă sau prin Google OAuth 2.0. Parolele sunt stocate exclusiv ca hash bcrypt cu factor de cost 12, niciodată în clar. La înregistrarea cu parolă, adresa de e-mail este confirmată o singură dată printr-un cod de unică folosință, iar încercările eșuate de conectare sunt limitate la 10 în 15 minute per instanță a aplicației. Platforma nu oferă un al doilea factor pe traseul cu parolă. Cine se conectează prin Google folosește MFA din propriul cont Google.",
           "rbac": "Permisiuni bazate pe roluri: administrator, evaluator, membru; aplicate la nivelul aplicației prin middleware tRPC",
           "separation": "Izolare multi-tenant: fiecare interogare care conține date filtrează la nivelul bazei de date după ID-ul companiei utilizatorului autentificat; nu există fonduri de date comune între clienți",
-          "secrets": "Nicio parolă în text clar pe platformă. Autentificarea este exclusiv bazată pe OAuth",
+          "secrets": "Parolele nu sunt niciodată stocate în clar. Fiecare conectare este comparată cu un hash bcrypt, inclusiv atunci când pentru adresa indicată nu există niciun cont, astfel încât timpul de răspuns să nu dezvăluie cine este înregistrat.",
           "personnel": "Măsuri privind personalul: accesul la sistemele de producție și la datele cu caracter personal este limitat la un grup restrâns, nominalizat, obligat la confidențialitate. Accesul respectă principiul privilegiului minim și este revocat la încetarea unui rol."
         }
       },
@@ -727,7 +727,7 @@
           "redundancy": "Stocarea documentelor de dovadă în AWS S3 cu garanțiile de durabilitate a obiectelor oferite de AWS",
           "rateLimit": "Limitarea ratei pentru încercările de autentificare, punctele finale publice (verificarea aplicabilității, portalul furnizorilor) și punctele finale autentificate cu consum intens de resurse (exporturi PDF, generarea de certificate)",
           "uploadLimit": "Fișierele încărcate sunt limitate la 50 MB per fișier",
-          "status": "Monitorizarea disponibilității: starea operațională a platformei este monitorizată continuu și vizibilă public la nisd2.eu/status."
+          "status": "Indicator de disponibilitate: nisd2.eu/status verifică la fiecare solicitare accesibilitatea bazei de date și afișează public rezultatul, memorat în cache 30 de secunde. Nu operăm monitorizare continuă cu alertare automată."
         }
       },
       "evaluation": {


### PR DESCRIPTION
The TOMs page is a published Art. 32 document and two of its claims were false. Verified against the code, not against the copy.

## What was wrong

| Claim | Reality |
|---|---|
| `confidentiality.items.auth`: "ausschließlich über Google OAuth 2.0; keine Speicherung von Passwörtern" | `lib/auth/config.ts` registers `Credentials` with `bcrypt.compare` **before** `Google()`, and Google is conditional on `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` being set |
| `confidentiality.items.secrets`: "Authentifizierung erfolgt ausschließlich über OAuth" | same |
| `availability.items.status`: "laufend überwacht" | `status/page.tsx` runs one `SELECT 1` per request with `revalidate = 30`, and there is no alerting |
| `CalModal.tsx` + `/start` hardcoded `data-cal-link="sorzel/work"` | a public route, so any self-hosted instance embedded a private calendar |

## What this does

All three strings corrected in all ten locales. The auth string now names both sign-in paths, bcrypt at cost factor 12, the one-time code at registration, and states plainly that there is no second factor on the password path. The secrets string now describes the constant-time compare against `DUMMY_HASH`, which is both true and the stronger claim. The status string says what the check actually is, and says we run no alerting.

The login rate limit is described as "je Anwendungsinstanz" because `loginAttempts` is an in-memory `Map`: per process, reset on restart. An unscoped "10 per 15 minutes" would repeat the class of overclaim this PR exists to remove.

The cal handle now comes from `CAL_LINK`, **empty by default**. Where it is unset, the booking section and the hero CTA that scrolls to it are both hidden, so a self-hosted instance renders no booking UI rather than someone else's.

## Deploy note

`CAL_LINK=nisd2` is already set in Coolify. It is deliberately not `NEXT_PUBLIC_`: the Dockerfile declares no build args, so a `NEXT_PUBLIC_` value set in the deploy platform would never reach the client bundle.

## Checks

`tsc --noEmit` clean. The repo has no eslint config, so `bun run lint` (`next lint`) is vestigial on this Next version and typecheck is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJBZDGVhKrnL9ifPm5L7VS