### PR TITLE
copy(de): give the hero a subject so it stops reading as a fragment

### DIFF
--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -1741,7 +1741,7 @@
         "description": "NIS2 wird europäische Unternehmen 31,2 Milliarden Euro pro Jahr kosten. Hier ist die Aufschlüsselung - und unser Plan, sie zu halbieren."
       },
       "badge": "Unsere Mission",
-      "title": "Halbiert Europas NIS2-Rechnung.",
+      "title": "Wir halbieren Europas NIS2-Rechnung.",
       "subtitle": "Das 31-Milliarden-Euro-Problem - und unser Plan, es zu lösen.",
       "problem": {
         "heading": "Das 31-Milliarden-Euro-Problem",

--- a/messages/landing/de.json
+++ b/messages/landing/de.json
@@ -1,6 +1,6 @@
 {
   "landing": {
-    "title": "Halbiert Europas <blue>NIS2</blue>-Rechnung.",
+    "title": "Wir halbieren Europas <blue>NIS2</blue>-Rechnung.",
     "eyebrow": "Open Source · Kostenlos · Kein Lock-in",
     "subtitle": "Die kostenlose Plattform, mit der regulierte Unternehmen und ihre Lieferanten NIS2 umsetzen: mit Selbsteinschätzung, Vorlagen und Schulung für die Geschäftsführung. <os>Open Source</os>, kein Lock-in.",
     "productLine": "Kostenlose NIS2-Compliance und Informationen für regulierte Unternehmen und ihre Lieferanten.",


### PR DESCRIPTION
## The problem

`"Halbiert Europas NIS2-Rechnung."` has no register-neutral reading in German. A native reader gets three parses and none is the intended one:

1. **3rd person singular** — "[Es] halbiert Europas NIS2-Rechnung." This is the default parse, and the subject is missing, so the headline reads like the back half of a sentence whose front fell off.
2. **Past participle** — a bare fragment.
3. **ihr-imperative** — "you lot, halve it!" Grammatically an imperative, but `ihr` is informal-collective. Wrong register for the Geschäftsführer and Justiziare this page addresses.

English gets away with the imperative because its imperative is register-neutral. German has no such form — du, ihr and Sie each either patronise or over-familiarise — so the literal imperative cannot cross over. The declarative does the same work without the ambiguity.

## What changed

| file | before | after |
|---|---|---|
| `messages/landing/de.json:3` | Halbiert Europas NIS2-Rechnung. | Wir halbieren Europas NIS2-Rechnung. |
| `messages/info/de.json:1744` | Halbiert Europas NIS2-Rechnung. | Wir halbieren Europas NIS2-Rechnung. |

The verb was never the problem. `halbieren` is exactly *"in zwei [gleiche] Teile teilen"* — the action of cutting in two. Every other German string using it was already correct and is untouched: the mission-page infinitive `"Europas NIS2-Rechnung halbieren"`, `"Wie wir es halbieren"`, `"die NIS2-Kosten zu halbieren"`.

Copy only, two values, no keys added or removed. Both files re-parse as JSON.

## Not in this PR

- **`messages/landing/nl.json:3`** has the same bug — `"Halveer"` is the informal `jij` imperative. Left alone since NL is gated.
- **`Rechnung`** is a partial false friend (English "bill" covers an aggregate national cost; German *Rechnung* is primarily a concrete invoice). It works metaphorically and is used consistently across ~8 strings, so it reads as a house metaphor rather than an error. Separate call from the grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeeTDUZjHpbbaeXEELjadG