### PR TITLE
release: give the upgrade gate data to trip over

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
       # First, and before any login: every other step here authenticates, so
       # this is the only one that exercises the path a self-hoster's docker
       # actually takes. A GHCR package is private when first created.
@@ -260,6 +266,31 @@ jobs:
           docker run --rm --network host -e DATABASE_URL="${DB}" \
             "${IMAGE}:${{ steps.previous.outputs.tag }}" \
             node /app/scripts/runtime-migrate.mjs
+
+      # Until now this gate migrated an empty schema, which is the one thing
+      # migration-policy.md rule 3 says it cannot afford to do: a bare
+      # `SET NOT NULL` or a new UNIQUE index passes against nothing and fails on
+      # a database with real rows in it. These two steps put rows in the way.
+      #
+      # The seed is used rather than hand-written INSERTs because it produces a
+      # populated instance across ~50 tables and is maintained anyway, so it
+      # cannot rot the way a fixed list of columns would.
+      - name: Fill the previous release's schema with realistic data
+        if: steps.previous.outputs.tag != ''
+        run: |
+          DATABASE_URL="${DB}" \
+          AUTH_SECRET="gate_only_not_real_0123456789abcdef" \
+          NODE_ENV=development \
+            bun run drizzle/seed.ts | tail -3
+
+      # Then make that data awkward: one null in every nullable column that has
+      # a value. Schema-derived, so it covers tables added since this was
+      # written without anybody updating it.
+      - name: Introduce the shapes a new constraint would reject
+        if: steps.previous.outputs.tag != ''
+        run: |
+          docker run --rm --network host -i postgres:17-alpine \
+            psql "${DB}" -v ON_ERROR_STOP=1 -f - < scripts/ci/dirty-data.sql
 
       - name: Apply this release's migrations
         run: |

--- a/scripts/ci/dirty-data.sql
+++ b/scripts/ci/dirty-data.sql
@@ -1,0 +1,31 @@
+-- For every nullable column that currently has a value, blank it out in one
+-- row. That manufactures the exact condition rule 3 warns about: a database
+-- where a later `SET NOT NULL` finds rows it cannot accept.
+--
+-- Schema-derived on purpose. A hand-written list of columns would rot the
+-- first time a table changed; this adapts to whatever the previous release's
+-- schema actually is, including tables that did not exist when it was written.
+DO $$
+DECLARE r record; n int; nulled int := 0; skipped int := 0;
+BEGIN
+  FOR r IN
+    SELECT c.table_name, c.column_name
+    FROM information_schema.columns c
+    JOIN pg_class p ON p.relname = c.table_name
+    JOIN pg_namespace ns ON ns.oid = p.relnamespace AND ns.nspname = 'public'
+    WHERE c.table_schema = 'public' AND c.is_nullable = 'YES' AND p.relkind = 'r'
+  LOOP
+    BEGIN
+      EXECUTE format(
+        'UPDATE %I SET %I = NULL WHERE ctid = (SELECT ctid FROM %I WHERE %I IS NOT NULL LIMIT 1)',
+        r.table_name, r.column_name, r.table_name, r.column_name);
+      GET DIAGNOSTICS n = ROW_COUNT;
+      nulled := nulled + n;
+    EXCEPTION WHEN others THEN
+      -- A CHECK or a partial index may forbid the null. That column simply
+      -- cannot hold one, so there is nothing for a later migration to trip on.
+      skipped := skipped + 1;
+    END;
+  END LOOP;
+  RAISE NOTICE 'dirty-data: nulled % value(s), skipped % column(s)', nulled, skipped;
+END $$;


### PR DESCRIPTION
The last of the four gaps from the update-safety review.

## The problem, in `migration-policy.md`'s own words

> The upgrade gate in CI runs migrations against a schema it built from scratch, so it can only ever see clean data. A self-hoster's database has years of real tenant data in it: nulls where you did not expect them, duplicates a constraint would reject. A bare `ALTER TABLE ... SET NOT NULL` or a new `UNIQUE` index **passes CI by construction** and fails on their machine, which under a plain `docker compose up -d` means a crash-looping container.

Rule 3 mitigated it by asking people to be careful. #113 made it mechanically checkable. This makes the gate actually able to see it.

## Demonstrated, not asserted

Same migration, same gate, real schema. Against seeded-but-clean data:

```
ALTER TABLE asset ALTER COLUMN description SET NOT NULL;
ALTER TABLE                      <- passes, ships, breaks the self-hoster
```

Against the same data after this change:

```
ERROR:  column "description" of relation "asset" contains null values
```

## How

Two steps between "apply the previous release's migrations" and "apply this release's migrations":

**Fill it.** The seed, not hand-written `INSERT`s — it populates around fifty tables, is maintained regardless, and cannot rot the way a fixed column list would.

**Make it awkward.** One null in every nullable column that currently holds a value, derived from `information_schema`. Schema-derived on purpose: tables added later are covered without anyone remembering to update a list. Columns that genuinely cannot hold a null (a `CHECK`, a partial index) are skipped and counted.

## Rehearsed end to end

Against the published `0.2.7` image locally:

```
previous release's migrations   applied
seed                            165 requirements, 8 assets, 1 company
dirty-data                      nulled 97 value(s), skipped 1 column
this release's migrations       applied
second run                      up to date — 0 new migrations
data afterwards                 intact, nulls still present
```

Skipped on a first release, which has no previous version and so nothing to fill.

## What it still does not cover

Duplicates. A new `UNIQUE` index over data that already has repeats is the other half of rule 3, and manufacturing a duplicate generically is harder than manufacturing a null — it has to respect existing constraints. Worth doing if it ever bites; the null case is the common one.