### PR TITLE
fix(e2e): retire every onboarding surface, not the two that predate the split

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -23,6 +23,9 @@ import {
   E2E_STORAGE_STATE,
   E2E_STORAGE_STATE_MANAGER,
 } from "./lib/env";
+import { getTableColumns } from "drizzle-orm";
+import { user } from "@/schema";
+import { HINTS, HINT_COLUMN } from "@/lib/onboarding/hints";
 import { e2eQuery } from "./lib/db";
 import { signInViaForm } from "./lib/signin";
 
@@ -77,9 +80,17 @@ setup("provision and authenticate", async ({ page, browser }) => {
   // every hermetic run, so without this it would arm itself in every spec.
   // Unconditional, so a guide spec that dies mid-run leaves the next run
   // clean rather than poisoned. e2e/l1/guide.spec.ts opts back in on purpose.
+  //
+  // Derived from HINT_COLUMN rather than listed by hand. Splitting the journey
+  // and requirement walkthroughs added a fourth column and this statement kept
+  // stamping the old pair, so the manager — the one harness user no spec
+  // retires by name — spent every run behind an overlay that ate its sign-off
+  // click. Column names come from the table, not from snake-casing the field:
+  // journeyTourDismissedAt is `tour_dismissed_at`.
+  const userColumns = getTableColumns(user);
+  const retireHints = HINTS.map((hint) => `${userColumns[HINT_COLUMN[hint]].name} = NOW()`);
   await e2eQuery(
-    `UPDATE "user" SET tour_dismissed_at = NOW(), help_offer_dismissed_at = NOW()
-      WHERE email = ANY($1::text[])`,
+    `UPDATE "user" SET ${retireHints.join(", ")} WHERE email = ANY($1::text[])`,
     [[E2E_USER_EMAIL, E2E_MANAGER_EMAIL]],
   );
 


### PR DESCRIPTION
Green again: **90 passed, 1 skipped, 0 failed** locally against a fresh hermetic stack.

## What broke

`feat(tour): split the journey and requirement walkthroughs` split one dismissal flag into two, adding `requirement_tour_dismissed_at` (migration `0008_split_tour_dismissals`). `guide.spec.ts`'s own `retire()` helper was updated to stamp all three columns. `auth.setup.ts` was not — it kept stamping the pre-split pair:

```sql
UPDATE "user" SET tour_dismissed_at = NOW(), help_offer_dismissed_at = NOW()
```

The harness fixtures sign in once and replay a `storageState` for the rest of the run, so `login_count` stays 1 forever. With `requirement_tour_dismissed_at` NULL, `resolveHints` kept returning `requirementTour: true` — a blocking overlay on every requirement page.

## Why the failures looked unrelated to the tour

The pass/fail shape is what identifies it:

| spec | result | why |
|---|---|---|
| `signoff.spec.ts:32` single signer | **passed** | admin is rescued by `guide.spec.ts`'s `test.afterAll(retire)`, which stamps all three columns — but only for `E2E_USER_EMAIL` |
| `signoff.spec.ts:48` N-of-M | failed at line 90 | the **manager's** sign-off. No spec retires that fixture by name, so the overlay was never dismissed and the click never produced a `signOff` POST |
| `signoff.spec.ts:97` history rows | failed | asserts on a second sign-off that never happened |
| `grand-tour.spec.ts:13` | failed | `1.4` at `in_progress`, waiting on that same missing signature |

Three failures, one cause. Nothing wrong with the sign-off chain itself, and nothing wrong with the tour in the product — a real user's `login_count` increments on every sign-in and one click retires the surface.

## The fix

Derive the column list from `HINT_COLUMN` in `lib/onboarding/hints.ts` instead of writing it out a third time. That constant is documented for exactly this ("adding a surface is one entry rather than a hunt through the mutations that happen to know about it"), and it is what stops the next split doing this again.

Names resolve through `getTableColumns(user)` rather than snake-casing the field, because they do not line up: `journeyTourDismissedAt` is `tour_dismissed_at`.

## Scope

One file, 13 lines. Test harness only — no product code, no schema, no migration.

Fixes the e2e suite, red on `main` since 766db73 (#88) on 26 August and inherited by every PR since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeeTDUZjHpbbaeXEELjadG