### PR TITLE
release: keep latest tracking stable instead of leaving it stranded

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,13 +327,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Move stable
+      # `latest` moves with `stable`, not instead of it. A bare
+      # `docker pull ghcr.io/nisd2/open-isms` resolves to `:latest`, so someone
+      # doing the obvious thing gets whatever it points at. Leaving it behind
+      # is worse than not having it: v0.2.0 published one before this workflow
+      # stopped emitting it, and it sat pointing at an old release while the
+      # docs told everyone to use `stable`.
+      #
+      # Both are written here, after the gate, so neither can name a version
+      # that failed to install.
+      - name: Move stable and latest
         run: |
-          docker buildx imagetools create -t "${IMAGE}:stable" "${IMAGE}:${VERSION}"
-          echo "::notice::stable now points at ${VERSION}"
+          docker buildx imagetools create \
+            -t "${IMAGE}:stable" \
+            -t "${IMAGE}:latest" \
+            "${IMAGE}:${VERSION}"
+          echo "::notice::stable and latest now point at ${VERSION}"
 
-      - name: Stable is pullable without credentials
-        run: bash scripts/ci/assert-public-pull.sh "${IMAGE}" stable
+      - name: Stable and latest are pullable without credentials
+        run: |
+          bash scripts/ci/assert-public-pull.sh "${IMAGE}" stable
+          bash scripts/ci/assert-public-pull.sh "${IMAGE}" latest
 
       # Creates the tag and the release together, from this commit. The notes
       # are generated from the merged PRs, which is what self-hosters read


### PR DESCRIPTION
`ghcr.io/nisd2/open-isms:latest` currently points at **v0.2.0**, three releases behind, while the docs tell self-hosters to use `stable`.

It exists because `docker/metadata-action` defaults to `flavor: latest=auto` and appended it during the v0.2.0 release. The workflow no longer emits it, so nothing will ever move it again.

## Why not just delete it

```
:latest -> sha256:bcb4cd10c449a382a1a
:0.2.0  -> sha256:bcb4cd10c449a382a1a
```

Same digest. GHCR holds those as one version carrying two tags, so deleting the version in the package UI takes `0.2.0` with it — the release the upgrade gate tests against, and the one a rollback lands on.

## Why keeping it is right anyway

A bare `docker pull ghcr.io/nisd2/open-isms` resolves to `:latest`. People will do that. Handing them a stale image is worse than either alternative.

So `promote` now writes `stable` and `latest` together, after the gate, and asserts both are anonymously pullable. Neither can name a version that failed to install.

`stable` remains the documented tag; `OPEN_ISMS_VERSION` and the compose default are unchanged. `latest` is there purely so the conventional pull is not a trap.

## Effect

Merging this triggers a release (it touches a workflow), and that release repoints `latest` at the current version.