### PR TITLE
docs: say what the update feature actually does, which is nothing yet

### DIFF
--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -85,13 +85,12 @@ AWS_S3_REGION=eu-north-1
 # --------------------------------------------------------------------------
 # Updates
 # --------------------------------------------------------------------------
-# off     no outbound update traffic at all. The version you run is shown in
-#         the admin area and that is it.
-# notify  one GET a day against the GitHub releases API to find out whether a
-#         newer version exists. No instance identifier, no telemetry, no
-#         payload. Shows what changed, including legal content updates.
-# auto    unattended updates. Not recommended for a compliance database:
-#         migrations would run without anyone having taken a backup first.
+# Not implemented yet: no application code reads this. Left here because the
+# compose file passes it through, and a variable that silently does nothing is
+# worse than one that says so. Checking for updates is manual for now, see
+# docs/updating.md. Planned: `notify` = one GET a day against the GitHub
+# releases API, no instance identifier and no telemetry. Unattended updates
+# are deliberately not planned for a compliance database.
 UPDATE_MODE=off
 
 # Only for the updater profile. openssl rand -hex 32

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@nisd2/grc-data-model"><img src="https://img.shields.io/npm/v/@nisd2/grc-data-model.svg?logo=npm&label=grc-data-model" alt="npm"></a>
+  <a href="https://github.com/NISD2/open-isms/tags"><img src="https://img.shields.io/github/v/tag/NISD2/open-isms?logo=github&label=version&color=284b63" alt="Latest version"></a>
+  <a href="https://github.com/NISD2/open-isms/pkgs/container/open-isms"><img src="https://img.shields.io/badge/ghcr.io-open--isms-284b63?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="https://github.com/NISD2/open-isms/actions/workflows/ci.yml"><img src="https://github.com/NISD2/open-isms/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/NISD2/open-isms/actions/workflows/release.yml"><img src="https://github.com/NISD2/open-isms/actions/workflows/release.yml/badge.svg" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
   <a href="https://www.nisd2.eu"><img src="https://img.shields.io/badge/site-nisd2.eu-284b63.svg" alt="nisd2.eu"></a>
 </p>
@@ -66,10 +68,14 @@ curl -o Caddyfile    https://raw.githubusercontent.com/NISD2/open-isms/main/Cadd
 docker compose up -d                        # http://localhost:3026
 ```
 
-No clone and no fork: this pulls the same published image nisd2.eu runs, with
-a bundled MinIO for evidence files so no AWS account is needed. Migrations
-apply at container start, and `OPEN_ISMS_VERSION` in `.env` decides whether
-you follow releases or pin one.
+No clone and no fork: this pulls the same published image nisd2.eu runs, from
+`ghcr.io/nisd2/open-isms`, built natively for x86-64 and ARM64 so a NAS pulls
+the same release an Intel server does. Evidence files go to a bundled MinIO,
+so no AWS account is needed and nothing leaves the machine. Migrations apply
+at container start.
+
+`OPEN_ISMS_VERSION` in `.env` decides what you run: `stable` follows releases,
+an exact version pins you there and is how you roll back.
 
 Full walkthrough, the environment variables, and which third-party services
 you can do without: **[docs/self-hosting.md](./docs/self-hosting.md)**.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -110,7 +110,7 @@ Evidence files do not go in Postgres. They go to S3-compatible object storage, u
 
 ### Bundled MinIO, no external account
 
-Uncomment the object-store block in `.env`, set the two secrets, and add `--profile minio` to your compose command:
+This is the default. The `minio` profile is already on in `COMPOSE_PROFILES` and the object-store block in `.env` already points at it, so the only things left to fill in are the two secrets:
 
 ```bash
 AWS_S3_BUCKET=evidence
