### PR TITLE
migrations: prove the failure path, and make rule 3 possible to follow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
       - name: shipped migrations are unchanged
         run: bun run check:migration-immutability
 
+      # Rule 3 in one command. A constraint added in one step passes CI here by
+      # construction, because this schema is built from scratch and has no rows
+      # to violate it, then fails on a self-hoster's database. Also catches
+      # `-- migrate:no-transaction` on a migration that has no CONCURRENTLY in
+      # it, which is the only thing that marker is for.
+      - name: migrations are safe against existing data
+        run: bun run check:migration-safety
+
       # REFERENCE.md is generated from the framework data and is published as
       # the public reference. It silently went stale after a correction pass,
       # leaving it citing CIR Annex points that do not exist in the OJ text.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,41 @@ jobs:
           AUTH_SECRET: "ci_build_dummy_value_not_a_real_secret_0000"
           RESEND_API_KEY: "re_dummy_for_ci_build"
 
+  # What happens to a customer's database when a migration fails. Every other
+  # migration test asks whether the good path works; this one deliberately
+  # breaks it, because "your data is untouched" is a promise docs/updating.md
+  # makes to people storing audit evidence, and it was untested until now.
+  migration-failure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: drill
+          POSTGRES_PASSWORD: drill
+          POSTGRES_DB: drill
+        options: >-
+          --health-cmd "pg_isready -U drill"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: a failing migration leaves the database untouched
+        run: bash scripts/ci/migration-failure-drill.sh
+        env:
+          DATABASE_URL: postgres://drill:drill@localhost:5432/drill
+
   # The published self-host stack has to stay parseable and internally
   # consistent. `docker compose config` resolves every variable reference and
   # profile, so a typo in a service name or an unbalanced ${...} fails here

--- a/docs/migration-policy.md
+++ b/docs/migration-policy.md
@@ -57,9 +57,22 @@ constraint would reject. A bare `ALTER TABLE ... SET NOT NULL` or a new
 under a plain `docker compose up -d` means a crash-looping container.
 
 Add the column or index nullable and unvalidated, backfill the existing rows
-in the same migration, and validate in a later one. Prefer `CREATE UNIQUE
-INDEX CONCURRENTLY` where the table is large, and reconcile duplicates in code
-before the constraint exists rather than assuming there are none.
+in the same migration, and validate in a later one. Reconcile duplicates in
+code before the constraint exists rather than assuming there are none.
+
+`CREATE UNIQUE INDEX CONCURRENTLY` is the right tool on a large table, and
+Postgres refuses to run it inside a transaction block — which every migration
+otherwise is. Opt that file out with a first line of:
+
+```sql
+-- migrate:no-transaction
+```
+
+Understand what you are giving up. A migration that runs outside a transaction
+and fails partway leaves the schema partly changed, and is not recorded as
+applied, so the next boot retries it from the top. Every statement in such a
+file must therefore be safe to re-run: `IF NOT EXISTS`, or an explicit guard.
+Use it only where the transaction is genuinely the obstacle.
 
 ## 4. A migration may not depend on the app that shipped with it
 

--- a/docs/migration-policy.md
+++ b/docs/migration-policy.md
@@ -72,7 +72,20 @@ Understand what you are giving up. A migration that runs outside a transaction
 and fails partway leaves the schema partly changed, and is not recorded as
 applied, so the next boot retries it from the top. Every statement in such a
 file must therefore be safe to re-run: `IF NOT EXISTS`, or an explicit guard.
