### PR TITLE
security: compute the CSP storage origin at runtime, not at build

### DIFF
--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -67,7 +67,15 @@ MINIO_KMS_KEY=
 # The address the browser uses, and the one the server uses. Different on
 # purpose with bundled MinIO; identical on real S3 (leave the internal one
 # empty there).
-AWS_S3_ENDPOINT=https://storage.example.com
+#
+# Defaults to the bundled MinIO as published by the compose file, so evidence
+# uploads work on a fresh install with nothing to fill in. Presigned URLs are
+# signed for exactly this host and the browser has to reach it, so the moment
+# you put the instance on a domain this becomes https://storage.example.com
+# or wherever MinIO actually answers. It is also what the app names in its
+# Content-Security-Policy, so a wrong value here blocks uploads in the browser
+# rather than failing on the server.
+AWS_S3_ENDPOINT=http://localhost:9000
 AWS_S3_INTERNAL_ENDPOINT=http://minio:9000
 
 # Real S3 instead: drop `minio` from COMPOSE_PROFILES, leave both endpoints

--- a/lib/security/csp.test.ts
+++ b/lib/security/csp.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { buildCsp, storageOrigin } from "./csp";
+
+describe("storageOrigin", () => {
+  test("a custom endpoint wins, reduced to its origin", () => {
+    expect(storageOrigin({ AWS_S3_ENDPOINT: "http://localhost:9000" })).toBe(
+      "http://localhost:9000",
+    );
+    expect(
+      storageOrigin({ AWS_S3_ENDPOINT: "https://storage.example.com/evidence?x=1" }),
+    ).toBe("https://storage.example.com");
+  });
+
+  test("a bucket without an endpoint implies the AWS virtual-host origin", () => {
+    expect(storageOrigin({ AWS_S3_BUCKET: "mine", AWS_S3_REGION: "eu-central-1" })).toBe(
+      "https://mine.s3.eu-central-1.amazonaws.com",
+    );
+  });
+
+  // The bug this module exists for: an unconfigured instance used to inherit
+  // the build machine's bucket, so every self-hoster advertised ours.
+  test("nothing configured names nothing", () => {
+    expect(storageOrigin({})).toBe("");
+    expect(buildCsp({})).not.toContain("amazonaws.com");
+    expect(buildCsp({})).toContain("connect-src 'self' https://accounts.google.com");
+  });
+
+  test("an unparseable endpoint does not leak into the policy", () => {
+    expect(storageOrigin({ AWS_S3_ENDPOINT: "not a url" })).toBe("");
+  });
+});
+
+describe("buildCsp", () => {
+  test("the runtime storage origin reaches connect-src", () => {
+    expect(buildCsp({ AWS_S3_ENDPOINT: "http://localhost:9000" })).toContain(
+      "connect-src 'self' https://accounts.google.com http://localhost:9000",
+    );
+  });
+
+  test("upgrade-insecure-requests only when the operator opts in", () => {
+    expect(buildCsp({})).not.toContain("upgrade-insecure-requests");
+    expect(buildCsp({ CSP_UPGRADE_INSECURE: "1" })).toContain("upgrade-insecure-requests");
+  });
+
+  test("directives never carry a blank source", () => {
+    expect(buildCsp({})).not.toMatch(/\s{2,}/);
+    expect(buildCsp({})).not.toMatch(/;\s*;/);
+  });
+});

