### PR TITLE
fix(tour): stop the walkthroughs being eaten before they can run

### DIFF
--- a/components/onboarding/PortalGuide.tsx
+++ b/components/onboarding/PortalGuide.tsx
@@ -6,12 +6,10 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { trpc } from "@/lib/trpc/client";
 import type { Hint } from "@/lib/onboarding/hints";
-
-type TourHint = RouteTour["hint"];
 import { usePortalPath } from "@/components/portal/use-portal-path";
 import { HelpDialog } from "./HelpDialog";
 import { TourOverlay } from "./tour/TourOverlay";
-import { tourForPath, type RouteTour, type TourStep } from "./tour/steps";
+import { tourForPath, type TourStep } from "./tour/steps";
 
 /** Drop steps whose target is not on this page before the tour starts. */
 function presentSteps(steps: readonly TourStep[]): readonly TourStep[] {
@@ -19,6 +17,16 @@ function presentSteps(steps: readonly TourStep[]): readonly TourStep[] {
     document.querySelector(`[data-tour="${step.target}"]`),
   );
 }
+
+/**
+ * How long to keep waiting for a walkthrough's page to render before giving
+ * up on it. Long, deliberately: waiting costs nothing, and being impatient
+ * costs the walkthrough, which is the one thing this component exists to do.
+ */
+const TARGET_WAIT_MS = 15_000;
+
+/** Shared so "no tour here" is the same value every time and React bails out. */
+const NO_STEPS: readonly TourStep[] = [];
 
 /**
  * Owns every guided surface in the portal: the question mark in the header,
@@ -40,36 +48,71 @@ export function PortalGuide({
   const path = usePortalPath();
   const dismissHint = trpc.user.dismissHint.useMutation();
 
-  // Seeded from the server-resolved hints and owned by the client from then
-  // on. The portal layout does not remount between pages, so a dismissal
-  // holds for the rest of the session without waiting on the round trip that
-  // persists it.
-  // Per-walkthrough, so dismissing one leaves the other still to come.
-  const [armed, setArmed] = useState<Record<TourHint, boolean>>({
-    journeyTour: hints.journeyTour,
-    requirementTour: hints.requirementTour,
+  // What this session has dismissed, per surface, so skipping one leaves the
+  // others still to come. Only the dismissals are held here: the portal layout
+  // does not remount between pages, so a dismissal has to hold for the rest of
+  // the session without waiting on the round trip that persists it.
+  //
+  // Whether a surface is armed is derived from the prop rather than copied
+  // into state beside it. Copying froze it at whatever the first render of
+  // this layout saw, so re-arming a surface could not reach the component at
+  // all until the whole document was reloaded by hand.
+  const [dismissed, setDismissed] = useState<Record<Hint, boolean>>({
+    journeyTour: false,
+    requirementTour: false,
+    helpOffer: false,
   });
-  const [helpAuto, setHelpAuto] = useState(hints.helpOffer);
   const [helpManual, setHelpManual] = useState(false);
-  const [steps, setSteps] = useState<readonly TourStep[]>([]);
+  const [steps, setSteps] = useState<readonly TourStep[]>(NO_STEPS);
   const [index, setIndex] = useState(0);
 
+  const helpAuto = hints.helpOffer && !dismissed.helpOffer;
+
   const routeTour = tourForPath(path);
-  const routeArmed = routeTour ? armed[routeTour.hint] : false;
+  const routeArmed = routeTour
+    ? hints[routeTour.hint] && !dismissed[routeTour.hint]
+    : false;
 
   // Re-resolve on every navigation. Each route asks whether ITS walkthrough is
   // still armed, so walking the journey and then opening a requirement starts
   // the second one, and skipping the journey does not cancel it.
   useEffect(() => {
     if (!routeTour || !routeArmed) {
-      setSteps([]);
+      setSteps(NO_STEPS);
       return;
     }
-    const frame = requestAnimationFrame(() => {
+
+    // The page being explained is not necessarily in the DOM yet. This header
+    // lives in the portal layout, which hydrates as soon as the shell arrives,
+    // while a route with a loading.tsx is still showing its skeleton. Sampling
+    // once and keeping whatever happened to be present lost the walkthrough on
+    // exactly those loads: the anchor was missing, the step list came back
+    // empty, and nothing was left to re-run the check. That is the reload-it-
+    // three-times bug.
+    //
+    // So wait for the opening step's target instead. Every tour opens on
+    // something its route always renders (see TourSteps), so that element
+    // arriving is the signal that the page is here. The rest of it landed in
+    // the same commit, and presentSteps then drops only the sections that
+    // genuinely do not apply to this requirement.
+    const anchor = routeTour.steps[0].target;
+    const start = () => {
+      if (!document.querySelector(`[data-tour="${anchor}"]`)) return false;
       setSteps(presentSteps(routeTour.steps));
       setIndex(0);
+      return true;
+    };
+    if (start()) return;
+
+    const observer = new MutationObserver(() => {
+      if (start()) observer.disconnect();
     });
-    return () => cancelAnimationFrame(frame);
+    observer.observe(document.body, { childList: true, subtree: true });
+    const giveUp = setTimeout(() => observer.disconnect(), TARGET_WAIT_MS);
+    return () => {
+      observer.disconnect();
+      clearTimeout(giveUp);
+    };
   }, [routeArmed, routeTour, path]);
 
   // Plain functions: nothing downstream is memoised and none of these sit in a
@@ -78,14 +121,16 @@ export function PortalGuide({
 
   const closeTour = () => {
     if (!routeTour) return;
-    setArmed((current) => ({ ...current, [routeTour.hint]: false }));
-    setSteps([]);
+    setDismissed((current) => ({ ...current, [routeTour.hint]: true }));
+    setSteps(NO_STEPS);
     dismiss(routeTour.hint);
   };
 
   const closeHelp = () => {
+    // Only the automatic offer is a one-time surface worth stamping. Closing
+    // one the user opened from the header themselves records nothing.
     if (helpAuto) dismiss("helpOffer");
-    setHelpAuto(false);
+    setDismissed((current) => ({ ...current, helpOffer: true }));
     setHelpManual(false);
   };
 

--- a/components/onboarding/tour/steps.ts
+++ b/components/onboarding/tour/steps.ts
@@ -19,6 +19,18 @@ export type TourStep = {
 };
 
 /**
+ * A tour's steps, opening step first, and never empty.
+ *
+ * The opening step is load-bearing beyond being shown first: the guide waits
+ * for its target to appear before starting the tour, and treats that as the
+ * signal that the route has actually rendered. So it has to point at
+ * something the route always puts on the page, never at a conditional
+ * section. The tuple type is what stops a later edit leaving a tour with no
+ * first step for the guide to wait on.
+ */
+export type TourSteps = readonly [TourStep, ...TourStep[]];
+
+/**
  * Establish the whole board, narrow to what a single row is, then explain the
  * controls, then hand over to the rest of the portal.
  *
@@ -32,7 +44,7 @@ export type TourStep = {
  * there is no room beside a row that spans the content column, and Radix
  * shifting a colliding card is what made it look clipped.
  */