-Use it only where the transaction is genuinely the obstacle.
+Use it only where the transaction is genuinely the obstacle. `bun run
+check:migration-safety` enforces that: a migration carrying the marker without
+a `CONCURRENTLY` in it fails CI, because there is no other statement that needs
+it.
+
+The same check flags one-step constraints on tables that already exist. It
+skips tables created in the same migration, which have no rows to violate
+anything, and it only looks at migrations that have not shipped yet, since
+shipped ones are immutable under rule 1. A genuine exception is declared in
+the file so the reasoning is visible in review:
+
+```sql
+-- migration-safety:allow: <why this is safe here>
+```
 
 ## 4. A migration may not depend on the app that shipped with it
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:unit": "bun test lib server schema/",
     "check:migrations": "bun scripts/check-migration-journals.ts",
     "check:migration-immutability": "bun scripts/check-migration-immutability.ts",
+    "check:migration-safety": "bun scripts/check-migration-safety.ts",
     "db:seed:demo": "bun run scripts/seed-demo-company.ts",
     "db:export:demo": "bun run scripts/export-demo-ordner.tsx",
     "db:generate": "drizzle-kit generate",

--- a/scripts/check-migration-safety.ts
+++ b/scripts/check-migration-safety.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env bun
+/**
+ * The two ways a migration bricks somebody else's instance, caught here rather
+ * than on their server. See docs/migration-policy.md rule 3.
+ *
+ * 1. A constraint added in one step. CI builds its schema from scratch, so a
+ *    bare `SET NOT NULL` or a new `UNIQUE` index passes by construction and
+ *    fails on a database with years of real tenant data in it: nulls where you
+ *    did not expect them, duplicates the constraint rejects.
+ *
+ * 2. `-- migrate:no-transaction` used for anything other than the one thing it
+ *    exists for. That marker turns off the all-or-nothing guarantee for a file,
+ *    so a failure halfway leaves the schema partly changed AND unrecorded — the
+ *    next boot retries from the top and hits "already exists". The only reason
+ *    to reach for it is CREATE INDEX CONCURRENTLY, which Postgres refuses to
+ *    run inside a transaction. Any other use is someone silencing an error.
+ *
+ * Both are opt-out-able with an inline comment, because there are real
+ * exceptions — a brand-new table has no existing rows to violate anything. The
+ * point is that the exception becomes visible in review instead of implicit.
+ *
+ *   bun scripts/check-migration-safety.ts
+ */
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHAINS = [
+  "packages/grc-data-model/drizzle",
+  "packages/isms-schema/drizzle",
+  "drizzle",
+] as const;
+
+const ALLOW = "migration-safety:allow";
+const NO_TRANSACTION = /^\s*--\s*migrate:no-transaction\b/m;
+
+type Finding = { readonly file: string; readonly problem: string; readonly remedy: string };
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const git = (args: readonly string[]): string =>
+  execFileSync("git", [...args], { cwd: root, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 });
+
+/**
+ * Migrations that shipped in a release are immutable (rule 1), so they cannot
+ * be annotated and there is nothing to be done about them. Only what has not
+ * shipped yet is actionable.
+ */
+const shippedAlready = (): ReadonlySet<string> => {
+  const tags = git(["tag", "--list", "v*", "--sort=-v:refname"]).trim();
+  if (tags === "") return new Set();
+  const latest = tags.split("\n")[0];
+  const listed = git(["ls-tree", "-r", "--name-only", latest]).trim();
+  return new Set(listed === "" ? [] : listed.split("\n"));
+};
+
+/**
+ * Tables created by this same migration have no existing rows, so an index or
+ * constraint on them cannot fail on anybody's data. Only pre-existing tables
+ * carry that risk.
+ *
+ * This reads SQL with patterns rather than a parser, which is the tool this
+ * repo normally avoids. It is a heuristic guard with a visible opt-out, not a
+ * source of truth: a miss costs a review comment, and a false positive costs
+ * one line. A real parser would be a dependency for a lint rule.
+ */
+const tablesCreatedHere = (sql: string): ReadonlySet<string> => {
+  const names = [...sql.matchAll(/\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([\w.]+)"?/gi)];
+  return new Set(names.map((m) => (m[1] ?? "").toLowerCase()));
+};
+
+const targetOf = (sql: string, pattern: RegExp): string => {
+  const m = sql.match(pattern);
+  return (m?.[1] ?? "").toLowerCase();
+};
+
+/** Comments cannot violate a constraint; only statements can. */
+const stripComments = (sql: string): string =>
+  sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n");
+
+const RISKY = [
+  {
+    pattern: /\bSET\s+NOT\s+NULL\b/i,
+    target: /\bALTER\s+TABLE\s+(?:ONLY\s+)?"?([\w.]+)"?/i,
+    problem: "adds NOT NULL in one step",
+    remedy:
+      "Add the column nullable, backfill in the same migration, and set NOT NULL in a later one. Existing rows are why this passes CI and fails on a real database.",
+  },
+  {
+    pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b(?![\s\S]*\bCONCURRENTLY\b)/i,
+    target: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b[\s\S]*?\bON\s+"?([\w.]+)"?/i,
+    problem: "creates an index without CONCURRENTLY",
+    remedy:
+      "On a large table this holds a write lock for the duration. Use CREATE INDEX CONCURRENTLY with `-- migrate:no-transaction`, or mark this allowed if the table is small or new.",
+  },
+  {
+    pattern: /\bADD\s+CONSTRAINT\b(?![\s\S]*\bNOT\s+VALID\b)/i,
+    target: /\bALTER\s+TABLE\s+(?:ONLY\s+)?"?([\w.]+)"?/i,
+    problem: "adds a constraint without NOT VALID",
+    remedy:
+      "Add it NOT VALID, then VALIDATE CONSTRAINT in a later migration. Validating immediately scans every existing row and fails on the first that does not fit.",
+  },
+] as const;
+
+const checkFile = (path: string): readonly Finding[] => {
+  const raw = readFileSync(path, "utf-8");
+  const sql = stripComments(raw);
+  if (raw.includes(ALLOW)) return [];
+
+  const findings: Finding[] = [];
+
+  // The escape hatch is only ever justified by CONCURRENTLY.
+  if (NO_TRANSACTION.test(raw) && !/\bCONCURRENTLY\b/i.test(sql)) {
+    findings.push({
+      file: path,
+      problem: "uses -- migrate:no-transaction without CONCURRENTLY",
+      remedy:
+        "That marker turns off the all-or-nothing guarantee: a failure halfway leaves the schema partly changed and unrecorded, so the next boot retries and hits 'already exists'. CREATE INDEX CONCURRENTLY is the only statement that needs it.",
+    });
+  }
+
+  const fresh = tablesCreatedHere(sql);
+  for (const { pattern, target, problem, remedy } of RISKY) {
+    if (!pattern.test(sql)) continue;
+    if (fresh.has(targetOf(sql, target))) continue;
+    findings.push({ file: path, problem, remedy });
+  }
+
+  return findings;
+};
+
+const shipped = shippedAlready();
+
+const findings = CHAINS.flatMap((chain) => {
+  const dir = resolve(root, chain);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".sql"))
+    .filter((name) => !shipped.has(`${chain}/${name}`))
+    .flatMap((name) => checkFile(resolve(dir, name)));
+});
+
+if (findings.length > 0) {
+  console.error(
+    `[migration-safety] ${findings.length} finding(s). These pass CI against an empty schema and fail on a database with real data:\n`,
+  );
+  for (const { file, problem, remedy } of findings) {
+    console.error(`  ${file.replace(root, "")}`);
+    console.error(`    ${problem}`);
+    console.error(`    ${remedy}\n`);
+  }
+  console.error(
+    `See docs/migration-policy.md rule 3. If an exception is genuinely correct, add a\n  -- ${ALLOW}: <why>\ncomment to the migration so the reasoning is visible in review.`,
+  );
+} else {
+  console.log("[migration-safety] no one-step constraints, no unjustified no-transaction markers");
+}
+
+process.exit(findings.length > 0 ? 1 : 0);

