### PR TITLE
e2e: run the suite against a published image, in the published stack

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -17,6 +17,10 @@ import {
 } from "@aws-sdk/client-s3";
 import {
   assertE2eTargets,
+  E2E_S3_ACCESS_KEY_ID,
+  E2E_S3_BUCKET,
+  E2E_S3_ENDPOINT,
+  E2E_S3_SECRET_ACCESS_KEY,
   E2E_USER_EMAIL,
   E2E_USER_PASSWORD,
   E2E_MANAGER_EMAIL,
@@ -35,12 +39,15 @@ setup("provision and authenticate", async ({ page, browser }) => {
   // Evidence bucket for the MinIO stack (idempotent).
   const s3 = new S3Client({
     region: "eu-north-1",
-    endpoint: "http://localhost:9000",
+    endpoint: E2E_S3_ENDPOINT,
     forcePathStyle: true,
-    credentials: { accessKeyId: "minioadmin", secretAccessKey: "minioadmin" },
+    credentials: {
+      accessKeyId: E2E_S3_ACCESS_KEY_ID,
+      secretAccessKey: E2E_S3_SECRET_ACCESS_KEY,
+    },
   });
   try {
-    await s3.send(new CreateBucketCommand({ Bucket: "e2e-evidence" }));
+    await s3.send(new CreateBucketCommand({ Bucket: E2E_S3_BUCKET }));
   } catch (err) {
     if (
       !(err instanceof BucketAlreadyOwnedByYou) &&

--- a/e2e/lib/env.ts
+++ b/e2e/lib/env.ts
@@ -16,6 +16,15 @@ export const E2E_DATABASE_URL =
 
 export const E2E_BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:3410";
 
+/** Object store the harness provisions the evidence bucket in. Defaults to the
+ *  hermetic stack in e2e/docker-compose.yml; overridden when the suite runs
+ *  against a self-host stack, whose MinIO lives on a different port with
+ *  different credentials. See scripts/e2e-against-image.sh. */
+export const E2E_S3_ENDPOINT = process.env.E2E_S3_ENDPOINT ?? "http://localhost:9000";
+export const E2E_S3_BUCKET = process.env.E2E_S3_BUCKET ?? "e2e-evidence";
+export const E2E_S3_ACCESS_KEY_ID = process.env.E2E_S3_ACCESS_KEY_ID ?? "minioadmin";
+export const E2E_S3_SECRET_ACCESS_KEY = process.env.E2E_S3_SECRET_ACCESS_KEY ?? "minioadmin";
+
 /** Seeded by drizzle/seed.ts (Dev GmbH admin). The harness only adds the
  *  password hash — see e2e/auth.setup.ts. */
 export const E2E_USER_EMAIL = "dev@nis2.local";

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "preview:certificate": "bun run scripts/preview-certificate.ts",
     "og": "og-shot",
     "e2e": "playwright test",
+    "e2e:image": "bash scripts/e2e-against-image.sh",
     "e2e:ui": "playwright test --ui",
     "e2e:serve": "bash e2e/serve.sh",
     "e2e:demo-evidence": "bun e2e/demo-evidence.ts",

--- a/scripts/e2e-against-image.sh
+++ b/scripts/e2e-against-image.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Run the e2e suite against a published image, in the published compose stack.
+#
+# CI builds a bundle and serves it with `next start`, so the behavioural suite
+# has never touched the artifact self-hosters actually pull. That gap is not
+# theoretical: running this against 0.2.0 by hand is what found the
+# Content-Security-Policy storage origin frozen at build time, which blocked
+# browser evidence uploads on every self-hosted instance and which no
+# local-build run could have surfaced.
+#
+#   scripts/e2e-against-image.sh                # :stable
+#   scripts/e2e-against-image.sh 0.2.3          # a specific version
+#   scripts/e2e-against-image.sh stable --keep  # leave the stack running
+#
+# The database is named openisms_e2e so the harness's own never-on-prod guard
+# (e2e/lib/env.ts assertE2eTargets) is satisfied honestly rather than bypassed:
+# the suite writes directly to it and it is genuinely disposable.
+
+set -euo pipefail
+
+VERSION="${1:-stable}"
+KEEP="${2:-}"
+IMAGE="ghcr.io/nisd2/open-isms"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STACK="$(mktemp -d)"
+PROJECT="e2e-image-$$"
+
+log() { printf '\n\033[1m[e2e-image]\033[0m %s\n' "$1"; }
+
+cleanup() {
+  if [[ "$KEEP" == "--keep" ]]; then
+    log "left running in $STACK (docker compose -p $PROJECT down -v to remove)"
+    return
+  fi
+  log "tearing down"
+  docker compose -p "$PROJECT" -f "$STACK/compose.yaml" --env-file "$STACK/.env" down -v >/dev/null 2>&1 || true
+  rm -rf "$STACK"
+}
+trap cleanup EXIT
+
+# A free port, so this coexists with whatever else is already bound. The
+# harness pins nothing now that the storage target is configurable.
+free_port() {
+  python3 - "$1" <<'PY'
+import socket, sys
+start = int(sys.argv[1])
+for port in range(start, start + 200):
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", port)); print(port); break
+    except OSError:
+        continue
+    finally:
+        s.close()
+PY
+}
+
+APP_PORT="$(free_port 3410)"
+PG_PORT="$(free_port 15432)"
+MINIO_PORT="$(free_port 19000)"
+
+log "version=${VERSION}  app=${APP_PORT}  postgres=${PG_PORT}  minio=${MINIO_PORT}"
+
+cp "$ROOT/compose.self-host.yml" "$STACK/compose.yaml"
+cp "$ROOT/Caddyfile.self-host.example" "$STACK/Caddyfile"
+
+# Every value here is a throwaway localhost dummy, same as e2e/app-env.sh.
+cat > "$STACK/.env" <<ENVEOF
+OPEN_ISMS_VERSION=${VERSION}
+COMPOSE_PROFILES=minio
+POSTGRES_USER=e2e
+POSTGRES_PASSWORD=e2e
+POSTGRES_DB=openisms_e2e
+POSTGRES_PORT=${PG_PORT}
+APP_PORT=${APP_PORT}
+MINIO_PORT=${MINIO_PORT}
+AUTH_SECRET=e2e-dummy-auth-secret-0123456789abcdef
+ERASURE_EMAIL_HASH_SALT=e2e-dummy-erasure-salt-0123456789abcdef
+AUTH_URL=http://localhost:${APP_PORT}
+NEXT_PUBLIC_APP_URL=http://localhost:${APP_PORT}
+AWS_S3_BUCKET=e2e-evidence
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_S3_ENDPOINT=http://localhost:${MINIO_PORT}
+AWS_S3_INTERNAL_ENDPOINT=http://minio:9000
+MINIO_KMS_KEY=$(printf 'e2e-minio-kms-0123456789abcdef!!' | base64)
+ENVEOF
+
+log "pulling ${IMAGE}:${VERSION} and starting the stack"
+docker compose -p "$PROJECT" -f "$STACK/compose.yaml" --env-file "$STACK/.env" up -d --pull always
+
+log "waiting for /api/health"
+for _ in $(seq 1 60); do
+  if body=$(curl -fsS --max-time 3 "http://localhost:${APP_PORT}/api/health" 2>/dev/null); then
+    echo "  $body"
+    break
+  fi
+  sleep 3
+done
+if [[ -z "${body:-}" ]]; then
+  echo "::error::the stack never became healthy"
+  docker compose -p "$PROJECT" -f "$STACK/compose.yaml" --env-file "$STACK/.env" logs app | tail -40
+  exit 1
+fi
+
+# Framework data is not in the image yet (issue #102), so the suite would find
+# an empty portal without this. Seed refuses NODE_ENV=production by itself.
+log "seeding framework data"
+DATABASE_URL="postgres://e2e:e2e@localhost:${PG_PORT}/openisms_e2e" \
+AUTH_SECRET="e2e-dummy-auth-secret-0123456789abcdef" \
+NODE_ENV=development \
+  bun run "$ROOT/drizzle/seed.ts" | tail -3
+
+log "running the suite against the container"
+cd "$ROOT"
+E2E_BASE_URL="http://localhost:${APP_PORT}" \
+E2E_DATABASE_URL="postgres://e2e:e2e@localhost:${PG_PORT}/openisms_e2e" \
+E2E_S3_ENDPOINT="http://localhost:${MINIO_PORT}" \
+E2E_S3_BUCKET="e2e-evidence" \
+E2E_S3_ACCESS_KEY_ID="minioadmin" \
+E2E_S3_SECRET_ACCESS_KEY="minioadmin" \
+  bun run e2e -- "${@:3}"


### PR DESCRIPTION
```
bun run e2e:image            # :stable
bun run e2e:image 0.2.3      # a specific version
bun run e2e:image stable --keep
```

## Why

CI builds a bundle and serves it with `next start`, so the behavioural suite has never touched the artifact self-hosters actually pull.

That gap is not theoretical. Running the suite against `0.2.0` by hand is what found the Content-Security-Policy storage origin frozen at build time — browser evidence uploads blocked on every self-hosted instance, silently, leaving evidence rows pointing at objects that were never stored. No local-build run could have surfaced it, because a local build bakes the local environment.

## Result

Against `:stable`, just now:

```
1 skipped
90 passed (3.3m)
```

Including `evidence: upload, list, download link, delete round-trip` — the spec that failed against `0.2.0`, and the reason this script exists.

## What it does

Pulls the image, brings up `compose.self-host.yml` **as published**, seeds the framework data, points the suite at the container, tears down. Ports are chosen free at runtime so it coexists with whatever else is bound — the first manual run collided with 5432 and 9000 and left a half-created postgres behind, which surfaced as a misleading `getaddrinfo ENOTFOUND postgres`.

The database is named `openisms_e2e`, so `assertE2eTargets` is satisfied **honestly** rather than bypassed: the harness writes to it directly and it is genuinely disposable.

## The one code change

`auth.setup.ts` hardcoded `localhost:9000`, `minioadmin` and the `e2e-evidence` bucket, so the suite could only ever run against `e2e/docker-compose.yml`. Those are now four env vars in `e2e/lib/env.ts` **defaulting to exactly the current values**, so the hermetic stack behaves identically and nothing about the existing e2e workflow changes.

## Note

Seeding is still a step here because framework data is not in the image (#102). Once it is, this script loses that step and gets closer to what a real self-hoster does.

Groundwork for #105, which wires the same thing into the release pipeline so it runs before `promote` rather than when someone remembers.