### PR TITLE
docs: list all three npm packages, and correct the counts against the data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Auto-audit middleware extracts entity ID from input (checks: id, statusId, evide
 - **GRC-core schema lives in `@nisd2/grc-data-model`** (workspace package at `packages/grc-data-model/`, mirrored to `github.com/NISD2/grc-data-model` via `git subtree push`)
   - Drizzle tables: `framework`, `requirement`, `requirement-satisfaction`, `supplier`, `asset`, `risk`, `incident`
   - GRC enums (16): framework, entity_type, evidence_type, frequency, priority, etc.
-  - Framework data: NIS2 (12 cats / 49 reqs) + GDPR (5 / 7), satisfaction pairs
+  - Framework data: NIS2 (12 cats / 49 reqs), GDPR (6 / 9), EU AI Act (10 / 24), CRA (10 / 21), ISO 27001:2022 (5 / 116), 125 satisfaction pairs
 - **App-only schema** in `schema/`:
   - `schema/tables/*.ts` — auth, billing, audit-log, notification, evidence, policies, leads, supplier-portal, training, etc.
   - `schema/enums.ts` — app-specific enums (plan, lead_intent, ai_data_sharing, notification_status, operational-table enums)
@@ -267,7 +267,7 @@ When answering substantive questions about NIS 2 / GDPR / EU AI Act / CRA / ISO 
 
 ### Framework + legal facts (in-repo, canonical)
 
-- `packages/grc-data-model/src/frameworks/` — article-level data per framework. NIS 2 has 49 requirements across 12 categories with EUR-Lex references and BSIG transposition links. GDPR has 7 articles. Same for EU AI Act, CRA, ISO 27001:2022.
+- `packages/grc-data-model/src/frameworks/` — article-level data per framework. NIS 2 has 49 requirements across 12 categories with EUR-Lex references and BSIG transposition links. GDPR has 9 across 6, the EU AI Act 24 across 10, the CRA 21 across 10, ISO 27001:2022 116 across 5. 219 requirements and 125 satisfaction pairs in total.
 - `packages/grc-data-model/src/schema/` — Drizzle table definitions for framework, requirement, asset, supplier, risk, incident
 - `packages/grc-data-model/src/mappings/` — cross-framework mappings (NIS 2 ↔ GDPR)
 - `packages/incident-notification-schema/` — NIS 2 §23(4) incident notification format: structured fields, severity, timing windows, IoC reporting

--- a/README.md
+++ b/README.md
@@ -93,16 +93,27 @@ docker compose up --build # http://localhost:3000
 
 ## Quick start (just the schema packages)
 
+The framework data and schemas are published to npm on their own, so you can
+build against them without running any of this. There is no npm package for
+the platform itself: open-isms ships as a container image, see above.
+
 ```bash
-bun add @nisd2/grc-data-model @nisd2/incident-notification-schema
+bun add @nisd2/grc-data-model @nisd2/incident-notification-schema @nisd2/nis2-supply-chain-questionnaire-schema
 ```
+
+| package | what it gives you |
+|---|---|
+| [`@nisd2/grc-data-model`](https://www.npmjs.com/package/@nisd2/grc-data-model) | 219 requirements across NIS 2, GDPR, the EU AI Act, the CRA and ISO 27001:2022, with 125 cross-framework satisfaction pairs and Drizzle-compatible Postgres schemas |
+| [`@nisd2/incident-notification-schema`](https://www.npmjs.com/package/@nisd2/incident-notification-schema) | the NIS 2 Article 23 incident notification format as a typed Zod schema |
+| [`@nisd2/nis2-supply-chain-questionnaire-schema`](https://www.npmjs.com/package/@nisd2/nis2-supply-chain-questionnaire-schema) | the questions a regulated entity asks its suppliers, as Zod plus JSON Schema |
 
 ```ts
 import { nis2Categories, getNis2RequirementsForCategory } from "@nisd2/grc-data-model/frameworks";
 import { complianceFramework, requirement } from "@nisd2/grc-data-model/schema";
 ```
 
-49 NIS 2 articles, 7 GDPR articles, NIS 2 ↔ GDPR mappings, Drizzle-compatible Postgres schema.
+Per framework: NIS 2 12 categories / 49 requirements, GDPR 6 / 9, EU AI Act
+10 / 24, CRA 10 / 21, ISO 27001:2022 5 / 116.
 
 ## Legal scope
 

--- a/packages/grc-data-model/README.md
+++ b/packages/grc-data-model/README.md
@@ -1,6 +1,6 @@
 # @nisd2/grc-data-model
 
-**The canonical EU cybersecurity + AI compliance data model.** 217 requirements across NIS 2, GDPR, EU AI Act, CRA, and ISO 27001:2022. 111 cross-framework satisfaction pairs. Drizzle schemas, framework metadata, article-level mappings. MIT-licensed. Used in production by [nisd2.eu](https://www.nisd2.eu).
+**The canonical EU cybersecurity + AI compliance data model.** 219 requirements across NIS 2, GDPR, EU AI Act, CRA, and ISO 27001:2022. 125 cross-framework satisfaction pairs. Drizzle schemas, framework metadata, article-level mappings. MIT-licensed. Used in production by [nisd2.eu](https://www.nisd2.eu).
 
 **[Browse the full reference (REFERENCE.md)](./REFERENCE.md)** — every requirement, every pair, every article-level mapping in one document.
 


### PR DESCRIPTION
Answers the question directly: **there is no npm package for open-isms itself.** The root package is `nis2-compliance` with `private: true`; the platform ships as a container image. Only the three data/schema packages publish. The README now says so, rather than leaving someone to infer it from an absence.

## The counts were wrong in four places

Verified against `packages/grc-data-model` rather than copied forward:

| | claimed | actual |
|---|---|---|
| `grc-data-model` README | 217 requirements | **219** |
| `grc-data-model` README | 111 satisfaction pairs | **125** |
| root README | "7 GDPR articles" | **9**, across 6 categories |
| `CLAUDE.md` | GDPR (5 cats / 7 reqs) | **6 / 9** |
| `CLAUDE.md:270` | "GDPR has 7 articles" | **9 across 6** |

Per framework: NIS 2 12/49, GDPR 6/9, EU AI Act 10/24, CRA 10/21, ISO 27001:2022 5/116.

The pair figure comes from `allSatisfactionPairs`, the canonical export. Summing the seven per-pair arrays independently gives the same 125 (11 + 87 + 9 + 2 + 7 + 5 + 4).

Worth recording how nearly this went wrong: my first pass read the per-pair arrays through `tail -4`, saw four of seven, and produced 109. A second pass summing every array in the module double-counted `allSatisfactionPairs` alongside its own members and produced 250. Only the canonical export and the explicit seven-way sum agree, so that is what shipped.

## README

All three packages are now listed with what each one gives you and a link to its registry page, instead of an install line covering two of them.

`REFERENCE.md` is generated and CI verifies it is current, so it needed no change — its NIS 2 12/49 and GDPR 6/9 already matched the data and were what exposed the drift elsewhere.