--- a/scripts/ci/migration-failure-drill.sh
+++ b/scripts/ci/migration-failure-drill.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Proves what happens to a customer's data when a migration fails.
+#
+# Every other migration test asks "does the good path work". This asks the
+# question a self-hoster actually cares about: their instance holds audit
+# evidence and sign-offs, an update goes wrong, and they need to know the
+# database is not left half-changed.
+#
+# The claim in docs/updating.md is that a failing migration rolls back and the
+# container refuses to serve rather than running against a half-applied schema.
+# That was an untested claim in a document until this script existed.
+#
+#   DATABASE_URL=postgres://... scripts/ci/migration-failure-drill.sh
+#
+# The failing migration creates a table and THEN divides by zero, so a pass
+# means the rollback undid work that had already succeeded inside the
+# transaction — not merely that the failing statement failed.
+
+set -euo pipefail
+
+DB="${DATABASE_URL:?DATABASE_URL is required}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+psql() { docker run --rm --network host -e PGPASSWORD -i postgres:17-alpine psql "$DB" "$@"; }
+fingerprint() {
+  psql -tAc "
+    SELECT string_agg(table_name || ':' || column_name || ':' || data_type, ',' ORDER BY table_name, column_name)
+    FROM information_schema.columns WHERE table_schema = 'public';"
+}
+bookkeeping() {
+  psql -tAc "
+    SELECT coalesce(string_agg(t || ':' || n, ',' ORDER BY t), 'none') FROM (
+      SELECT 'grc' t, count(*)::text n FROM drizzle.__drizzle_migrations_grc
+      UNION ALL SELECT 'isms', count(*)::text FROM drizzle.__drizzle_migrations_isms
+      UNION ALL SELECT 'saas', count(*)::text FROM drizzle.__drizzle_migrations_saas
+    ) x;"
+}
+
+echo "[drill] bringing the database to the current schema"
+( cd "$ROOT" && DATABASE_URL="$DB" node scripts/runtime-migrate.mjs ) | tail -2
+
+echo "[drill] writing a row that stands in for customer data"
+psql -q -c "CREATE TABLE IF NOT EXISTS drill_customer_data (id int primary key, note text);
+            INSERT INTO drill_customer_data VALUES (1, 'sign-off evidence')
+            ON CONFLICT (id) DO NOTHING;"
+
+SCHEMA_BEFORE="$(fingerprint)"
+BOOKS_BEFORE="$(bookkeeping)"
+echo "[drill] snapshot taken"
+
+# A copy of the real chains with one deliberately poisoned migration appended.
+# The real drizzle/ is never touched.
+cp -R "$ROOT/drizzle" "$WORK/drizzle"
+mkdir -p "$WORK/packages/grc-data-model" "$WORK/packages/isms-schema"
+cp -R "$ROOT/packages/grc-data-model/drizzle" "$WORK/packages/grc-data-model/drizzle"
+cp -R "$ROOT/packages/isms-schema/drizzle" "$WORK/packages/isms-schema/drizzle"
+
+cat > "$WORK/drizzle/9999_drill_poison.sql" <<'SQL'
+CREATE TABLE drill_should_not_survive (id int);
+--> statement-breakpoint
+SELECT 1/0;
+SQL
+
+python3 - "$WORK/drizzle/meta/_journal.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+j = json.load(open(path))
+last = max(e["when"] for e in j["entries"])
+j["entries"].append({
+    "idx": len(j["entries"]), "version": j["entries"][-1]["version"],
+    "when": last + 1, "tag": "9999_drill_poison", "breakpoints": True,
+})
+json.dump(j, open(path, "w"))
+PY
+
+echo "[drill] applying a migration that fails partway through"
+set +e
+# The repo's own migrator, so `pg` resolves from the repo's node_modules,
+# but with cwd on the poisoned tree, since the chain paths are relative.
+( cd "$WORK" && DATABASE_URL="$DB" node "$ROOT/scripts/runtime-migrate.mjs" ) > "$WORK/out.log" 2>&1
+EXIT=$?
+set -e
+tail -3 "$WORK/out.log" | sed 's/^/    /'
+
+fail=0
+check() { if [ "$2" = "$3" ]; then echo "  PASS  $1"; else echo "  FAIL  $1"; echo "        expected: $3"; echo "        actual:   $2"; fail=1; fi; }
+
+echo "[drill] verdict"
+[ "$EXIT" -ne 0 ] && echo "  PASS  the migrator exited non-zero (${EXIT}), so the container would refuse to serve" \
+                 || { echo "  FAIL  the migrator exited 0 despite a failing migration"; fail=1; }
+check "the schema is byte-identical to before the failure" "$(fingerprint)" "$SCHEMA_BEFORE"
+check "no migration was recorded as applied" "$(bookkeeping)" "$BOOKS_BEFORE"
+check "the table created before the failing statement was rolled back" \
+      "$(psql -tAc "SELECT to_regclass('public.drill_should_not_survive') IS NULL;" | tr -d '[:space:]')" "t"
+check "the customer row survived untouched" \
+      "$(psql -tAc "SELECT note FROM drill_customer_data WHERE id = 1;" | tr -d '[:space:]')" "sign-offevidence"
+
+echo "[drill] and the database is still usable afterwards"
+( cd "$ROOT" && DATABASE_URL="$DB" node scripts/runtime-migrate.mjs ) 2>&1 | grep -q "all chains complete" \
+  && echo "  PASS  a clean migrator run still succeeds against it" \
+  || { echo "  FAIL  the database was left wedged"; fail=1; }
+
+exit "$fail"