-const JOURNEY_STEPS: readonly TourStep[] = [
+const JOURNEY_STEPS: TourSteps = [
   { target: "journey-board", key: "overview", side: "top" },
   { target: "journey-first-step", key: "firstStep", side: "bottom" },
   { target: "journey-order", key: "order", side: "bottom" },
@@ -52,7 +64,7 @@ const JOURNEY_STEPS: readonly TourStep[] = [
  * rendered while the requirement is still open, so a signed-off or
  * not-applicable one simply has one step fewer.
  */
-const REQUIREMENT_STEPS: readonly TourStep[] = [
+const REQUIREMENT_STEPS: TourSteps = [
   { target: "requirement-status", key: "status", side: "bottom" },
   { target: "requirement-form", key: "form", side: "top" },
   { target: "requirement-evidence", key: "evidence", side: "top" },
@@ -66,7 +78,8 @@ const REQUIREMENT_STEPS: readonly TourStep[] = [
 export type RouteTour = {
   /** The hint this walkthrough arms and dismisses on its own. */
   hint: Extract<Hint, "journeyTour" | "requirementTour">;
-  steps: readonly TourStep[];
+  /** Opening step first; the guide waits on it. See `TourSteps`. */
+  steps: TourSteps;
 };
 
 /**

--- a/components/platform-admin/DevPanel.tsx
+++ b/components/platform-admin/DevPanel.tsx
@@ -79,6 +79,7 @@ function Armed({ on }: { on: boolean }) {
 }
 
 export function DevPanel() {
+  const router = useRouter();
   const state = trpc.platformAdmin.myDevState.useQuery();
   const data = state.data;
   // The only destructive action on the tab, so it asks twice rather than
@@ -88,6 +89,12 @@ export function DevPanel() {
   const arm = trpc.platformAdmin.armOnboardingSurface.useMutation({
     onSuccess: async ({ surface }) => {
       await state.refetch();
+      // These surfaces are resolved server-side in the portal layout, and the
+      // router keeps a shared layout it has already fetched. Without dropping
+      // that cache, walking over to the portal can render the layout as it was
+      // before the arm, and the walkthrough does not appear until the whole
+      // document is reloaded by hand.
+      router.refresh();
       toast.success(SURFACES.find((s) => s.hint === surface)?.armedToast ?? "Armed.");
     },
     onError: () => toast.error("Could not arm that surface."),
@@ -160,7 +167,9 @@ export function DevPanel() {
             ))}
           </div>
           <p className="text-xs text-muted-foreground">
-            Takes effect on the next portal page load. No sign-out needed.
+            Takes effect immediately, and survives a sign-out: the tours arm at
+            a login count of zero, so the sign-in that follows still counts as
+            a first one.
           </p>
         </CardContent>
       </Card>

--- a/e2e/l1/guide.spec.ts
+++ b/e2e/l1/guide.spec.ts
@@ -153,6 +153,41 @@ test("skipping the journey walkthrough leaves the requirement one armed", async 
   await dismissalLanded("requirement_tour_dismissed_at");
 });
 
+test("the requirement walkthrough survives arriving from the journey", async ({
+  page,
+}) => {
+  await setGuideState(
+    "login_count = 1, tour_dismissed_at = NOW(), requirement_tour_dismissed_at = NULL",
+  );
+
+  await page.goto("/journey");
+  await expect(page.getByTestId("journey-node-2.1")).toBeVisible();
+
+  // Hold the requirement page back so its loading skeleton is what is on
+  // screen while the portal header — which owns the walkthrough and stays
+  // mounted across the navigation — is already hydrated.
+  //
+  // That gap is the regression. The guide used to sample the DOM once, a
+  // single frame after the route changed, and keep whatever it found. On this
+  // path it found the skeleton, ended up with no steps, and had nothing left
+  // to re-run the check, so the walkthrough was silently gone until the page
+  // was reloaded by hand a couple of times.
+  await page.route("**/compliance/**", async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    await route.continue();
+  });
+
+  await page.getByTestId("journey-node-2.1").click();
+
+  const card = page.getByTestId("tour-card");
+  await expect(card).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByTestId("tour-progress")).toContainText("1");
+
+  await page.getByTestId("tour-skip").click();
+  await expect(card).toBeHidden();
+  await dismissalLanded("requirement_tour_dismissed_at");
+});
+
 test("a second login offers help, and does not offer it twice", async ({
   page,
 }) => {

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -322,7 +322,7 @@ export const getSession = cache(async (): Promise<Session | null> => {
       sessionVersion: true,
       loginCount: true,
       journeyTourDismissedAt: true,
-            requirementTourDismissedAt: true,
+      requirementTourDismissedAt: true,
       helpOfferDismissedAt: true,
     },
   });

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -104,7 +104,7 @@ export const platformAdminRouter = router({
    * Re-arm one of the one-time onboarding surfaces for the caller.
    *
    * Takes which surface because the two cannot both be armed: resolveHints
-   * gates the tour on `loginCount <= 1` and the offer of help on
+   * gates the tours on `loginCount <= 1` and the offer of help on
    * `loginCount >= 2`, so arming either means moving the counter to a value
    * that disarms the other. Clearing the dismissal stamp alone would do
    * nothing on an account that has signed in more than once.
@@ -116,7 +116,14 @@ export const platformAdminRouter = router({
     .mutation(async ({ ctx, input }) => {
       // Both tours want a first-login account; the offer of help wants a
       // second. Everything else is just clearing that surface's own stamp.
-      const loginCount = input.surface === "helpOffer" ? 2 : 1;
+      //
+      // The tours arm at 0, not 1, so that arming survives a sign-out. The
+      // jwt callback increments this on every sign-in, so parking it on the
+      // last value that still counts as a first login meant "arm it, log out,
+      // log back in" landed on 2 and silently disarmed the thing that had
+      // just been armed. From 0 the next sign-in lands on 1 and the tour is
+      // still there, which is how the reset is actually used.
+      const loginCount = input.surface === "helpOffer" ? 2 : 0;
       await ctx.db
         .update(user)
         .set({ loginCount, [HINT_COLUMN[input.surface]]: null })


### PR DESCRIPTION
Three separate reasons a freshly armed walkthrough did not appear. Each one is curable by reloading the page a couple of times, which is why they were being read as a single flaky bug.

**The guide sampled the DOM once**, a frame after the route changed, and kept whatever it found. `/compliance/[categorySlug]/[requirementCode]` has a `loading.tsx`, so the portal header hydrates while the page is still a skeleton: no anchor, an empty step list, and nothing left to re-run the check. It now waits for the opening step's target to arrive. `TourSteps` is a non-empty tuple so a later edit cannot leave a tour without the anchor the guide waits on.

**Armed-ness was copied into state at mount.** The portal layout does not remount between pages, so the copy was frozen at whatever the first render saw, and re-arming could not reach the component until the whole document was reloaded by hand. It is derived from the prop now; only dismissals are held, and all three surfaces share one record instead of the offer of help keeping its own frozen copy. The dev panel drops the router cache after arming so the layout is actually re-rendered.

**Arming a tour set `login_count` to 1**, and the `jwt` callback increments it on every sign-in, so "arm it, sign out, sign back in" landed on 2 and silently disarmed the thing that had just been armed. Tours arm at 0 now, so the sign-in that follows still counts as a first one.

Not involved, despite looking like it: the server-side route cache. The portal layout reads `headers()` and cookies and `/journey` is `force-dynamic`, so none of this is prerendered.

## Verification

`e2e/l1/guide.spec.ts` gains a spec that holds the requirement page back while the header is already hydrated. It fails on the previous code (`tour-card` never appears) and passes here.

```
7 passed (53.6s)
```

`bun run typecheck` clean.