### PR TITLE
chore: correct what drifted, now that the packages are actually published

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,12 @@ bun db:seed              # Seed database (drops + recreates dev data)
 |-------|------|---------|-------|
 | Framework | Next.js | 16.1.6 | App Router, SSR-first |
 | React | React | 19.1.0 | `useOptimistic`, `useTransition` available |
-| TypeScript | TS | 5.7.3 | Strict mode |
+| TypeScript | TS | 6.0.3 | Strict mode. Note: 6.x errors on deprecated options such as `baseUrl` (TS5101) |
 | Styling | Tailwind CSS | 4.1.0 | `@theme inline` for shadcn color vars |
 | Validation | Zod | **4.x** | NOT v3. Uses `_def.type` not `_def.typeName` |
 | ORM | Drizzle | 0.45.x | PostgreSQL, relational queries |
 | API | tRPC | 11.1.0 | superjson transformer |
-| Auth | NextAuth | 5.0.0-beta.30 | JWT strategy, Google OAuth |
+| Auth | NextAuth | 5.0.0-beta.32 | JWT strategy, Google OAuth |
 | i18n | next-intl | 4.8.2 | Cookie-based locale, DE default + EN + NL |
 | AI | Vercel AI SDK | 6.x | + @ai-sdk/xai (grok-2-1212) for form prefill |
 | Storage | AWS S3 | SDK v3 | Presigned URLs for evidence uploads |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/NISD2/open-isms/tags"><img src="https://img.shields.io/github/v/tag/NISD2/open-isms?logo=github&label=version&color=284b63" alt="Latest version"></a>
+  <a href="https://www.npmjs.com/package/@nisd2/grc-data-model"><img src="https://img.shields.io/npm/v/@nisd2/grc-data-model.svg?logo=npm&label=grc-data-model" alt="npm"></a>
   <a href="https://github.com/NISD2/open-isms/pkgs/container/open-isms"><img src="https://img.shields.io/badge/ghcr.io-open--isms-284b63?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="https://github.com/NISD2/open-isms/actions/workflows/ci.yml"><img src="https://github.com/NISD2/open-isms/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/NISD2/open-isms/actions/workflows/release.yml"><img src="https://github.com/NISD2/open-isms/actions/workflows/release.yml/badge.svg" alt="Release"></a>

--- a/packages/nis2-supply-chain-questionnaire-schema/package.json
+++ b/packages/nis2-supply-chain-questionnaire-schema/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@nisd2/nis2-supply-chain-questionnaire-schema",
   "version": "0.2.1",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Open EU data format for the NIS2 supply-chain questionnaire — typed Zod schema as source of truth, JSON + JSON Schema as published artefacts. The questions a NIS2-regulated entity asks its suppliers, anchored to NIS2 Art. 21(2)(d), CIR 2024/2690, ENISA TIG, GDPR, and the Cyber Resilience Act.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/NISD2/nis2-supply-chain-questionnaire-schema",


### PR DESCRIPTION
A cleanup sweep after the release work. Three real corrections; everything else I checked was already fine and is listed below so the sweep is auditable.

## Fixed

**`CLAUDE.md` claimed TypeScript 5.7.3; it is `^6.0.3`.** That gap cost real time today — 6.x turns deprecated options into hard errors, which is why the package dts builds failed with `TS5101` on `baseUrl` while the doc described a version where it is merely deprecated. Annotated inline so the next person trusts the error over the table. `next-auth` was two betas behind as well.

**`nis2-supply-chain-questionnaire-schema` had no `publishConfig`.** The only publishable package without it. It published fine because `publish-all.ts` passes `--access public`, but scoped packages default to restricted, so a manual `npm publish` in that directory hits a 402 the other two do not.

**npm badge restored.** It was removed because nothing had ever been published and it rendered broken on a public front page. `@nisd2/grc-data-model` is now on the registry.

## Checked and deliberately left alone

- No references anywhere to the deleted `scripts/release.ts` or `check-versions.ts`.
- No stale manual-release instructions in `docs/`, `README.md` or `CONTRIBUTING.md`.
- All three published packages are coherent. `grc-data-model` and `incident-notification-schema` ship `dist` with `main`/`types` pointing at it; the questionnaire schema is **source-only by design** — `exports` names `./src/index.ts` and `files` includes `src`, so its absent `dist` is intent, not omission. I checked the actual published tarballs rather than the manifests.
- No `TODO`/`FIXME` left in the workflows or `scripts/ci/`.

## Also

Removed the merged worktrees left over from this work (`open-isms-tsfix`, `open-isms-latest`, and earlier `open-isms-autorelease`, `open-isms-docs`).