--- a/scripts/runtime-migrate.mjs
+++ b/scripts/runtime-migrate.mjs
@@ -24,6 +24,15 @@
  *        wrap the SQL in a transaction, apply statements, INSERT
  *        (hash, when) — hash matches drizzle's createHash("sha256").update(query).digest("hex")
  *
+ * The transaction is the guarantee a self-hoster depends on: a migration that
+ * fails leaves the database exactly as it was, because the bookkeeping INSERT
+ * commits with the DDL or not at all. scripts/ci/migration-failure-drill.sh
+ * proves it rather than asserting it.
+ *
+ * A migration whose first line is `-- migrate:no-transaction` runs outside one,
+ * for statements Postgres refuses inside a transaction block. See
+ * docs/migration-policy.md rule 3.
+ *
  * The three chains run independently against their own per-package
  * bookkeeping tables — see docs/migrations.md.
  */
@@ -186,24 +195,58 @@ try {
         continue;
       }
 
-      console.log(`[migrate ${label}] applying ${entry.tag}`);
+      // Opt-out for statements Postgres refuses to run inside a transaction.
+      // CREATE INDEX CONCURRENTLY is the one that matters: migration-policy.md
+      // rule 3 recommends it on large tables, and without this a migration
+      // following that advice fails at container start on every instance with
+      // "cannot run inside a transaction block".
+      //
+      // The trade is explicit and belongs to whoever writes the migration: a
+      // non-transactional migration that fails partway leaves the schema
+      // partly changed and is NOT recorded as applied, so the next boot
+      // retries it from the top. Every statement in such a file must therefore
+      // be independently re-runnable — IF NOT EXISTS, or a guard.
+      const nonTransactional = /^\s*--\s*migrate:no-transaction\b/m.test(sql);
 