@@ -238,7 +238,8 @@ Two things to back up if you run the bundled MinIO, not one: the Postgres databa
 | Login redirects back to the sign-in page forever | `AUTH_URL` does not match the scheme users actually reach you on. This is the single most common self-host failure. |
 | Sign-up says the code was sent, no email arrives | `RESEND_API_KEY` unset. The send path logs `[mail] RESEND_API_KEY not set, skipping email` and reports success anyway. |
 | Portal loads but there are no requirements | The seed has not been run. See [Load the framework data](#load-the-framework-data). |
-| Evidence upload fails in the browser with a CSP error | `AWS_S3_ENDPOINT` does not match the origin the browser is actually PUTting to. |
+| Evidence upload fails in the browser with a CSP error | `AWS_S3_ENDPOINT` does not match the origin the browser is actually PUTting to. The app names that origin in its `Content-Security-Policy`, computed per request, so `curl -sI <your-url>/ \| grep -i content-security-policy` shows exactly what it currently allows. |
+| An evidence row appears but the file is not in the bucket | The browser's upload was refused and the server never learned. Presigning is offline, so nothing server-side notices a blocked or failed PUT. Check the CSP row above first, then that the bucket exists. |
 | Upload rejected, MinIO logs mention server-side encryption | `MINIO_KMS_KEY` is unset or is not 32 bytes of base64. |
 | Upload works, deleting an evidence file fails | `AWS_S3_INTERNAL_ENDPOINT` is wrong. Presigning is offline so uploads never noticed; deletion is the first call the server actually makes. |
 | `Bind for 0.0.0.0:9000 failed: port is already allocated` | Something else on the box uses 9000. Set `MINIO_PORT` and match `AWS_S3_ENDPOINT` to it. |

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -85,34 +85,51 @@ and note that restoring loses anything written since the backup ran.
 
 ## Update notifications
 
-The app can tell you when a new version exists, including what is in it.
-`UPDATE_MODE` in `.env` controls this:
+**Not implemented yet.** `UPDATE_MODE` and `UPDATE_API_TOKEN` are carried
+through `.env` and the compose file, but no application code reads either one
+today. Setting `UPDATE_MODE=notify` does nothing: the instance makes no
+outbound update request, and nothing appears in the admin area. Documented
+here because the variables exist and would otherwise look broken rather than
+unbuilt.
 
-| Value | Behaviour |
-|---|---|
-| `off` (default) | No outbound update traffic at all. The admin area shows the version you run and links to the releases page. |
-| `notify` | One request a day to the GitHub releases API. No instance identifier, no telemetry, no payload of any kind: it asks what the newest release is and compares locally. |
-| `auto` | Unattended updates via the updater profile. |
+Until it lands, checking for updates is a manual step. Watch the tags at
+`github.com/NISD2/open-isms/tags`, or ask the registry directly:
 
-`auto` is not recommended here. It applies migrations to a compliance database
-with nobody watching and no fresh backup, which is a poor trade for the
-convenience.
+```bash
+curl -s "https://ghcr.io/token?scope=repository:nisd2/open-isms:pull&service=ghcr.io" \
+  | sed -n 's/.*"token":"\([^"]*\)".*/\1/p' \
+  | xargs -I{} curl -s -H "Authorization: Bearer {}" \
+      https://ghcr.io/v2/nisd2/open-isms/tags/list
+```
 
-Egress-restricted networks: `notify` needs `api.github.com`. Pulling images
-needs `ghcr.io` and `pkg-ghcr.githubusercontent.com`, and the rest of the
-stack comes from Docker Hub.
+Compare that against what your instance reports at `/api/health`.
+
+When it is built, the intent is one request a day to the GitHub releases API,
+with no instance identifier and no telemetry: it asks what the newest release
+is and compares locally. Unattended updates are deliberately not planned. They
+apply migrations to a compliance database with nobody watching and no fresh
+backup, which is a poor trade for the convenience.
+
+Egress-restricted networks: pulling images needs `ghcr.io` and
+`pkg-ghcr.githubusercontent.com`, and the rest of the stack comes from Docker
+Hub.
 
 ## The updater profile
 
-With `--profile updater`, the stack runs a small companion container that can
-pull a new image and recreate the app when the app asks it to. That is what
-puts an update button in the admin area instead of you running two commands.
+With `--profile updater`, the stack runs a small companion container
+(watchtower) that can pull a new image and recreate the app on request. It
+exposes an HTTP endpoint on the internal network, authenticated with
+`UPDATE_API_TOKEN`.
 
-It publishes no port, is reachable only from the app over the internal
-network, and does nothing on its own: with no periodic polling configured it
-acts only on request, and a request only happens after a human clicks. It is
-scoped by label to the app container and will not touch anything else on the
-host.
+The in-app button that would call it does not exist yet, so today the endpoint
+is only reachable by something you drive yourself. Running `docker compose
+pull && docker compose up -d` does the same job with nothing extra installed,
+which is why this profile is off by default.
+
+It publishes no port, is reachable only from within the stack, and does
+nothing on its own: with no periodic polling configured it acts only when
+called. It is scoped by label to the app container and will not touch anything
+else on the host.
 
 It does mount the Docker socket, which is root-equivalent on the host. That is
 true of every self-update mechanism, including the ones built into Coolify and
@@ -138,8 +155,8 @@ docker save ghcr.io/nisd2/open-isms:1.5.0 | gzip > openisms-1.5.0.tar.gz
 
 Move the file across, then `docker load < openisms-1.5.0.tar.gz`, set
 `OPEN_ISMS_VERSION=1.5.0`, and `docker compose up -d`. Migrations apply at
-startup exactly as they would otherwise. Set `UPDATE_MODE=off` so the instance
-does not try to reach the releases API.
+startup exactly as they would otherwise. Nothing in the app reaches out on its
+own today, so an air-gapped instance needs no extra setting to keep it quiet.
 
 Note that a fully offline instance cannot send email, and the sign-up flow
 verifies addresses with a one-time code, so no one can complete a first login
@@ -149,6 +166,7 @@ without a mail route. Plan for that before disconnecting.
 
 `COMPOSE_REVISION` in `.env` records which revision of `compose.yaml` you are
 running. Some releases need a change there — a new service, a new variable —
-and the release notes say so. With `UPDATE_MODE=notify` the app compares your
-revision against what the release expects and tells you, rather than letting
-the deployment drift silently into a state nobody can reproduce.
+and the tag notes say so. The app reports the value it was given at
+`/api/health` as `composeRevision`, so you can see what your deployment
+believes it is running. Comparing that against what a release expects is the
+manual half of the notification feature above.


### PR DESCRIPTION
Started as a README pass and turned up a documentation accuracy problem worth fixing first.

## `UPDATE_MODE` is documented but not implemented

`UPDATE_MODE` and `UPDATE_API_TOKEN` appear in `compose.self-host.yml`, `.env.self-host.example`, `docs/updating.md` and CI. They appear in **no application code**:

```
$ grep -rn "UPDATE_MODE" . --exclude-dir=node_modules --exclude-dir=.git
compose.self-host.yml:100
.env.self-host.example:95
docs/updating.md:89, 141, 152
```

The docs described a daily check against the GitHub releases API, an update button in the admin area, and a `COMPOSE_REVISION` comparison. None of it is built. A self-hoster setting `UPDATE_MODE=notify` gets silence and reasonably concludes their instance is broken.

Marked as unimplemented rather than quietly deleted — the variables are still threaded through the stack, so removing the docs would leave two settings that look real and do nothing. The manual alternative is documented instead, including how to ask the registry for the newest tag.

Related: the updater profile section claimed watchtower is what "puts an update button in the admin area". The container and its HTTP endpoint are real; the button is not.

And the air-gap section told operators to set `UPDATE_MODE=off` so the instance would not reach the releases API. It never did.

## Storage

The bundled MinIO is now the default rather than something to uncomment, matching the change to the env template. Added a troubleshooting row for the failure mode I hit against 0.2.0 — an evidence row whose object never arrived — and pointed the CSP row at the header the instance actually serves, now that it is computed per request.

## README

Version and container-image badges, plus the release workflow's own status:

```
version | ghcr.io/open-isms | CI | Release | AGPL-3.0 | nisd2.eu
```

Dropped the npm badge. Nothing has ever published to npm (`@nisd2/grc-data-model` 404s on the registry), so it rendered as broken on the front page of a public repo. It can come back when the publish step works.

The version badge reads tags rather than GitHub Releases, since no Releases exist yet. If we start cutting them it keeps working unchanged.