### PR TITLE
release: fix the two things the first real tag push found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,14 @@ jobs:
 
       - run: bun run build
         env:
+          # lib/env.ts:68 short-circuits on this; the rest are here so the
+          # block still describes reality if that escape hatch ever goes away.
+          # lib/env.ts validates DATABASE_URL and AUTH_SECRET (min 32 chars),
+          # and nothing named NEXTAUTH_*.
           SKIP_ENV_VALIDATION: "1"
-          RESEND_API_KEY: "re_dummy_for_ci_build"
           DATABASE_URL: "postgres://dummy:dummy@localhost:5432/dummy"
-          NEXTAUTH_SECRET: "dummy_for_ci_build"
-          NEXTAUTH_URL: "http://localhost:3026"
+          AUTH_SECRET: "ci_build_dummy_value_not_a_real_secret_0000"
+          RESEND_API_KEY: "re_dummy_for_ci_build"
 
   # The published self-host stack has to stay parseable and internally
   # consistent. `docker compose config` resolves every variable reference and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
+          # latest=auto is the action's default and it appends `latest` to any
+          # semver tag. That is a floating tag moving at manifest time, before
+          # the gate has run, which is the one thing this pipeline is built not
+          # to do. `stable` is the floating tag here and it moves in `promote`.
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,20 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Page-data collection evaluates route modules, which pull in lib/env.ts
+      # and fail the build without these. ci.yml has carried them since it was
+      # written; this job never ran until the first tag, so it never noticed.
       - name: Build
         run: bun run build
+        env:
+          # lib/env.ts:68 short-circuits on this; the rest are here so the
+          # block still describes reality if that escape hatch ever goes away.
+          # lib/env.ts validates DATABASE_URL and AUTH_SECRET (min 32 chars),
+          # and nothing named NEXTAUTH_*.
+          SKIP_ENV_VALIDATION: "1"
+          DATABASE_URL: "postgres://dummy:dummy@localhost:5432/dummy"
+          AUTH_SECRET: "ci_build_dummy_value_not_a_real_secret_0000"
+          RESEND_API_KEY: "re_dummy_for_ci_build"
 
       - name: Publish all packages
         run: bun scripts/publish-all.ts

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -62,7 +62,7 @@ for (const path of targets) {
 // 5. Commit + tag.
 await $`git add -A`.cwd(root);
 await $`git commit -m "release ${tag}"`.cwd(root);
-await $`git tag ${tag}`.cwd(root);
+await $`git tag -a ${tag} -m ${`release ${target}`}`.cwd(root);
 
 console.log(`\n  tagged ${tag}`);
 console.log(`  next:  git push --follow-tags`);


### PR DESCRIPTION
`v0.2.0` was the first tag this repository has ever pushed, and the Release workflow had never executed a single run before it. Both bugs below are pre-existing on main and neither was reachable until now.

## 1. The tag never reaches the remote

`scripts/release.ts:65` created the tag with `git tag`, which is **lightweight**. Its own docstring (line 13) and closing instruction (line 68) tell you to push with `git push --follow-tags`, and that flag pushes **annotated** tags only.

So the documented release flow pushes the version-bump commit to `main` and silently drops the tag. Nothing errors. The push prints `main -> main`, no workflow starts, and it looks like it worked. I only caught it because the tag was missing from the push output; `git cat-file -t v0.2.0` returned `commit` rather than `tag`.

Fixed with `git tag -a`.

## 2. The `release` job cannot build

It ran `bun run build` with no environment at all:

```
Error: Environment validation failed:
  DATABASE_URL: Invalid input: expected string, received undefined
  AUTH_SECRET: Invalid input: expected string, received undefined
> Build error occurred
Error: Failed to collect page data for /api/auth/resend-verification
```

Page-data collection evaluates route modules, those import `lib/env.ts`, and the build dies. The container legs were unaffected because `Dockerfile:59` sets `SKIP_ENV_VALIDATION=1` itself.

### Corrected rather than copied

`ci.yml` passes `NEXTAUTH_SECRET` and `NEXTAUTH_URL`. `lib/env.ts` validates neither, so both are inert and only `SKIP_ENV_VALIDATION` carries that build. Copying them into `release.yml` would have propagated a no-op, so both files now pass the names `lib/env.ts:5-6` actually reads.

## Verified

`bun run build` with exactly the new env block completes locally and prints the full route table.

## Not fixed here

`v0.2.0` itself cannot be salvaged: a re-run uses the workflow file from the tagged commit, which lacks this fix. Once this merges, `v0.2.1` gets a clean run. The `:0.2.0` images publish either way, since `image` has no `needs` on `release`; only `promote`, and therefore `:stable`, is blocked.