-      await client.query("BEGIN");
-      try {
-        for (const stmt of sql.split("--> statement-breakpoint")) {
-          const s = stmt.trim();
-          if (s) await client.query(s);
+      console.log(
+        `[migrate ${label}] applying ${entry.tag}${nonTransactional ? " (no transaction)" : ""}`,
+      );
+
+      const statements = sql
+        .split("--> statement-breakpoint")
+        .map((stmt) => stmt.trim())
+        .filter((stmt) => stmt !== "");
+
+      if (nonTransactional) {
+        try {
+          for (const stmt of statements) await client.query(stmt);
+          await client.query(
+            `INSERT INTO drizzle.${table} ("hash", "created_at") VALUES ($1, $2)`,
+            [hash, entry.when],
+          );
+          appliedCount++;
+        } catch (err) {
+          console.error(
+            `[migrate ${label}] FAILED on ${entry.tag} (no transaction — the schema may be partly changed, and this migration is not recorded as applied):`,
+            err.message,
+          );
+          throw err;
         }
-        await client.query(
-          `INSERT INTO drizzle.${table} ("hash", "created_at") VALUES ($1, $2)`,
-          [hash, entry.when],
-        );
-        await client.query("COMMIT");
-        appliedCount++;
-      } catch (err) {
-        await client.query("ROLLBACK");
-        console.error(`[migrate ${label}] FAILED on ${entry.tag}:`, err.message);
-        throw err;
+      } else {
+        await client.query("BEGIN");
+        try {
+          for (const stmt of statements) await client.query(stmt);
+          await client.query(
+            `INSERT INTO drizzle.${table} ("hash", "created_at") VALUES ($1, $2)`,
+            [hash, entry.when],
+          );
+          await client.query("COMMIT");
+          appliedCount++;
+        } catch (err) {
+          await client.query("ROLLBACK");
+          console.error(`[migrate ${label}] FAILED on ${entry.tag}:`, err.message);
+          throw err;
+        }
       }
     }
 


### PR DESCRIPTION
Two problems, both about what happens on somebody else's database.

## 1. Following the written policy produced a migration that always fails

`migration-policy.md` rule 3 tells you to use `CREATE UNIQUE INDEX CONCURRENTLY` on large tables. `runtime-migrate.mjs` wraps every migration in `BEGIN`/`COMMIT`. Postgres refuses that combination:

```
BEGIN
ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
ROLLBACK
```

A developer following your own policy, doing the careful thing on a big table, shipped a migration that fails at container start on **every** instance. Safely — rollback, exit, data intact — but the update is dead on arrival.

A first line of `-- migrate:no-transaction` now runs that file outside a transaction. The trade is explicit and documented in rule 3: such a migration is not atomic, is **not** recorded as applied if it fails partway, and every statement in it must therefore be safe to re-run (`IF NOT EXISTS`, or a guard).

Verified: with the marker, `CREATE UNIQUE INDEX CONCURRENTLY` applies and logs `(no transaction)`; the index exists afterwards.

## 2. The promise that matters most was never tested

`docs/updating.md` tells self-hosters that a failing migration rolls back and leaves their data untouched. That is *the* promise for someone storing audit evidence and sign-offs. It was a sentence in a document.

`scripts/ci/migration-failure-drill.sh` applies a migration that **creates a table and then divides by zero**, so passing means the rollback undid work that had already succeeded inside the transaction — not merely that a bad statement failed.

```
PASS  the migrator exited non-zero (1), so the container would refuse to serve
PASS  the schema is byte-identical to before the failure
PASS  no migration was recorded as applied
PASS  the table created before the failing statement was rolled back
PASS  the customer row survived untouched
PASS  a clean migrator run still succeeds against it
```

Runs in `ci.yml` against a real Postgres service, about 30 seconds.

## The guarantee itself needed no change

The migrator was already right, and worth saying so: the bookkeeping `INSERT` commits inside the **same transaction** as the DDL, so it can never record a migration that did not apply, and an advisory lock stops two containers racing. What was missing was proof, not mechanism.

## What this does and does not buy

It does not guarantee no migration ever fails against customer data — over years, one will. It guarantees that when one does, **nothing is lost**, the container refuses to serve rather than running on a half-changed schema, and the instance recovers by pinning the previous version, which is already tested both ways.

That is a claim you can now make to a customer and point at a test for.