### PR TITLE
ci: cancel superseded runs, and stop re-testing main twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded runs are cancelled. Pushing three times to a PR used to run three
+# full suites to completion; only the newest tells you anything.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,7 +26,7 @@ jobs:
         with:
           bun-version: latest
 
-      - run: bun install
+      - run: bun install --frozen-lockfile
 
       - run: bun run test
         working-directory: packages/grc-data-model

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded runs are cancelled. Pushing three times to a PR used to run three
+# full suites to completion; only the newest tells you anything.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,13 +19,19 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded runs are cancelled. Pushing three times to a PR used to run three
+# full suites to completion; only the newest tells you anything.
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
+      # Shallow on purpose: the scan below is --no-git, so the full history
+      # was being downloaded and never read.
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
 
       - name: Run gitleaks (Docker)
         run: |
@@ -38,7 +44,7 @@ jobs:
           # scan is sufficient.
           docker run --rm \
             -v "${{ github.workspace }}:/path" \
-            zricethezav/gitleaks:latest \
+            zricethezav/gitleaks:v8.30.1 \
             detect \
             --source=/path \
             --no-git \

--- a/.github/workflows/self-host.yml
+++ b/.github/workflows/self-host.yml
@@ -8,8 +8,12 @@ name: Self-host stack
 
 on:
   pull_request:
-  push:
-    branches: [main]
+  # No push trigger. A merge re-tests the tree the PR just tested, and
+  # release.yml's upgrade-gate covers the same migration path against the
+  # published image rather than a locally built one, which is the stronger
+  # check. What a push run added over the PR run was a second copy of the
+  # same answer.
+  #
   # Base images move underneath us (postgres, node, minio, the updater). A
   # weekly run catches a stack that broke without anybody touching the repo.
   schedule:


### PR DESCRIPTION
Measured first. Median job durations across recent PR runs:

```
e2e            8.0 min   <- sets wall clock; everything else finishes sooner
lifecycle      5.2
build          2.0
upgrade        0.4       (self-gated: skips unless migrations changed)
gitleaks       0.4
backup-drill   0.4
compose        0.1
```

**None of this makes a PR finish faster.** Wall clock is e2e alone. What it removes is work that was never going to tell anyone anything.

## 1. Superseded runs now cancel

`ci`, `e2e` and `gitleaks` had no concurrency group. Push three times to a PR and three full suites ran to completion, including three eight-minute e2e runs. `self-host` and `release` already did this; these three were the omission.

Biggest compute saving here, zero coverage risk.

## 2. `self-host` loses its push-to-main trigger

A merge re-tested the tree the PR had just tested. Meanwhile `release.yml`'s `upgrade-gate` covers the same migration path against the **published** image rather than a locally built one — strictly the stronger check.

Both remaining triggers earn their place: `pull_request` gates the change, and the weekly cron catches upstream base images (postgres, node, minio, watchtower) moving underneath a stack nobody touched.

## 3. `gitleaks` fetched history it never reads

`fetch-depth: 0` followed by a `--no-git` scan — the full history was downloaded and discarded every run.

It also ran `zricethezav/gitleaks:latest`. For a secret scanner that means detection rules can change between runs with no diff, and a compromised tag lands directly in CI. Pinned to `v8.30.1` and verified against this tree: *no leaks found*, 38 MB in 3.5s.

## 4. `ci` installed without `--frozen-lockfile`

`e2e` and `publish-npm` both use it; `ci` did not, so lockfile drift could never fail CI. Verified the lockfile is already clean, so this changes nothing today and catches the next one.

## Coverage

Unchanged. Nothing that ran on a PR stops running on a PR. The only thing deleted is a second copy of an answer already given.

## Not included

The real latency win is #105 — pointing e2e at the container `lifecycle` already builds, which deletes one of the three separate app builds per PR (`ci/build`, `e2e`, `lifecycle`). Bigger change, separate PR.