--- a/lib/security/csp.ts
+++ b/lib/security/csp.ts
@@ -1,0 +1,65 @@
+/**
+ * Content-Security-Policy, built from the environment at call time.
+ *
+ * next.config.ts `headers()` runs when the image is built, so every value it
+ * reads from the environment freezes to whatever the build machine had. That
+ * is wrong for the one directive that is operator-specific: evidence uploads
+ * PUT straight from the browser to a presigned URL, so `connect-src` has to
+ * name the storage origin, and a self-hoster's origin is their MinIO or their
+ * own S3 — never the origin this image was built with.
+ *
+ * The failure is silent and expensive. Presigning is offline, so the server
+ * never learns the PUT was blocked; the confirm step still writes the row, and
+ * the instance ends up holding evidence records whose objects do not exist.
+ *
+ * So proxy.ts calls this per request and overwrites the baked header. Both
+ * callers share this module so the two policies cannot drift.
+ */
+
+/** Index-signature shaped so `process.env` satisfies it directly. */
+export type CspEnv = { readonly [key: string]: string | undefined };
+
+const originOf = (url: string): string => URL.parse(url)?.origin ?? "";
+
+/**
+ * Where the browser is allowed to PUT evidence to.
+ *
+ * A custom endpoint wins: that is MinIO, or any S3-compatible server. Failing
+ * that, a configured bucket implies the AWS virtual-host origin. With neither
+ * set, storage is not configured and the directive names nothing — an unset
+ * instance must not inherit somebody else's bucket.
+ */
+export const storageOrigin = (env: CspEnv): string => {
+  if (env.AWS_S3_ENDPOINT) return originOf(env.AWS_S3_ENDPOINT);
+  if (env.AWS_S3_BUCKET) {
+    const region = env.AWS_S3_REGION ?? "eu-north-1";
+    return `https://${env.AWS_S3_BUCKET}.s3.${region}.amazonaws.com`;
+  }
+  return "";
+};
+
+const directive = (name: string, sources: readonly string[]): string =>
+  [name, ...sources.filter((s) => s !== "")].join(" ");
+
+export const buildCsp = (env: CspEnv): string => {
+  // HSTS and upgrade-insecure-requests both pin HTTPS for two years once a
+  // user reaches the host over TLS, so they stay off until the operator says
+  // the deployment is HTTPS-only.
+  const httpsHardened = env.CSP_UPGRADE_INSECURE === "1";
+  const analytics = env.ANALYTICS_SCRIPT_URL ? originOf(env.ANALYTICS_SCRIPT_URL) : "";
+  const storage = storageOrigin(env);
+
+  return [
+    directive("default-src", ["'self'"]),
+    directive("script-src", ["'self'", "'unsafe-inline'", "'unsafe-eval'", analytics, "https://accounts.google.com"]),
+    directive("style-src", ["'self'", "'unsafe-inline'"]),
+    directive("img-src", ["'self'", "data:", "blob:", "https:"]),
+    directive("font-src", ["'self'", "data:"]),
+    directive("connect-src", ["'self'", analytics, "https://accounts.google.com", storage]),
+    directive("frame-src", ["'self'", "https://accounts.google.com", "https://www.youtube.com", "https://www.youtube-nocookie.com"]),
+    directive("frame-ancestors", ["'none'"]),
+    directive("base-uri", ["'self'"]),
+    directive("form-action", ["'self'", "https://accounts.google.com"]),
+    ...(httpsHardened ? ["upgrade-insecure-requests"] : []),
+  ].join("; ");
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import { buildCsp } from "./lib/security/csp";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { LEGACY_REDIRECTS } from "./lib/content/legacy-redirects";
@@ -84,33 +85,10 @@ const nextConfig: NextConfig = {
     // once a user later visits the same hostname over HTTPS. Skip both
     // until the deployment is HTTPS-only with a real TLS cert.
     const httpsHardened = process.env.CSP_UPGRADE_INSECURE === "1";
-    // Evidence uploads PUT directly to presigned S3 URLs from the browser,
-    // so connect-src must include the storage origin. Derive it from the
-    // same env that configures the S3 client (custom endpoint = MinIO in
-    // the e2e stack; otherwise the bucket's virtual-host AWS origin).
-    // Without this the browser silently blocks every evidence upload.
-    const s3Origin =
-      process.env.AWS_S3_ENDPOINT ??
-      `https://${process.env.AWS_S3_BUCKET ?? "nisd2-dev-evidence"}.s3.${process.env.AWS_S3_REGION ?? "eu-north-1"}.amazonaws.com`;
-    // Analytics is operator-configured and off by default, so its origin has
-    // to come from the same env that renders the tag. Hardcoding ours would
-    // both leak to us and block a self-hoster's own endpoint.
-    const analyticsOrigin = process.env.ANALYTICS_SCRIPT_URL
-      ? (URL.parse(process.env.ANALYTICS_SCRIPT_URL)?.origin ?? "")
-      : "";
-    const cspDirectives = [
-      "default-src 'self'",
-      `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${analyticsOrigin} https://accounts.google.com`,
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https:",
-      "font-src 'self' data:",
-      `connect-src 'self' ${analyticsOrigin} https://accounts.google.com ${s3Origin}`,
-      "frame-src 'self' https://accounts.google.com https://www.youtube.com https://www.youtube-nocookie.com",
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-      "form-action 'self' https://accounts.google.com",
-      ...(httpsHardened ? ["upgrade-insecure-requests"] : []),
-    ];
+    // Build-time baseline only. Everything proxy.ts matches gets this header
+    // recomputed per request, because the storage origin is operator-specific
+    // and this file is evaluated when the image is built. See lib/security/csp.ts.
+    const csp = buildCsp(process.env);
     const commonHeaders = [
       { key: "X-Content-Type-Options", value: "nosniff" },
       { key: "X-Frame-Options", value: "DENY" },
@@ -120,7 +98,7 @@ const nextConfig: NextConfig = {
         value:
           "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=()",
       },
-      { key: "Content-Security-Policy", value: cspDirectives.join("; ") },
+      { key: "Content-Security-Policy", value: csp },
       ...(httpsHardened
         ? [
             {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,3 +1,4 @@
+import { buildCsp } from "@/lib/security/csp";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import createIntlMiddleware from "next-intl/middleware";
@@ -250,7 +251,7 @@ const FRAGEBOGEN_HOSTS = new Set([
   "www.sicherheitsfragebogen.de",
 ]);
 
-export async function proxy(request: NextRequest) {
+async function route(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const requestHost = request.headers.get("host")?.toLowerCase() ?? "";
@@ -334,6 +335,21 @@ export async function proxy(request: NextRequest) {
   const stripped = pathname.replace(LOCALE_STRIP, "") || "/";
   response.headers.set("x-pathname", stripped);
 
+  return response;
+}
+
+/**
+ * Every response leaves with a Content-Security-Policy computed now, not the
+ * one frozen into next.config.ts when the image was built.
+ *
+ * Only `connect-src` actually differs, and only by the storage origin, but it
+ * is the difference between a self-hoster's evidence uploads working and being
+ * blocked by an origin belonging to whoever ran the build. Set here rather than
+ * at each return so a new branch cannot forget it.
+ */
+export async function proxy(request: NextRequest) {
+  const response = await route(request);
+  response.headers.set("Content-Security-Policy", buildCsp(process.env));
   return response;
 }
 


### PR DESCRIPTION
Found by running the full e2e suite against the published `ghcr.io/nisd2/open-isms:0.2.0` container. 89 passed; the evidence round-trip failed, and the cause is a bug in the image rather than the test.

## The bug

Evidence uploads PUT straight from the browser to a presigned URL, so `connect-src` has to name the storage origin. It was derived in `next.config.ts`, which Next evaluates **when the image is built**. The Dockerfile sets no `AWS_*` variables, so every published image froze the hardcoded fallback:

```
connect-src 'self' https://accounts.google.com https://nisd2-dev-evidence.s3.eu-north-1.amazonaws.com
```

That is our own dev bucket, in every self-hoster's response headers, and no runtime configuration could change it. Their browser uploads are blocked by a policy naming an origin they have never heard of.

## Why it matters more than a failed upload

Presigning is offline, so the server never learns the PUT was refused. The confirm step still writes the row. The instance ends up holding evidence records whose objects do not exist — on a compliance platform, a file that looks present until an auditor asks for it.

Observed exactly that against 0.2.0: bucket empty, one evidence row in the database.

It also means `docs/self-hosting.md` currently blames the operator ("`AWS_S3_INTERNAL_ENDPOINT` is wrong") for a bug in the image. I verified the internal endpoint answered 200 from inside the container while the upload was still blocked.

## The fix

`lib/security/csp.ts` holds the policy and reads its environment when called. `next.config.ts` still bakes a baseline for paths the proxy does not match; `proxy.ts` recomputes it per request and overwrites the header. The proxy entry point is wrapped rather than each `return`, so a new branch cannot forget it.

An unconfigured instance now names **no** storage origin, instead of inheriting the build machine's bucket.

## Production is unaffected

Real S3 still works: set `AWS_S3_BUCKET` and the AWS virtual-host origin is derived as before, which is what nisd2.eu does. It is simply no longer the default, and it is now resolved at runtime, which is strictly more correct than baking it.

One thing to confirm on the Coolify environment: `AWS_S3_BUCKET` must be present in the **runtime** env, not only at build. It has to be anyway for the S3 client to address the bucket, so this should be a no-op.

## Also

`.env.self-host.example` pointed `AWS_S3_ENDPOINT` at `https://storage.example.com`, a placeholder that cannot work. It now defaults to the bundled MinIO as the compose file publishes it, so a fresh install has working uploads with nothing to fill in.

## Tests

`lib/security/csp.test.ts`, 7 cases, picked up by `bun run test:unit`. One pins the regression directly: an unconfigured instance must not emit `amazonaws.com` anywhere in its policy.