### PR TITLE
chore(ci): run the schema tests in test:unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "bun test lib server",
+    "test:unit": "bun test lib server schema/",
     "check:migrations": "bun scripts/check-migration-journals.ts",
     "db:seed:demo": "bun run scripts/seed-demo-company.ts",
     "db:export:demo": "bun run scripts/export-demo-ordner.tsx",


### PR DESCRIPTION
`test:unit` is `bun test lib server`. #83 put `schema/mass-assignment.test.ts` outside that glob, so the five assertions that a supplier edit cannot write `unsubscribeToken`, `supplierCompanyId` or the supplier-controlled lifecycle have never run in CI.

`schema/` with the slash: the bare word `schema` also matches the workspace `*-schema` packages, which have their own runners.

Before: 75 tests across 5 files. After: 110 across 9, all passing.