### PR TITLE
ci: run shellcheck, and fix what it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,16 @@ jobs:
       - name: migrations are safe against existing data
         run: bun run check:migration-safety
 
+      # Shell is where this repo does its riskiest work — the release gates,
+      # the failure drill, the self-host install path — and it is the one
+      # language here with no compiler. A `[ x ] && y || z` in a script whose
+      # job is reporting pass/fail is the kind of thing that reads correct and
+      # is not.
+      - name: shell scripts pass shellcheck
+        run: |
+          docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:v0.10.0 \
+            scripts/ci/*.sh scripts/*.sh e2e/*.sh
+
       # REFERENCE.md is generated from the framework data and is published as
       # the public reference. It silently went stale after a correction pass,
       # leaving it citing CIR Annex points that do not exist in the OJ text.

--- a/e2e/app-env.sh
+++ b/e2e/app-env.sh
@@ -25,6 +25,8 @@ esac
 E2E_MINIO_KMS_B64="$(printf 'e2e-minio-kms-0123456789abcdef!!' | base64)"
 export E2E_MINIO_KMS_B64
 
+# Consumed by e2e/start-server.sh and e2e/serve.sh, which source this file.
+# shellcheck disable=SC2034
 APP_ENV=(
   DATABASE_URL="$E2E_DATABASE_URL"
   AUTH_SECRET="e2e-dummy-auth-secret-0123456789abcdef"

--- a/scripts/ci/migration-failure-drill.sh
+++ b/scripts/ci/migration-failure-drill.sh
@@ -88,8 +88,12 @@ fail=0
 check() { if [ "$2" = "$3" ]; then echo "  PASS  $1"; else echo "  FAIL  $1"; echo "        expected: $3"; echo "        actual:   $2"; fail=1; fi; }
 
 echo "[drill] verdict"
-[ "$EXIT" -ne 0 ] && echo "  PASS  the migrator exited non-zero (${EXIT}), so the container would refuse to serve" \
-                 || { echo "  FAIL  the migrator exited 0 despite a failing migration"; fail=1; }
+if [ "$EXIT" -ne 0 ]; then
+  echo "  PASS  the migrator exited non-zero (${EXIT}), so the container would refuse to serve"
+else
+  echo "  FAIL  the migrator exited 0 despite a failing migration"
+  fail=1
+fi
 check "the schema is byte-identical to before the failure" "$(fingerprint)" "$SCHEMA_BEFORE"
 check "no migration was recorded as applied" "$(bookkeeping)" "$BOOKS_BEFORE"
 check "the table created before the failing statement was rolled back" \
@@ -98,8 +102,11 @@ check "the customer row survived untouched" \
       "$(psql -tAc "SELECT note FROM drill_customer_data WHERE id = 1;" | tr -d '[:space:]')" "sign-offevidence"
 
 echo "[drill] and the database is still usable afterwards"
-( cd "$ROOT" && DATABASE_URL="$DB" node scripts/runtime-migrate.mjs ) 2>&1 | grep -q "all chains complete" \
-  && echo "  PASS  a clean migrator run still succeeds against it" \
-  || { echo "  FAIL  the database was left wedged"; fail=1; }
+if ( cd "$ROOT" && DATABASE_URL="$DB" node scripts/runtime-migrate.mjs ) 2>&1 | grep -q "all chains complete"; then
+  echo "  PASS  a clean migrator run still succeeds against it"
+else
+  echo "  FAIL  the database was left wedged"
+  fail=1
+fi
 
 exit "$fail"

--- a/scripts/screenshot-pitch.sh
+++ b/scripts/screenshot-pitch.sh
@@ -29,7 +29,7 @@ for locale in "${LOCALES[@]}"; do
   if [[ -n "$SINGLE_SLIDE" ]]; then
     slides=("$SINGLE_SLIDE")
   else
-    slides=($(seq 0 $((TOTAL - 1))))
+    mapfile -t slides < <(seq 0 $((TOTAL - 1)))
   fi
 
   for i in "${slides[@]}"; do


### PR DESCRIPTION
Prompted by reviewing today's work for open-source quality. The TypeScript held up — no `as any`, no non-null assertions, no `let`, and `typecheck` clean. The shell did not.

## The find

`scripts/ci/migration-failure-drill.sh` reports whether a customer's data survives a failed migration. Two of its assertions were written as:

```bash
[ "$EXIT" -ne 0 ] && echo "  PASS ..." || { echo "  FAIL ..."; fail=1; }
```

That is **not** if-then-else. If the `PASS` branch ever fails, the `FAIL` branch runs as well (SC2015). Harmless with `echo`, but wrong in a script whose entire output is a verdict — and it reads correct, which is the problem. Both are now `if`/`else`.

## Two pre-existing warnings, fixed so the linter can be adopted

`scripts/screenshot-pitch.sh` split unquoted command output into an array (SC2207). `mapfile -t` does the same job without the word-splitting.

`e2e/app-env.sh` trips SC2034 because `APP_ENV` is consumed by the scripts that *source* it, which shellcheck cannot see. Documented with a targeted directive and a reason, rather than silencing the rule globally.

## The step

Covers `scripts/ci/*.sh`, `scripts/*.sh` and `e2e/*.sh`, pinned to `v0.10.0` — an unpinned linter changes its mind between runs, which is the same reason gitleaks got pinned in #110.

Shell is where this repo does its riskiest work: the release gates, the failure drill, the self-host install path. It was the only language here with nothing checking it.

Verified clean across every shell script in the repo at that pinned version.