### PR TITLE
fix(training): each course states its own certificate legal basis

### DIFF
--- a/app/api/training/certificate/route.ts
+++ b/app/api/training/certificate/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { hasLocale } from "next-intl";
 import { renderToBuffer } from "@react-pdf/renderer";
 import { routing } from "@/i18n/routing";
+import { pickLocalized } from "@/lib/locale";
 import { getSession } from "@/lib/auth";
 import { rateLimit } from "@/lib/rate-limit";
 import { api } from "@/lib/trpc/server";
@@ -52,7 +53,7 @@ export async function GET(request: NextRequest) {
     })),
   }));
 
-  const totalHours = Math.max(1, Math.round((completion.totalCount * 5) / 60));
+  const totalHours = Math.max(1, Math.round(completion.totalMinutes / 60));
 
   const buffer = await renderToBuffer(
     TrainingCertificateDocument({
@@ -67,6 +68,8 @@ export async function GET(request: NextRequest) {
         totalHours,
         totalLessons: completion.totalCount,
         certificateRef: ref,
+        legalBasis: pickLocalized(completion.certificate.legalBasis, locale),
+        sealLabel: completion.certificate.sealLabel,
         modules,
       },
       locale,

--- a/courses/cra-sbom/index.ts
+++ b/courses/cra-sbom/index.ts
@@ -27,6 +27,21 @@ const course = courseSchema.parse({
     "ro": "Construiți, mențineți și păstrați Software Bill of Materials pe care Cyber Resilience Act îl solicită. Conceput pentru manageri de produs, ingineri și responsabili de securitate la companii care vând produse cu elemente digitale în UE. Acoperă obligația SBOM din Anexa I, Partea II, punctul (1), formatele CycloneDX și SPDX, instrumentele și legătura cu raportarea vulnerabilităților din Articolul 14."
   },
   "version": "1.0",
+  "certificate": {
+    "sealLabel": "CRA",
+    "legalBasis": {
+      "en": "SBOM per Annex I, Part II, point (1) Cyber Resilience Act",
+      "de": "SBOM gemäß Anhang I Teil II Nummer 1 Cyber Resilience Act",
+      "nl": "SBOM volgens Bijlage I, Deel II, punt (1) Cyber Resilience Act",
+      "fr": "SBOM au titre de l'annexe I, partie II, point (1) du Cyber Resilience Act",
+      "it": "SBOM ai sensi dell'Allegato I, Parte II, punto (1) del Cyber Resilience Act",
+      "es": "SBOM conforme al Anexo I, Parte II, punto (1) del Cyber Resilience Act",
+      "pl": "SBOM zgodnie z Załącznikiem I Część II punkt (1) Cyber Resilience Act",
+      "cs": "SBOM podle Přílohy I Část II bod (1) Cyber Resilience Act",
+      "pt": "SBOM nos termos do Anexo I, Parte II, ponto (1) do Cyber Resilience Act",
+      "ro": "SBOM conform Anexei I, Partea II, punctul (1) din Cyber Resilience Act",
+    },
+  },
   "modules": [
     {
       "id": "foundation",

--- a/courses/nis2-ceo/index.ts
+++ b/courses/nis2-ceo/index.ts
@@ -27,6 +27,21 @@ const course = courseSchema.parse({
     ro: "Tot ceea ce Directiva NIS2 cere ca un membru al organului de conducere să cunoască, structurat în jurul celor trei domenii de competență ale BSI și al celor zece măsuri din articolul 21.",
   },
   version: "2.0",
+  certificate: {
+    sealLabel: "NIS 2",
+    legalBasis: {
+      en: "Management training per §38(3) BSIG / Article 20(2) NIS2 Directive",
+      de: "Managementschulung gemäß §38(3) BSIG / Artikel 20(2) NIS2-Richtlinie",
+      nl: "Managementtraining volgens artikel 20(2) NIS2-richtlijn",
+      fr: "Formation des dirigeants au titre du §38(3) BSIG / article 20(2) de la directive NIS2",
+      it: "Formazione per il management ai sensi del §38(3) BSIG / articolo 20(2) della direttiva NIS2",
+      es: "Formación de la dirección conforme al §38(3) BSIG / artículo 20(2) de la directiva NIS2",
+      pl: "Szkolenie kierownictwa zgodnie z §38(3) BSIG / artykułem 20(2) dyrektywy NIS2",
+      cs: "Školení vedení podle §38(3) BSIG / článku 20(2) směrnice NIS2",
+      pt: "Formação da direção nos termos do §38(3) BSIG / artigo 20(2) da Diretiva NIS2",
+      ro: "Instruirea conducerii conform §38(3) BSIG / articolului 20(2) din Directiva NIS2",
+    },
+  },
   modules: [
     {
       id: "foundation",

--- a/courses/nis2-tabletop/index.ts
+++ b/courses/nis2-tabletop/index.ts
@@ -25,6 +25,21 @@ const course = courseSchema.parse({
     ro: "Concepeți, derulați și documentați exercițiul anual pe care îl impune NIS 2. Conceput pentru facilitatori: responsabili cu securitatea informațiilor, manageri IT și responsabili de continuitatea activității care trebuie să conducă un exercițiu tabletop ce produce dovezi valabile la audit. Cadru la nivelul UE, cu referințe la transpunerea germană.",
   },
   version: "1.0",
+  certificate: {
+    sealLabel: "NIS 2",
+    legalBasis: {
+      en: "Exercise per Article 21(2)(b) and (c) NIS2 Directive",
+      de: "Übung gemäß Artikel 21(2)(b) und (c) NIS2-Richtlinie",
+      nl: "Oefening volgens artikel 21(2)(b) en (c) NIS2-richtlijn",
+      fr: "Exercice au titre de l'article 21(2)(b) et (c) de la directive NIS2",
+      it: "Esercitazione ai sensi dell'articolo 21(2)(b) e (c) della direttiva NIS2",
+      es: "Ejercicio conforme al artículo 21(2)(b) y (c) de la directiva NIS2",
+      pl: "Ćwiczenie zgodnie z artykułem 21(2)(b) i (c) dyrektywy NIS2",
+      cs: "Cvičení podle článku 21(2)(b) a (c) směrnice NIS2",
+      pt: "Exercício nos termos do artigo 21(2)(b) e (c) da Diretiva NIS2",
+      ro: "Exercițiu conform articolului 21(2)(b) și (c) din Directiva NIS2",
+    },
+  },
   modules: [
     {
       id: "foundation",

--- a/lib/pdf/training-certificate.tsx
+++ b/lib/pdf/training-certificate.tsx
@@ -22,6 +22,11 @@ interface TrainingCertificateData {
   /** Stable, non-reversible reference so a recipient and an auditor can talk
    *  about the same document. Computed by the route from the completion. */
   certificateRef: string;
+  /** The obligation this course actually teaches, in the reader's locale, and
+   *  the short mark on the seal. Both come from the course, because a single
+   *  template constant meant the CRA course claimed §38(3) BSIG. */
+  legalBasis: string;
+  sealLabel: string;
   modules: CertModule[];
 }
 
@@ -33,7 +38,6 @@ interface CertificateLabels {
   durationLabel: string;
   lessonsLabel: string;
   durationValue: (hours: number) => string;
-  legal: string;
   topics: string;
   disclaimer: string;
   issuer: string;
@@ -51,7 +55,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Dauer",
     lessonsLabel: "Lektionen",
     durationValue: (h) => `ca. ${h} Std.`,
-    legal: "Managementschulung gemäß §38(3) BSIG / Artikel 20(2) NIS2-Richtlinie",
     topics: "Behandelte Themen",
     disclaimer:
       "Diese Bescheinigung bestätigt die Teilnahme am Kurs. Sie stellt keine rechtliche Zertifizierung der Fachkompetenz dar.",
@@ -68,7 +71,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Duration",
     lessonsLabel: "Lessons",
     durationValue: (h) => `approx. ${h} h`,
-    legal: "Management training per §38(3) BSIG / Article 20(2) NIS2 Directive",
     topics: "Topics Covered",
     disclaimer:
       "This certificate confirms course participation. It does not constitute a legal certification of competence.",
@@ -85,7 +87,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Duur",
     lessonsLabel: "Lessen",
     durationValue: (h) => `ca. ${h} uur`,
-    legal: "Managementtraining volgens artikel 20(2) NIS2-richtlijn",
     topics: "Behandelde onderwerpen",
     disclaimer:
       "Dit certificaat bevestigt deelname aan de cursus. Het vormt geen wettelijke certificering van vakbekwaamheid.",
@@ -102,7 +103,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Durée",
     lessonsLabel: "Leçons",
     durationValue: (h) => `env. ${h} h`,
-    legal: "Formation des dirigeants au titre du §38(3) BSIG / article 20(2) de la directive NIS2",
     topics: "Sujets abordés",
     disclaimer:
       "Ce certificat confirme la participation au cours. Il ne constitue pas une certification légale de compétence.",
@@ -119,7 +119,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Durata",
     lessonsLabel: "Lezioni",
     durationValue: (h) => `circa ${h} h`,
-    legal: "Formazione per il management ai sensi del §38(3) BSIG / articolo 20(2) della direttiva NIS2",
     topics: "Argomenti trattati",
     disclaimer:
       "Questo certificato conferma la partecipazione al corso. Non costituisce una certificazione legale di competenza.",
@@ -136,7 +135,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Duración",
     lessonsLabel: "Lecciones",
     durationValue: (h) => `aprox. ${h} h`,
-    legal: "Formación de la dirección conforme al §38(3) BSIG / artículo 20(2) de la directiva NIS2",
     topics: "Temas tratados",
     disclaimer:
       "Este certificado confirma la participación en el curso. No constituye una certificación legal de competencia.",
@@ -153,7 +151,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Czas trwania",
     lessonsLabel: "Lekcje",
     durationValue: (h) => `ok. ${h} godz.`,
-    legal: "Szkolenie kierownictwa zgodnie z §38(3) BSIG / artykułem 20(2) dyrektywy NIS2",
     topics: "Omawiane tematy",
     disclaimer:
       "Niniejszy certyfikat potwierdza udział w kursie. Nie stanowi prawnej certyfikacji kompetencji.",
@@ -170,7 +167,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Délka",
     lessonsLabel: "Lekce",
     durationValue: (h) => `přibl. ${h} h`,
-    legal: "Školení vedení podle §38(3) BSIG / článku 20(2) směrnice NIS2",
     topics: "Probíraná témata",
     disclaimer:
       "Toto osvědčení potvrzuje účast v kurzu. Nepředstavuje právní certifikaci odborné způsobilosti.",
@@ -187,7 +183,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Duração",
     lessonsLabel: "Lições",
     durationValue: (h) => `aprox. ${h} h`,
-    legal: "Formação da direção nos termos do §38(3) BSIG / artigo 20(2) da Diretiva NIS2",
     topics: "Temas abordados",
     disclaimer:
       "Este certificado confirma a participação no curso. Não constitui uma certificação legal de competência.",
@@ -204,7 +199,6 @@ const LABELS: Record<Locale, CertificateLabels> = {
     durationLabel: "Durată",
     lessonsLabel: "Lecții",
     durationValue: (h) => `aprox. ${h} h`,
-    legal: "Instruirea conducerii conform §38(3) BSIG / articolului 20(2) din Directiva NIS2",
     topics: "Subiecte abordate",
     disclaimer:
       "Acest certificat confirmă participarea la curs. Nu constituie o certificare legală a competenței.",
@@ -437,12 +431,12 @@ function Header({ label, value }: { label: string; value: string }) {
   );
 }
 
-function Seal() {
+function Seal({ label }: { label: string }) {
   return (
     <View style={styles.seal}>
       <View style={styles.sealInner} />
       <ShieldGlyph size={17} color={BRAND.primary} strokeWidth={1.9} />
-      <Text style={styles.sealText}>NIS 2</Text>
+      <Text style={styles.sealText}>{label}</Text>
     </View>
   );
 }
@@ -480,7 +474,7 @@ export function TrainingCertificateDocument({
     <Document
       title={`${labels.title}: ${identity}`}
       author="NISD2.eu"
-      subject={labels.legal}
+      subject={data.legalBasis}
       keywords="NIS2, BSIG, management training, certificate"
     >
       {/* Page 1: certificate cover */}
@@ -489,7 +483,7 @@ export function TrainingCertificateDocument({
         <Header label={labels.refLabel} value={data.certificateRef} />
 
         <View style={styles.body}>
-          <Text style={styles.eyebrow}>{labels.legal}</Text>
+          <Text style={styles.eyebrow}>{data.legalBasis}</Text>
           <Text style={styles.title}>{labels.title}</Text>
 
           <Text style={styles.certifies}>{labels.certifies}</Text>
@@ -521,7 +515,7 @@ export function TrainingCertificateDocument({
           </View>
           <Text style={styles.disclaimer}>{labels.disclaimer}</Text>
           <View style={styles.sealWrap}>
-            <Seal />
+            <Seal label={data.sealLabel} />
           </View>
         </View>
       </Page>

--- a/lib/training/course-certificate.test.ts
+++ b/lib/training/course-certificate.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "bun:test";
+import { COURSE_IDS, loadCourse } from "./course-loader";
+import { routing } from "@/i18n/routing";
+
+const courses = await Promise.all(COURSE_IDS.map((id) => loadCourse(id)));
+
+describe("course certificate blocks", () => {
+  test.each(COURSE_IDS.map((id, i) => [id, courses[i]] as const))(
+    "%s states a legal basis in every shipped locale",
+    (_id, course) => {
+      for (const locale of routing.locales) {
+        expect(course.certificate.legalBasis[locale]?.trim()).toBeTruthy();
+      }
+    },
+  );
+
+  // The bug this guards: the basis used to be one hardcoded string in the PDF
+  // template, so the CRA SBOM certificate claimed "Managementschulung gemäß
+  // §38(3) BSIG". Two courses sharing a basis is the shape that mistake takes
+  // when a new course is started by copying an existing one.
+  test("no two courses claim the same legal basis", () => {
+    const seen = new Map<string, string>();
+    for (const course of courses) {
+      const basis = course.certificate.legalBasis.en;
+      const owner = seen.get(basis);
+      expect(owner, `${course.id} reuses the basis of ${owner}: "${basis}"`).toBeUndefined();
+      seen.set(basis, course.id);
+    }
+  });
+
+  test("the seal mark is short enough to sit inside the seal", () => {
+    for (const course of courses) {
+      expect(course.certificate.sealLabel.length).toBeLessThanOrEqual(8);
+    }
+  });
+});

--- a/lib/training/schemas.ts
+++ b/lib/training/schemas.ts
@@ -85,11 +85,29 @@ export const courseModuleSchema = z.object({
 
 export type CourseModule = z.infer<typeof courseModuleSchema>;
 
+/**
+ * What the completion certificate may claim about this course.
+ *
+ * Required, not optional. The certificate is a compliance document a learner
+ * forwards to an auditor, and the basis line used to be one hardcoded string
+ * in the PDF template — so the CRA SBOM course printed "Managementschulung
+ * gemäß §38(3) BSIG". A course that has not stated its own basis should fail
+ * to load rather than borrow the last one's.
+ *
+ * `legalBasis` cites the obligation the course actually teaches, in the same
+ * wording the course content uses. `sealLabel` is the short mark on the seal.
+ */
+export const courseCertificateSchema = z.object({
+  legalBasis: localeString,
+  sealLabel: z.string().min(1).max(8),
+});
+
 export const courseSchema = z.object({
   id: z.string(),
   title: localeString,
   description: localeString,
   version: z.string(),
+  certificate: courseCertificateSchema,
   modules: z.array(courseModuleSchema).min(1),
 });
 

--- a/scripts/preview-certificate.ts
+++ b/scripts/preview-certificate.ts
@@ -2,7 +2,7 @@
  * Render the training certificate to disk with real course data, no DB and no
  * server. Lets a design change be eyeballed in a PDF viewer in one command:
  *
- *   bun run scripts/preview-certificate.ts de en
+ *   bun run scripts/preview-certificate.ts --course cra-sbom de en
  */
 import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
@@ -11,22 +11,33 @@ import { loadCourse, loadLesson } from "@/lib/training/course-loader";
 import { TrainingCertificateDocument } from "@/lib/pdf/training-certificate";
 import { certificateRef } from "@/lib/training/certificate-ref";
 
-const COURSE_ID = "nis2-ceo";
 const OUT_DIR = join(process.cwd(), ".preview");
 const COMPLETION_ISO = "2026-07-10T09:24:00.000Z";
 
-const locales = process.argv.slice(2).length ? process.argv.slice(2) : ["de", "en"];
+// bun run scripts/preview-certificate.ts [--course <id>] [locale ...]
+const argv = process.argv.slice(2);
+const courseFlag = argv.indexOf("--course");
+const COURSE_ID = courseFlag === -1 ? "nis2-ceo" : argv[courseFlag + 1];
+const rest = courseFlag === -1 ? argv : [...argv.slice(0, courseFlag), ...argv.slice(courseFlag + 2)];
+const locales = rest.length ? rest : ["de", "en"];
 
 const course = await loadCourse(COURSE_ID);
 const modules = await Promise.all(
   course.modules.map(async (mod) => ({
     title: mod.title,
     lessons: await Promise.all(
-      mod.lessonIds.map(async (id) => ({ id, title: (await loadLesson(COURSE_ID, id)).title })),
+      mod.lessonIds.map(async (id) => {
+        const lesson = await loadLesson(COURSE_ID, id);
+        return { id, title: lesson.title, minutes: lesson.estimatedMinutes };
+      }),
     ),
   })),
 );
 const totalLessons = modules.reduce((n, m) => n + m.lessons.length, 0);
+const totalMinutes = modules.reduce(
+  (total, m) => total + m.lessons.reduce((n, l) => n + l.minutes, 0),
+  0,
+);
 
 await mkdir(OUT_DIR, { recursive: true });
 
@@ -44,8 +55,10 @@ const written = await Promise.all(
             month: "long",
             day: "numeric",
           }),
-          totalHours: Math.max(1, Math.round((totalLessons * 5) / 60)),
+          totalHours: Math.max(1, Math.round(totalMinutes / 60)),
           totalLessons,
+          legalBasis: course.certificate.legalBasis[locale] ?? course.certificate.legalBasis.en ?? "",
+          sealLabel: course.certificate.sealLabel,
           certificateRef: certificateRef({
             userId: "preview-user",
             courseId: COURSE_ID,
@@ -61,7 +74,7 @@ const written = await Promise.all(
         },
       }),
     );
-    const path = join(OUT_DIR, `certificate-${locale}.pdf`);
+    const path = join(OUT_DIR, `certificate-${COURSE_ID}-${locale}.pdf`);
     await writeFile(path, buffer);
     return path;
   }),

--- a/server/trpc/routers/training-certificate.ts
+++ b/server/trpc/routers/training-certificate.ts
@@ -39,16 +39,28 @@ export const trainingCertificateRouter = router({
 
       const courseModules: {
         title: Record<string, string>;
-        lessons: { id: string; title: Record<string, string> }[];
+        lessons: { id: string; title: Record<string, string>; minutes: number }[];
       }[] = [];
       for (const mod of course.modules) {
-        const lessons: { id: string; title: Record<string, string> }[] = [];
+        const lessons: { id: string; title: Record<string, string>; minutes: number }[] = [];
         for (const lessonId of mod.lessonIds) {
           const lesson = await loadLesson(input.courseId, lessonId);
-          lessons.push({ id: lessonId, title: lesson.title });
+          lessons.push({
+            id: lessonId,
+            title: lesson.title,
+            minutes: lesson.estimatedMinutes,
+          });
         }
         courseModules.push({ title: mod.title, lessons });
       }
+
+      // Summed from the lessons rather than assumed at five minutes each. The
+      // duration is the line a §38(3) auditor reads, and every lesson already
+      // carries its own estimate, so guessing it was only ever going to drift.
+      const totalMinutes = courseModules.reduce(
+        (total, mod) => total + mod.lessons.reduce((n, l) => n + l.minutes, 0),
+        0,
+      );
 
       const [userData] = await ctx.db
         .select({ name: user.name, email: user.email })
@@ -57,10 +69,12 @@ export const trainingCertificateRouter = router({
 
       return {
         courseTitle: course.title,
+        certificate: course.certificate,
         allCompleted,
         completedCount: completedIds.size,
         totalCount: allLessonIds.length,
         completionDate: completionDate?.toISOString() ?? null,
+        totalMinutes,
         userName: userData?.name ?? null,
         userEmail: userData?.email ?? null,
         courseModules,


### PR DESCRIPTION
## The answer to "does it work for all courses?"

The template did — same layout, same fonts, different data, for all three courses. But the **legal basis line was one hardcoded string in the template**, so every course printed the NIS 2 management-training claim:

| course | printed basis | seal |
|---|---|---|
| CRA SBOM Fundamentals | "Managementschulung gemäß §38(3) BSIG / Artikel 20(2) NIS2-Richtlinie" | NIS 2 |
| NIS 2 Tabletop Training | the same | NIS 2 |

Neither is true. The CRA course teaches the SBOM obligation in **Annex I, Part II, point (1)** of the Cyber Resilience Act. The tabletop course states its own basis in lesson `0-1`: *"The legal basis is Article 21(2)(b) and (c) NIS 2"* — it is not management training and §38(3) has nothing to do with it.

This is a document a learner forwards to an auditor, so a borrowed article number is the worst kind of wrong. It predates the redesign — `labels.legal` was always hardcoded — but the redesign promoted it from small grey text to the tracked-out eyebrow at the top of the page, which made it considerably more prominent.

## After

| course | basis | seal |
|---|---|---|
| nis2-ceo | Management training per §38(3) BSIG / Article 20(2) NIS2 Directive | NIS 2 |
| nis2-tabletop | Exercise per Article 21(2)(b) and (c) NIS2 Directive | NIS 2 |
| cra-sbom | SBOM per Annex I, Part II, point (1) Cyber Resilience Act | CRA |

## Shape

The basis moves into the course, where the rest of a course's facts already live, and **the schema requires it** — a course that has not stated its own basis fails to load rather than inheriting the last one's. Per-locale wording is lifted from each course's own content rather than translated fresh, so the certificate cites what the lessons cite.

Ten hardcoded `legal` strings leave the PDF template as a result.

A test asserts every course covers every shipped locale and that **no two courses claim the same basis** — that is the shape this mistake takes when a new course is started by copying an existing one.

## Also

Drops the five-minutes-per-lesson guess behind the duration in favour of summing the `estimatedMinutes` the lessons already carry. All three round to the same displayed figure today (`nis2-ceo` 229 vs 235 min, both "approx. 4 h"), so **nothing visible changes** — but the router loads every lesson anyway, and the duration is the line a §38(3) auditor reads.

## Verification

- `bun run typecheck` clean, `bun run test:unit` 80 pass.
- Rendered all three courses in DE and EN and read every cover.
- `nis2-ceo` output is unchanged, same certificate number — confirmed against the pre-change render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeeTDUZjHpbbaeXEELjadG