### PR TITLE
packages: let the dts builds finish so npm publishing can run

### DIFF
--- a/packages/grc-data-model/tsconfig.json
+++ b/packages/grc-data-model/tsconfig.json
@@ -13,6 +13,10 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // tsup's dts pass sets baseUrl internally, which TypeScript 6 rejects
+    // (TS5101). Nothing here sets it; silencing is the remedy the compiler
+    // itself names, until tsup stops emitting it.
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/incident-notification-schema/tsconfig.json
+++ b/packages/incident-notification-schema/tsconfig.json
@@ -13,6 +13,10 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // tsup's dts pass sets baseUrl internally, which TypeScript 6 rejects
+    // (TS5101). Nothing here sets it; silencing is the remedy the compiler
+    // itself names, until tsup stops emitting it.
+    "ignoreDeprecations": "6.0",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/packages/isms-schema/tsconfig.json
+++ b/packages/isms-schema/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "declaration": true,
-    "baseUrl": ".",
+    // No baseUrl: TypeScript 6 errors on it (TS5101) and the paths below are
+    // already relative to this file, which is how they resolve without it.
     "paths": {
       "@nisd2/grc-data-model": [
         "../grc-data-model/src/index.ts"


### PR DESCRIPTION
The first **Publish npm packages** run failed at the build step, before publishing anything:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in
TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
DTS Build error
```

tsup's dts pass sets `baseUrl` internally and TypeScript 6.0.3 rejects it. Nothing in this repo sets it for those two packages.

Worth noting why it slipped past the earlier check: the JS output is written regardless, so `dist/` exists and only the exit code fails. `publish-all.ts` verifies `dist/` is present, which it was — the failure surfaced one layer up, in the build step I added for exactly this reason.

## Fix

`ignoreDeprecations: "6.0"` on the two tsup-built packages, which is the remedy the compiler names. The third builds with `tsc` and already exits 0.

`isms-schema` also set `baseUrl` itself, needlessly — its `paths` are relative to the tsconfig and resolve identically without it.

## Why this is the second time

These three edits were made once already, during #99, and lost before that PR was committed. While testing `set-package-versions.ts` I ran `git checkout -- packages/` to revert the test version bump, which reverted the tsconfig edits sitting in the same directory. The commit went out without them and the failure reappeared on the first real publish run.

## Verified

- `bun run --filter './packages/*' build` exits **0** for all three.
- `bun run typecheck` clean.
- Diff is exactly three tsconfig files, nothing else.