### PR TITLE
feat(pricing): self-hosting is free, the licence is gone

### DIFF
--- a/components/pricing/PricingCards.tsx
+++ b/components/pricing/PricingCards.tsx
@@ -2,12 +2,13 @@
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
+import { Link } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Check } from "lucide-react";
 
 const freeKeys = ["f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10"] as const;
-const selfHostKeys = ["h1", "h2", "h3", "h4"] as const;
+const selfHostKeys = ["h1", "h2", "h3", "h4", "h5", "h6"] as const;
 
 export function PricingCards() {
   const t = useTranslations("pricing");
@@ -51,9 +52,7 @@ export function PricingCards() {
           </CardHeader>
           <CardContent className="space-y-4">
             <Button variant="outline" className="w-full" size="lg" asChild>
-              <a href="mailto:contact@nisd2.eu?subject=Self-Host%20License">
-                {t("selfHost.cta")}
-              </a>
+              <Link href="/open-source">{t("selfHost.cta")}</Link>
             </Button>
             <ul className="space-y-2 text-sm">
               {selfHostKeys.map((key) => (
@@ -66,6 +65,10 @@ export function PricingCards() {
           </CardContent>
         </Card>
       </div>
+
+      <p className="mx-auto max-w-2xl text-center text-sm text-muted-foreground">
+        {t("whyFree")}
+      </p>
 
       <p className="text-center text-sm text-muted-foreground">
         {t("consultantFootnote")}{" "}

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,6 +1,22 @@
 {
   "entries": [
     {
+      "id": "2026-08-29-product-self-host-free",
+      "date": "2026-08-29",
+      "category": "product",
+      "titleDe": "Selbstbetrieb ist jetzt kostenlos, die Lizenz entfaellt",
+      "titleEn": "Self-hosting is now free, the licence is gone",
+      "bodyDe": "Die Preisseite kannte zwei Wege: kostenlos gehostet auf nisd2.eu, oder Selbstbetrieb gegen eine einmalige Lizenz nach dem Prinzip 'Zahlen Sie, was Sie koennen'. Diese Lizenz gibt es nicht mehr. Der Quellcode steht weiterhin unter AGPL-3.0, alle kuenftigen Updates sind eingeschlossen, und es gibt weder Vertrag noch Freischaltung. Wer auf nisd2.eu angefangen hat, exportiert seinen Stand und betreibt ihn selbst weiter. Nebenbei korrigiert: die Seite nannte in allen zehn Sprachen die falsche Domain nis2.eu statt nisd2.eu.",
+      "bodyEn": "The pricing page offered two routes: hosted free at nisd2.eu, or self-hosting against a one-time 'pay what you can' licence. That licence is gone. The source stays under AGPL-3.0, all future updates are included, and there is no contract and no activation key. Anyone who started on nisd2.eu can export their work and carry on running it themselves. Fixed along the way: the page named the wrong domain, nis2.eu instead of nisd2.eu, in all ten languages.",
+      "links": [
+        {
+          "labelDe": "Preise",
+          "labelEn": "Pricing",
+          "href": "/pricing"
+        }
+      ]
+    },
+    {
       "id": "2026-08-25-product-nis2-focus",
       "date": "2026-08-25",
       "category": "product",

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -4,10 +4,10 @@
       "id": "2026-08-29-product-self-host-free",
       "date": "2026-08-29",
       "category": "product",
-      "titleDe": "Selbstbetrieb ist jetzt kostenlos, die Lizenz entfaellt",
-      "titleEn": "Self-hosting is now free, the licence is gone",
-      "bodyDe": "Die Preisseite kannte zwei Wege: kostenlos gehostet auf nisd2.eu, oder Selbstbetrieb gegen eine einmalige Lizenz nach dem Prinzip 'Zahlen Sie, was Sie koennen'. Diese Lizenz gibt es nicht mehr. Der Quellcode steht weiterhin unter AGPL-3.0, alle kuenftigen Updates sind eingeschlossen, und es gibt weder Vertrag noch Freischaltung. Wer auf nisd2.eu angefangen hat, exportiert seinen Stand und betreibt ihn selbst weiter. Nebenbei korrigiert: die Seite nannte in allen zehn Sprachen die falsche Domain nis2.eu statt nisd2.eu.",
-      "bodyEn": "The pricing page offered two routes: hosted free at nisd2.eu, or self-hosting against a one-time 'pay what you can' licence. That licence is gone. The source stays under AGPL-3.0, all future updates are included, and there is no contract and no activation key. Anyone who started on nisd2.eu can export their work and carry on running it themselves. Fixed along the way: the page named the wrong domain, nis2.eu instead of nisd2.eu, in all ten languages.",
+      "titleDe": "Selbstbetrieb kostet jetzt nichts",
+      "titleEn": "Self-hosting now costs nothing",
+      "bodyDe": "Die Preisseite kannte zwei Wege: kostenlos gehostet auf nisd2.eu, oder Selbstbetrieb gegen einen einmaligen Betrag nach dem Prinzip 'Zahlen Sie, was Sie koennen'. Der Betrag entfaellt ersatzlos. Beide Wege stehen jetzt auf 0 Euro, dauerhaft, mit allen kuenftigen Updates. Es gibt keinen Vertrag und keine Freischaltung. Wer auf nisd2.eu angefangen hat, exportiert seinen Stand und betreibt ihn selbst weiter. Nebenbei korrigiert: die Seite nannte in allen zehn Sprachen die falsche Domain nis2.eu statt nisd2.eu.",
+      "bodyEn": "The pricing page offered two routes: hosted free at nisd2.eu, or self-hosting against a one-time 'pay what you can' amount. That amount is gone for good. Both routes now read 0 euro, permanently, with all future updates. There is no contract and no activation key. Anyone who started on nisd2.eu can export their work and carry on running it themselves. Fixed along the way: the page named the wrong domain, nis2.eu instead of nisd2.eu, in all ten languages.",
       "links": [
         {
           "labelDe": "Preise",

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -726,7 +726,7 @@ export function buildSoftwareApplicationJsonLd(input: {
     ...(input.featureList && input.featureList.length > 0
       ? { featureList: input.featureList }
       : {}),
-    license: "https://opensource.org/licenses/Apache-2.0",
+    license: "https://www.gnu.org/licenses/agpl-3.0.html",
   };
 }
 

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Za co účtujeme",
-        "p1": "Školicí kurzy pro vedení a personál. Vedené poradenství pro rozhodnutí specifická pro danou společnost: kompromisy při ošetření rizik, vyjednávání s dodavateli, složitá reakce na incidenty. Prémiové funkce, jak se budou vyvíjet. Za vlastní provoz si neúčtujeme nic: kód je pod licencí AGPL-3.0, bez licenčního poplatku.",
+        "p1": "Školicí kurzy pro vedení a personál. Vedené poradenství pro rozhodnutí specifická pro danou společnost: kompromisy při ošetření rizik, vyjednávání s dodavateli, složitá reakce na incidenty. Prémiové funkce, jak se budou vyvíjet. Za vlastní provoz si neúčtujeme nic, kód je otevřený pod AGPL-3.0.",
         "p2": "Jádro platformy pro shodu zůstává zdarma. Otevřená datová sada zůstává otevřená. Princip je ten, že účet má být snížen, nikoli přesunut na nás."
       },
       "team": {

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Za co účtujeme",
-        "p1": "Školicí kurzy pro vedení a personál. Vedené poradenství pro rozhodnutí specifická pro danou společnost: kompromisy při ošetření rizik, vyjednávání s dodavateli, složitá reakce na incidenty. Prémiové funkce, jak se budou vyvíjet. Licence pro vlastní hosting pro subjekty, které potřebují provozovat platformu interně.",
+        "p1": "Školicí kurzy pro vedení a personál. Vedené poradenství pro rozhodnutí specifická pro danou společnost: kompromisy při ošetření rizik, vyjednávání s dodavateli, složitá reakce na incidenty. Prémiové funkce, jak se budou vyvíjet. Za vlastní provoz si neúčtujeme nic: kód je pod licencí AGPL-3.0, bez licenčního poplatku.",
         "p2": "Jádro platformy pro shodu zůstává zdarma. Otevřená datová sada zůstává otevřená. Princip je ten, že účet má být snížen, nikoli přesunut na nás."
       },
       "team": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Wofür wir Geld nehmen",
-        "p1": "Schulungskurse für Geschäftsführung und Personal. Geführte Beratung für unternehmensspezifische Entscheidungen: Risikobehandlungs-Abwägungen, Lieferantenverhandlungen, komplexe Vorfallreaktion. Premium-Funktionen nach Entwicklung. Für den Selbstbetrieb nehmen wir nichts: der Code steht unter AGPL-3.0, ohne Lizenzgebühr.",
+        "p1": "Schulungskurse für Geschäftsführung und Personal. Geführte Beratung für unternehmensspezifische Entscheidungen: Risikobehandlungs-Abwägungen, Lieferantenverhandlungen, komplexe Vorfallreaktion. Premium-Funktionen nach Entwicklung. Für den Selbstbetrieb nehmen wir nichts, der Code ist offen unter AGPL-3.0.",
         "p2": "Die Kern-Compliance-Plattform bleibt kostenlos. Der offene Datensatz bleibt offen. Das Prinzip ist, dass die Rechnung gekürzt werden soll: nicht zu uns verschoben."
       },
       "team": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Wofür wir Geld nehmen",
-        "p1": "Schulungskurse für Geschäftsführung und Personal. Geführte Beratung für unternehmensspezifische Entscheidungen: Risikobehandlungs-Abwägungen, Lieferantenverhandlungen, komplexe Vorfallreaktion. Premium-Funktionen nach Entwicklung. Self-Host-Lizenzierung für Einrichtungen, die die Plattform intern betreiben müssen.",
+        "p1": "Schulungskurse für Geschäftsführung und Personal. Geführte Beratung für unternehmensspezifische Entscheidungen: Risikobehandlungs-Abwägungen, Lieferantenverhandlungen, komplexe Vorfallreaktion. Premium-Funktionen nach Entwicklung. Für den Selbstbetrieb nehmen wir nichts: der Code steht unter AGPL-3.0, ohne Lizenzgebühr.",
         "p2": "Die Kern-Compliance-Plattform bleibt kostenlos. Der offene Datensatz bleibt offen. Das Prinzip ist, dass die Rechnung gekürzt werden soll: nicht zu uns verschoben."
       },
       "team": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Where we charge",
-        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. Self-host licensing for entities that need to run the platform internally.",
+        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting: the code is AGPL-3.0, with no licence fee.",
         "p2": "The core compliance platform stays free. The open dataset stays open. The principle is that the bill should be cut, not shifted to us."
       },
       "team": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Where we charge",
-        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting: the code is AGPL-3.0, with no licence fee.",
+        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting, the code is open under AGPL-3.0.",
         "p2": "The core compliance platform stays free. The open dataset stays open. The principle is that the bill should be cut, not shifted to us."
       },
       "team": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Dónde cobramos",
-        "p1": "Cursos de formación para la dirección y el personal. Consultoría guiada para decisiones específicas de cada empresa: compromisos en el tratamiento de riesgos, negociaciones con proveedores, respuesta a incidentes complejos. Funciones premium a medida que se desarrollen. Por el autoalojamiento no cobramos nada: el código está bajo AGPL-3.0, sin cuota de licencia.",
+        "p1": "Cursos de formación para la dirección y el personal. Consultoría guiada para decisiones específicas de cada empresa: compromisos en el tratamiento de riesgos, negociaciones con proveedores, respuesta a incidentes complejos. Funciones premium a medida que se desarrollen. Por el autoalojamiento no cobramos nada, el código es abierto bajo AGPL-3.0.",
         "p2": "La plataforma básica de cumplimiento sigue siendo gratuita. El conjunto de datos abierto sigue siendo abierto. El principio es que la factura debe recortarse, no trasladarse a nosotros."
       },
       "team": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Dónde cobramos",
-        "p1": "Cursos de formación para la dirección y el personal. Consultoría guiada para decisiones específicas de cada empresa: compromisos en el tratamiento de riesgos, negociaciones con proveedores, respuesta a incidentes complejos. Funciones premium a medida que se desarrollen. Licencias de autoalojamiento para entidades que necesiten ejecutar la plataforma internamente.",
+        "p1": "Cursos de formación para la dirección y el personal. Consultoría guiada para decisiones específicas de cada empresa: compromisos en el tratamiento de riesgos, negociaciones con proveedores, respuesta a incidentes complejos. Funciones premium a medida que se desarrollen. Por el autoalojamiento no cobramos nada: el código está bajo AGPL-3.0, sin cuota de licencia.",
         "p2": "La plataforma básica de cumplimiento sigue siendo gratuita. El conjunto de datos abierto sigue siendo abierto. El principio es que la factura debe recortarse, no trasladarse a nosotros."
       },
       "team": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Là où nous facturons",
-        "p1": "Des formations pour la direction et le personnel. Du conseil guidé pour les décisions propres à l'entreprise : arbitrages de traitement des risques, négociations avec les fournisseurs, réponse à incident complexe. Des fonctionnalités premium au fur et à mesure de leur développement. Des licences d'auto-hébergement pour les entités qui ont besoin d'exploiter la plateforme en interne.",
+        "p1": "Des formations pour la direction et le personnel. Du conseil guidé pour les décisions propres à l'entreprise : arbitrages de traitement des risques, négociations avec les fournisseurs, réponse à incident complexe. Des fonctionnalités premium au fur et à mesure de leur développement. L'auto-hébergement ne nous rapporte rien : le code est sous AGPL-3.0, sans frais de licence.",
         "p2": "La plateforme de conformité de base reste gratuite. Le jeu de données ouvert reste ouvert. Le principe est que la facture doit être réduite, et non reportée sur nous."
       },
       "team": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Là où nous facturons",
-        "p1": "Des formations pour la direction et le personnel. Du conseil guidé pour les décisions propres à l'entreprise : arbitrages de traitement des risques, négociations avec les fournisseurs, réponse à incident complexe. Des fonctionnalités premium au fur et à mesure de leur développement. L'auto-hébergement ne nous rapporte rien : le code est sous AGPL-3.0, sans frais de licence.",
+        "p1": "Des formations pour la direction et le personnel. Du conseil guidé pour les décisions propres à l'entreprise : arbitrages de traitement des risques, négociations avec les fournisseurs, réponse à incident complexe. Des fonctionnalités premium au fur et à mesure de leur développement. L'auto-hébergement ne nous rapporte rien, le code est ouvert sous AGPL-3.0.",
         "p2": "La plateforme de conformité de base reste gratuite. Le jeu de données ouvert reste ouvert. Le principe est que la facture doit être réduite, et non reportée sur nous."
       },
       "team": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Dove facciamo pagare",
-        "p1": "Corsi di formazione per la direzione e il personale. Consulenza guidata per decisioni specifiche all'azienda: compromessi sul trattamento del rischio, negoziazioni con i fornitori, risposta a incidenti complessi. Funzioni premium man mano che si sviluppano. Licenze self-host per i soggetti che hanno bisogno di eseguire la piattaforma internamente.",
+        "p1": "Corsi di formazione per la direzione e il personale. Consulenza guidata per decisioni specifiche all'azienda: compromessi sul trattamento del rischio, negoziazioni con i fornitori, risposta a incidenti complessi. Funzioni premium man mano che si sviluppano. Per il self-hosting non facciamo pagare nulla: il codice è sotto AGPL-3.0, senza costi di licenza.",
         "p2": "La piattaforma di conformità di base resta gratuita. Il dataset aperto resta aperto. Il principio è che il conto deve essere tagliato, non spostato su di noi."
       },
       "team": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Dove facciamo pagare",
-        "p1": "Corsi di formazione per la direzione e il personale. Consulenza guidata per decisioni specifiche all'azienda: compromessi sul trattamento del rischio, negoziazioni con i fornitori, risposta a incidenti complessi. Funzioni premium man mano che si sviluppano. Per il self-hosting non facciamo pagare nulla: il codice è sotto AGPL-3.0, senza costi di licenza.",
+        "p1": "Corsi di formazione per la direzione e il personale. Consulenza guidata per decisioni specifiche all'azienda: compromessi sul trattamento del rischio, negoziazioni con i fornitori, risposta a incidenti complessi. Funzioni premium man mano che si sviluppano. Per il self-hosting non facciamo pagare nulla, il codice è aperto con AGPL-3.0.",
         "p2": "La piattaforma di conformità di base resta gratuita. Il dataset aperto resta aperto. Il principio è che il conto deve essere tagliato, non spostato su di noi."
       },
       "team": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Where we charge",
-        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. Self-host licensing for entities that need to run the platform internally.",
+        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting: the code is AGPL-3.0, with no licence fee.",
         "p2": "The core compliance platform stays free. The open dataset stays open. The principle is that the bill should be cut, not shifted to us."
       },
       "cta": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -1868,7 +1868,7 @@
       },
       "paid": {
         "heading": "Where we charge",
-        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting: the code is AGPL-3.0, with no licence fee.",
+        "p1": "Training courses for management and staff. Guided consultancy for company-specific decisions: risk treatment trade-offs, supplier negotiations, complex incident response. Premium features as they develop. We charge nothing for self-hosting, the code is open under AGPL-3.0.",
         "p2": "The core compliance platform stays free. The open dataset stays open. The principle is that the bill should be cut, not shifted to us."
       },
       "cta": {

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Za co pobieramy opłaty",
-        "p1": "Kursy szkoleniowe dla kadry zarządzającej i pracowników. Doradztwo prowadzone w przypadku decyzji specyficznych dla firmy: kompromisy w postępowaniu z ryzykiem, negocjacje z dostawcami, złożone reagowanie na incydenty. Funkcje premium w miarę ich rozwoju. Licencjonowanie samodzielnego hostingu dla podmiotów, które muszą uruchamiać platformę wewnętrznie.",
+        "p1": "Kursy szkoleniowe dla kadry zarządzającej i pracowników. Doradztwo prowadzone w przypadku decyzji specyficznych dla firmy: kompromisy w postępowaniu z ryzykiem, negocjacje z dostawcami, złożone reagowanie na incydenty. Funkcje premium w miarę ich rozwoju. Za samodzielny hosting nie pobieramy nic: kod jest na licencji AGPL-3.0, bez opłaty licencyjnej.",
         "p2": "Podstawowa platforma zgodności pozostaje bezpłatna. Otwarty zbiór danych pozostaje otwarty. Zasada jest taka, że rachunek ma zostać obcięty, a nie przeniesiony na nas."
       },
       "team": {

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Za co pobieramy opłaty",
-        "p1": "Kursy szkoleniowe dla kadry zarządzającej i pracowników. Doradztwo prowadzone w przypadku decyzji specyficznych dla firmy: kompromisy w postępowaniu z ryzykiem, negocjacje z dostawcami, złożone reagowanie na incydenty. Funkcje premium w miarę ich rozwoju. Za samodzielny hosting nie pobieramy nic: kod jest na licencji AGPL-3.0, bez opłaty licencyjnej.",
+        "p1": "Kursy szkoleniowe dla kadry zarządzającej i pracowników. Doradztwo prowadzone w przypadku decyzji specyficznych dla firmy: kompromisy w postępowaniu z ryzykiem, negocjacje z dostawcami, złożone reagowanie na incydenty. Funkcje premium w miarę ich rozwoju. Za samodzielny hosting nie pobieramy nic, kod jest otwarty na AGPL-3.0.",
         "p2": "Podstawowa platforma zgodności pozostaje bezpłatna. Otwarty zbiór danych pozostaje otwarty. Zasada jest taka, że rachunek ma zostać obcięty, a nie przeniesiony na nas."
       },
       "team": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Onde cobramos",
-        "p1": "Cursos de formação para a gestão e o pessoal. Consultoria orientada para decisões específicas da empresa: compromissos no tratamento de risco, negociações com fornecedores, resposta a incidentes complexos. Funcionalidades premium à medida que se desenvolvem. Licenciamento de auto-alojamento para entidades que precisam de executar a plataforma internamente.",
+        "p1": "Cursos de formação para a gestão e o pessoal. Consultoria orientada para decisões específicas da empresa: compromissos no tratamento de risco, negociações com fornecedores, resposta a incidentes complexos. Funcionalidades premium à medida que se desenvolvem. Pelo autoalojamento não cobramos nada: o código está sob AGPL-3.0, sem taxa de licença.",
         "p2": "A plataforma central de conformidade permanece gratuita. O conjunto de dados aberto permanece aberto. O princípio é que a fatura deve ser cortada, não transferida para nós."
       },
       "team": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Onde cobramos",
-        "p1": "Cursos de formação para a gestão e o pessoal. Consultoria orientada para decisões específicas da empresa: compromissos no tratamento de risco, negociações com fornecedores, resposta a incidentes complexos. Funcionalidades premium à medida que se desenvolvem. Pelo autoalojamento não cobramos nada: o código está sob AGPL-3.0, sem taxa de licença.",
+        "p1": "Cursos de formação para a gestão e o pessoal. Consultoria orientada para decisões específicas da empresa: compromissos no tratamento de risco, negociações com fornecedores, resposta a incidentes complexos. Funcionalidades premium à medida que se desenvolvem. Pelo autoalojamento não cobramos nada, o código é aberto sob AGPL-3.0.",
         "p2": "A plataforma central de conformidade permanece gratuita. O conjunto de dados aberto permanece aberto. O princípio é que a fatura deve ser cortada, não transferida para nós."
       },
       "team": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Unde percepem tarif",
-        "p1": "Cursuri de instruire pentru conducere si personal. Consultanta ghidata pentru decizii specifice companiei: compromisuri de tratare a riscului, negocieri cu furnizorii, raspuns la incidente complexe. Functii premium pe masura ce se dezvolta. Pentru auto-gazduire nu percepem nimic: codul este sub AGPL-3.0, fara taxa de licenta.",
+        "p1": "Cursuri de instruire pentru conducere si personal. Consultanta ghidata pentru decizii specifice companiei: compromisuri de tratare a riscului, negocieri cu furnizorii, raspuns la incidente complexe. Functii premium pe masura ce se dezvolta. Pentru auto-gazduire nu percepem nimic, codul este deschis sub AGPL-3.0.",
         "p2": "Platforma de baza de conformitate ramane gratuita. Setul de date deschis ramane deschis. Principiul este ca factura sa fie redusa, nu mutata catre noi."
       },
       "team": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -1867,7 +1867,7 @@
       },
       "paid": {
         "heading": "Unde percepem tarif",
-        "p1": "Cursuri de instruire pentru conducere si personal. Consultanta ghidata pentru decizii specifice companiei: compromisuri de tratare a riscului, negocieri cu furnizorii, raspuns la incidente complexe. Functii premium pe masura ce se dezvolta. Licentiere pentru gazduire proprie pentru entitatile care trebuie sa ruleze platforma intern.",
+        "p1": "Cursuri de instruire pentru conducere si personal. Consultanta ghidata pentru decizii specifice companiei: compromisuri de tratare a riscului, negocieri cu furnizorii, raspuns la incidente complexe. Functii premium pe masura ce se dezvolta. Pentru auto-gazduire nu percepem nimic: codul este sub AGPL-3.0, fara taxa de licenta.",
         "p2": "Platforma de baza de conformitate ramane gratuita. Setul de date deschis ramane deschis. Principiul este ca factura sa fie redusa, nu mutata catre noi."
       },
       "team": {

--- a/messages/pricing/cs.json
+++ b/messages/pricing/cs.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Ceník - Platforma pro shodu s NIS2",
-      "description": "Platforma je trvale zdarma. Hostovaná na nisd2.eu nebo ve vlastním provozu na vaší infrastruktuře pod licencí AGPL-3.0. Žádná licence, žádná aktivace, žádný lock-in."
+      "description": "Platforma je trvale zdarma. Hostovaná na nisd2.eu nebo ve vlastním provozu na vaší infrastruktuře, zdrojový kód otevřený pod AGPL-3.0. Žádná smlouva, žádná aktivace, žádný lock-in."
     },
     "title": "Ceník",
     "subtitle": "Trvale zdarma. Vybíráte jen to, kdo ji provozuje.",
@@ -32,15 +32,15 @@
       "priceSub": "navždy",
       "cta": "Zobrazit zdrojový kód",
       "features": {
-        "h1": "Celý zdrojový kód platformy pod licencí AGPL-3.0",
+        "h1": "Celý zdrojový kód platformy, otevřený pod AGPL-3.0",
         "h2": "Všechny budoucí aktualizace v ceně, trvale",
         "h3": "Na vlastní infrastruktuře, s vlastními daty",
-        "h4": "Žádná licence, žádná smlouva, žádný aktivační klíč",
+        "h4": "Žádná smlouva, žádný aktivační klíč, žádný účet u nás",
         "h5": "Exportujte svou práci z nisd2.eu a provozujte ji dál sami",
         "h6": "Přímý kontakt e-mailem a přes Signal"
       }
     },
-    "whyFree": "Proč zdarma: zdrojový kód je veřejný na GitHubu pod licencí AGPL-3.0. Licence by nám hlavně ukázala, kdo platformu provozuje. To není důvod posílat vám fakturu.",
+    "whyFree": "Proč zdarma: zdrojový kód je otevřený na GitHubu, ověřitelný a můžete si ho provozovat sami. Vydělávat počítáme na školeních a poradenství, ne na platformě.",
     "consultantFootnote": "Potřebujete konzultanta pro NIS2? Spojíme vás s prověřenými specialisty, a to pro vás zdarma.",
     "consultantCta": "Vyžádat konzultanta"
   }

--- a/messages/pricing/cs.json
+++ b/messages/pricing/cs.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Ceník - Platforma pro shodu s NIS2",
-      "description": "Dva způsoby provozu platformy. Hostováno na nis2.eu, navždy zdarma. Vlastní hosting pod licencí AGPL-3.0: zaplaťte, kolik můžete, jako jednorázová doživotní licence."
+      "description": "Platforma je trvale zdarma. Hostovaná na nisd2.eu nebo ve vlastním provozu na vaší infrastruktuře pod licencí AGPL-3.0. Žádná licence, žádná aktivace, žádný lock-in."
     },
     "title": "Ceník",
-    "subtitle": "Dva způsoby provozu platformy. Vyberte si jeden.",
+    "subtitle": "Trvale zdarma. Vybíráte jen to, kdo ji provozuje.",
     "free": {
-      "name": "Hostováno na nis2.eu",
+      "name": "Hostováno na nisd2.eu",
       "description": "Celá platforma, kterou provozujeme my na infrastruktuře v EU.",
       "price": "0 €",
       "priceSub": "navždy",
@@ -22,22 +22,25 @@
         "f7": "Neomezený počet členů týmu",
         "f8": "Registry rizik, aktiv a dodavatelů",
         "f9": "Pomoc s formuláři využívající AI",
-        "f10": "Kein Lock-in. Datový model je Open Source. Export kdykoli."
+        "f10": "Žádný lock-in. Otevřený datový model. Export kdykoli, i do vlastního provozu."
       }
     },
     "selfHost": {
-      "name": "Vlastní hosting",
-      "description": "Celý zdrojový kód. Provozujte ji na vlastní infrastruktuře, navždy.",
-      "price": "Zaplaťte, kolik můžete",
-      "priceSub": "jednorázově, doživotní licence",
-      "cta": "Spojte se s námi",
+      "name": "Vlastní provoz",
+      "description": "Celý zdrojový kód. Na vlastní infrastruktuře, trvale.",
+      "price": "0 €",
+      "priceSub": "navždy",
+      "cta": "Zobrazit zdrojový kód",
       "features": {
         "h1": "Celý zdrojový kód platformy pod licencí AGPL-3.0",
-        "h2": "Všechny budoucí aktualizace v ceně",
-        "h3": "Provoz na vlastní infrastruktuře, s vlastními daty",
-        "h4": "Jmenovaný kontakt pro podporu přes e-mail a Signal"
+        "h2": "Všechny budoucí aktualizace v ceně, trvale",
+        "h3": "Na vlastní infrastruktuře, s vlastními daty",
+        "h4": "Žádná licence, žádná smlouva, žádný aktivační klíč",
+        "h5": "Exportujte svou práci z nisd2.eu a provozujte ji dál sami",
+        "h6": "Přímý kontakt e-mailem a přes Signal"
       }
     },
+    "whyFree": "Proč zdarma: zdrojový kód je veřejný na GitHubu pod licencí AGPL-3.0. Licence by nám hlavně ukázala, kdo platformu provozuje. To není důvod posílat vám fakturu.",
     "consultantFootnote": "Potřebujete konzultanta pro NIS2? Spojíme vás s prověřenými specialisty, a to pro vás zdarma.",
     "consultantCta": "Vyžádat konzultanta"
   }

--- a/messages/pricing/de.json
+++ b/messages/pricing/de.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Preise - NIS2-Compliance-Plattform",
-      "description": "Die Plattform ist kostenlos, dauerhaft. Gehostet auf nisd2.eu oder im Selbstbetrieb auf eigener Infrastruktur unter AGPL-3.0. Keine Lizenz, keine Freischaltung, kein Lock-in."
+      "description": "Die Plattform ist kostenlos, dauerhaft. Gehostet auf nisd2.eu oder im Selbstbetrieb auf eigener Infrastruktur, Quellcode offen unter AGPL-3.0. Kein Vertrag, keine Freischaltung, kein Lock-in."
     },
     "title": "Preise",
     "subtitle": "Kostenlos, dauerhaft. Sie entscheiden nur, wer sie betreibt.",
@@ -32,15 +32,15 @@
       "priceSub": "für immer",
       "cta": "Zum Quellcode",
       "features": {
-        "h1": "Vollständiger Plattform-Quellcode unter AGPL-3.0",
+        "h1": "Vollständiger Plattform-Quellcode, offen unter AGPL-3.0",
         "h2": "Alle künftigen Updates inklusive, dauerhaft",
         "h3": "Auf eigener Infrastruktur, mit eigenen Daten",
-        "h4": "Keine Lizenz, kein Vertrag, keine Freischaltung",
+        "h4": "Kein Vertrag, keine Freischaltung, keine Anmeldung bei uns",
         "h5": "Ihren Stand von nisd2.eu exportieren und selbst weiterbetreiben",
         "h6": "Direkter Kontakt per E-Mail und Signal"
       }
     },
-    "whyFree": "Warum kostenlos: Der Quellcode steht unter AGPL-3.0 und ist auf GitHub einsehbar. Eine Lizenz hätte uns vor allem gezeigt, wer die Plattform einsetzt. Das ist kein Grund, Ihnen eine Rechnung zu schicken.",
+    "whyFree": "Warum kostenlos: Der Quellcode liegt offen auf GitHub, prüfbar und selbst betreibbar. Geld nehmen wir perspektivisch für Schulungen und Beratung, nicht für die Plattform.",
     "consultantFootnote": "Brauchen Sie einen NIS2-Berater? Wir vermitteln geprüfte Fachleute, kostenlos für Sie.",
     "consultantCta": "Berater anfragen"
   }

--- a/messages/pricing/de.json
+++ b/messages/pricing/de.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Preise - NIS2-Compliance-Plattform",
-      "description": "Zwei Wege, die Plattform zu nutzen. Gehostet auf nis2.eu, kostenlos für immer. Self-Hosting unter AGPL-3.0: Zahlen Sie, was Sie können, als einmalige, lebenslange Lizenz."
+      "description": "Die Plattform ist kostenlos, dauerhaft. Gehostet auf nisd2.eu oder im Selbstbetrieb auf eigener Infrastruktur unter AGPL-3.0. Keine Lizenz, keine Freischaltung, kein Lock-in."
     },
     "title": "Preise",
-    "subtitle": "Zwei Wege, die Plattform zu nutzen. Wählen Sie einen.",
+    "subtitle": "Kostenlos, dauerhaft. Sie entscheiden nur, wer sie betreibt.",
     "free": {
-      "name": "Gehostet auf nis2.eu",
+      "name": "Gehostet auf nisd2.eu",
       "description": "Die vollständige Plattform, von uns auf EU-Infrastruktur betrieben.",
       "price": "0 €",
       "priceSub": "für immer",
@@ -22,22 +22,25 @@
         "f7": "Unbegrenzte Teammitglieder",
         "f8": "Risiko-, Asset- und Lieferantenregister",
         "f9": "KI-gestützte Formularausfüllung",
-        "f10": "Kein Lock-in. Open Source Datenmodell. Jederzeit exportierbar."
+        "f10": "Kein Lock-in. Offenes Datenmodell. Export jederzeit, auch in den Selbstbetrieb."
       }
     },
     "selfHost": {
-      "name": "Self-Hosting",
-      "description": "Vollständiger Quellcode. Auf eigener Infrastruktur betreiben, dauerhaft.",
-      "price": "Zahlen Sie, was Sie können",
-      "priceSub": "einmalig, lebenslange Lizenz",
-      "cta": "Kontakt aufnehmen",
+      "name": "Selbstbetrieb",
+      "description": "Vollständiger Quellcode. Auf eigener Infrastruktur, dauerhaft.",
+      "price": "0 €",
+      "priceSub": "für immer",
+      "cta": "Zum Quellcode",
       "features": {
         "h1": "Vollständiger Plattform-Quellcode unter AGPL-3.0",
-        "h2": "Alle künftigen Updates inklusive",
+        "h2": "Alle künftigen Updates inklusive, dauerhaft",
         "h3": "Auf eigener Infrastruktur, mit eigenen Daten",
-        "h4": "Persönlicher Ansprechpartner per E-Mail und Signal"
+        "h4": "Keine Lizenz, kein Vertrag, keine Freischaltung",
+        "h5": "Ihren Stand von nisd2.eu exportieren und selbst weiterbetreiben",
+        "h6": "Direkter Kontakt per E-Mail und Signal"
       }
     },
+    "whyFree": "Warum kostenlos: Der Quellcode steht unter AGPL-3.0 und ist auf GitHub einsehbar. Eine Lizenz hätte uns vor allem gezeigt, wer die Plattform einsetzt. Das ist kein Grund, Ihnen eine Rechnung zu schicken.",
     "consultantFootnote": "Brauchen Sie einen NIS2-Berater? Wir vermitteln geprüfte Fachleute, kostenlos für Sie.",
     "consultantCta": "Berater anfragen"
   }

--- a/messages/pricing/en.json
+++ b/messages/pricing/en.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Pricing - NIS2 Compliance Platform",
-      "description": "Two ways to run the platform. Hosted at nis2.eu, free forever. Self-host under AGPL-3.0: pay what you can, one-time, lifetime licence."
+      "description": "The platform is free, permanently. Hosted at nisd2.eu, or self-hosted on your own infrastructure under AGPL-3.0. No licence, no activation, no lock-in."
     },
     "title": "Pricing",
-    "subtitle": "Two ways to run the platform. Pick one.",
+    "subtitle": "Free, permanently. The only choice is who runs it.",
     "free": {
-      "name": "Hosted at nis2.eu",
+      "name": "Hosted at nisd2.eu",
       "description": "The full platform, operated by us on EU infrastructure.",
       "price": "€0",
       "priceSub": "forever",
@@ -22,22 +22,25 @@
         "f7": "Unlimited team members",
         "f8": "Risk, asset, and supplier registers",
         "f9": "AI-powered form assistance",
-        "f10": "Kein Lock-in. Open Source data model. Export anytime."
+        "f10": "No lock-in. Open data model. Export anytime, including into self-hosting."
       }
     },
     "selfHost": {
       "name": "Self-host",
-      "description": "Full source code. Run it on your own infrastructure, forever.",
-      "price": "Pay what you can",
-      "priceSub": "one-time, lifetime licence",
-      "cta": "Talk to us",
+      "description": "Full source code. On your own infrastructure, permanently.",
+      "price": "€0",
+      "priceSub": "forever",
+      "cta": "View the source",
       "features": {
         "h1": "Full platform source under AGPL-3.0",
-        "h2": "All future updates included",
-        "h3": "Run on your own infrastructure, your own data",
-        "h4": "Named contact for email and Signal support"
+        "h2": "All future updates included, permanently",
+        "h3": "On your own infrastructure, with your own data",
+        "h4": "No licence, no contract, no activation key",
+        "h5": "Export your work from nisd2.eu and carry on running it yourself",
+        "h6": "Direct contact by email and Signal"
       }
     },
+    "whyFree": "Why free: the source is public under AGPL-3.0 on GitHub. A licence would mainly have told us who runs the platform. That is no reason to send you an invoice.",
     "consultantFootnote": "Need a NIS2 consultant? We connect you with vetted specialists at no cost to you.",
     "consultantCta": "Request a consultant"
   }

--- a/messages/pricing/en.json
+++ b/messages/pricing/en.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Pricing - NIS2 Compliance Platform",
-      "description": "The platform is free, permanently. Hosted at nisd2.eu, or self-hosted on your own infrastructure under AGPL-3.0. No licence, no activation, no lock-in."
+      "description": "The platform is free, permanently. Hosted at nisd2.eu, or self-hosted on your own infrastructure, source open under AGPL-3.0. No contract, no activation, no lock-in."
     },
     "title": "Pricing",
     "subtitle": "Free, permanently. The only choice is who runs it.",
@@ -32,15 +32,15 @@
       "priceSub": "forever",
       "cta": "View the source",
       "features": {
-        "h1": "Full platform source under AGPL-3.0",
+        "h1": "Full platform source, open under AGPL-3.0",
         "h2": "All future updates included, permanently",
         "h3": "On your own infrastructure, with your own data",
-        "h4": "No licence, no contract, no activation key",
+        "h4": "No contract, no activation key, no account with us",
         "h5": "Export your work from nisd2.eu and carry on running it yourself",
         "h6": "Direct contact by email and Signal"
       }
     },
-    "whyFree": "Why free: the source is public under AGPL-3.0 on GitHub. A licence would mainly have told us who runs the platform. That is no reason to send you an invoice.",
+    "whyFree": "Why free: the source is open on GitHub, auditable and yours to run. We expect to earn from training and consultancy, not from the platform.",
     "consultantFootnote": "Need a NIS2 consultant? We connect you with vetted specialists at no cost to you.",
     "consultantCta": "Request a consultant"
   }

--- a/messages/pricing/es.json
+++ b/messages/pricing/es.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Precios - Plataforma de cumplimiento NIS2",
-      "description": "La plataforma es gratuita, de forma permanente. Alojada en nisd2.eu o autoalojada en su propia infraestructura bajo AGPL-3.0. Sin licencia, sin activación, sin dependencia del proveedor."
+      "description": "La plataforma es gratuita, de forma permanente. Alojada en nisd2.eu o autoalojada en su propia infraestructura, código abierto bajo AGPL-3.0. Sin contrato, sin activación, sin dependencia del proveedor."
     },
     "title": "Precios",
     "subtitle": "Gratis, de forma permanente. Lo único que elige es quién la opera.",
@@ -32,15 +32,15 @@
       "priceSub": "para siempre",
       "cta": "Ver el código fuente",
       "features": {
-        "h1": "Código fuente completo de la plataforma bajo AGPL-3.0",
+        "h1": "Código fuente completo de la plataforma, abierto bajo AGPL-3.0",
         "h2": "Todas las actualizaciones futuras incluidas, de forma permanente",
         "h3": "En su propia infraestructura, con sus propios datos",
-        "h4": "Sin licencia, sin contrato, sin clave de activación",
+        "h4": "Sin contrato, sin clave de activación, sin cuenta con nosotros",
         "h5": "Exporte su trabajo desde nisd2.eu y siga operándolo usted mismo",
         "h6": "Contacto directo por correo electrónico y Signal"
       }
     },
-    "whyFree": "Por qué es gratis: el código fuente es público bajo AGPL-3.0 en GitHub. Una licencia nos habría servido sobre todo para saber quién usa la plataforma. Eso no es motivo para enviarle una factura.",
+    "whyFree": "Por qué es gratis: el código está abierto en GitHub, auditable y puede ejecutarlo usted mismo. Esperamos ganar dinero con formación y consultoría, no con la plataforma.",
     "consultantFootnote": "¿Necesita un consultor de NIS2? Le ponemos en contacto con especialistas verificados sin coste alguno para usted.",
     "consultantCta": "Solicitar un consultor"
   }

--- a/messages/pricing/es.json
+++ b/messages/pricing/es.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Precios - Plataforma de cumplimiento NIS2",
-      "description": "Dos formas de utilizar la plataforma. Alojada en nis2.eu, gratis para siempre. Autoalojamiento bajo AGPL-3.0: pague lo que pueda, como licencia perpetua de pago único."
+      "description": "La plataforma es gratuita, de forma permanente. Alojada en nisd2.eu o autoalojada en su propia infraestructura bajo AGPL-3.0. Sin licencia, sin activación, sin dependencia del proveedor."
     },
     "title": "Precios",
-    "subtitle": "Dos formas de utilizar la plataforma. Elija una.",
+    "subtitle": "Gratis, de forma permanente. Lo único que elige es quién la opera.",
     "free": {
-      "name": "Alojada en nis2.eu",
+      "name": "Alojada en nisd2.eu",
       "description": "La plataforma completa, operada por nosotros en infraestructura de la UE.",
       "price": "0 €",
       "priceSub": "para siempre",
@@ -22,22 +22,25 @@
         "f7": "Miembros del equipo ilimitados",
         "f8": "Registros de riesgos, activos y proveedores",
         "f9": "Asistencia de formularios con IA",
-        "f10": "Kein Lock-in. Modelo de datos Open Source. Exporte cuando quiera."
+        "f10": "Sin dependencia del proveedor. Modelo de datos abierto. Exporte cuando quiera, también al autoalojamiento."
       }
     },
     "selfHost": {
       "name": "Autoalojamiento",
-      "description": "Código fuente completo. Ejecútelo en su propia infraestructura, para siempre.",
-      "price": "Pague lo que pueda",
-      "priceSub": "pago único, licencia perpetua",
-      "cta": "Hable con nosotros",
+      "description": "Código fuente completo. En su propia infraestructura, de forma permanente.",
+      "price": "0 €",
+      "priceSub": "para siempre",
+      "cta": "Ver el código fuente",
       "features": {
         "h1": "Código fuente completo de la plataforma bajo AGPL-3.0",
-        "h2": "Todas las actualizaciones futuras incluidas",
-        "h3": "Ejecútela en su propia infraestructura, con sus propios datos",
-        "h4": "Contacto designado para soporte por correo electrónico y Signal"
+        "h2": "Todas las actualizaciones futuras incluidas, de forma permanente",
+        "h3": "En su propia infraestructura, con sus propios datos",
+        "h4": "Sin licencia, sin contrato, sin clave de activación",
+        "h5": "Exporte su trabajo desde nisd2.eu y siga operándolo usted mismo",
+        "h6": "Contacto directo por correo electrónico y Signal"
       }
     },
+    "whyFree": "Por qué es gratis: el código fuente es público bajo AGPL-3.0 en GitHub. Una licencia nos habría servido sobre todo para saber quién usa la plataforma. Eso no es motivo para enviarle una factura.",
     "consultantFootnote": "¿Necesita un consultor de NIS2? Le ponemos en contacto con especialistas verificados sin coste alguno para usted.",
     "consultantCta": "Solicitar un consultor"
   }

--- a/messages/pricing/fr.json
+++ b/messages/pricing/fr.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Tarifs - Plateforme de conformité NIS2",
-      "description": "La plateforme est gratuite, durablement. Hébergée sur nisd2.eu ou auto-hébergée sur votre propre infrastructure sous AGPL-3.0. Pas de licence, pas d'activation, pas de verrouillage."
+      "description": "La plateforme est gratuite, durablement. Hébergée sur nisd2.eu ou auto-hébergée sur votre propre infrastructure, code source ouvert sous AGPL-3.0. Pas de contrat, pas d'activation, pas de verrouillage."
     },
     "title": "Tarifs",
     "subtitle": "Gratuite, durablement. Le seul choix, c'est qui l'exploite.",
@@ -32,15 +32,15 @@
       "priceSub": "pour toujours",
       "cta": "Voir le code source",
       "features": {
-        "h1": "Code source complet de la plateforme sous AGPL-3.0",
+        "h1": "Code source complet de la plateforme, ouvert sous AGPL-3.0",
         "h2": "Toutes les mises à jour futures incluses, durablement",
         "h3": "Sur votre propre infrastructure, avec vos propres données",
-        "h4": "Pas de licence, pas de contrat, pas de clé d'activation",
+        "h4": "Pas de contrat, pas de clé d'activation, pas de compte chez nous",
         "h5": "Exportez votre travail depuis nisd2.eu et continuez à l'exploiter vous-même",
         "h6": "Contact direct par e-mail et Signal"
       }
     },
-    "whyFree": "Pourquoi c'est gratuit : le code source est public sous AGPL-3.0 sur GitHub. Une licence nous aurait surtout indiqué qui exploite la plateforme. Ce n'est pas une raison pour vous envoyer une facture.",
+    "whyFree": "Pourquoi c'est gratuit : le code source est ouvert sur GitHub, vérifiable et exploitable par vos soins. Nous comptons gagner notre vie avec la formation et le conseil, pas avec la plateforme.",
     "consultantFootnote": "Besoin d'un consultant NIS2 ? Nous vous mettons en relation avec des spécialistes vérifiés, sans frais pour vous.",
     "consultantCta": "Demander un consultant"
   }

--- a/messages/pricing/fr.json
+++ b/messages/pricing/fr.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Tarifs - Plateforme de conformité NIS2",
-      "description": "Deux façons d'utiliser la plateforme. Hébergée sur nis2.eu, gratuite pour toujours. Auto-hébergement sous AGPL-3.0 : payez ce que vous pouvez, en un paiement unique pour une licence à vie."
+      "description": "La plateforme est gratuite, durablement. Hébergée sur nisd2.eu ou auto-hébergée sur votre propre infrastructure sous AGPL-3.0. Pas de licence, pas d'activation, pas de verrouillage."
     },
     "title": "Tarifs",
-    "subtitle": "Deux façons d'utiliser la plateforme. Choisissez-en une.",
+    "subtitle": "Gratuite, durablement. Le seul choix, c'est qui l'exploite.",
     "free": {
-      "name": "Hébergée sur nis2.eu",
+      "name": "Hébergée sur nisd2.eu",
       "description": "La plateforme complète, exploitée par nos soins sur une infrastructure de l'UE.",
       "price": "0 €",
       "priceSub": "pour toujours",
@@ -22,22 +22,25 @@
         "f7": "Membres d'équipe illimités",
         "f8": "Registres des risques, des actifs et des fournisseurs",
         "f9": "Assistance aux formulaires par IA",
-        "f10": "Kein Lock-in. Modèle de données Open Source. Export à tout moment."
+        "f10": "Aucun verrouillage. Modèle de données ouvert. Export à tout moment, y compris vers l'auto-hébergement."
       }
     },
     "selfHost": {
       "name": "Auto-hébergement",
-      "description": "Code source complet. Exécutez-la sur votre propre infrastructure, pour toujours.",
-      "price": "Payez ce que vous pouvez",
-      "priceSub": "paiement unique, licence à vie",
-      "cta": "Parlons-en",
+      "description": "Code source complet. Sur votre propre infrastructure, durablement.",
+      "price": "0 €",
+      "priceSub": "pour toujours",
+      "cta": "Voir le code source",
       "features": {
         "h1": "Code source complet de la plateforme sous AGPL-3.0",
-        "h2": "Toutes les mises à jour futures incluses",
-        "h3": "Exécution sur votre propre infrastructure, avec vos propres données",
-        "h4": "Contact nommé pour le support par e-mail et Signal"
+        "h2": "Toutes les mises à jour futures incluses, durablement",
+        "h3": "Sur votre propre infrastructure, avec vos propres données",
+        "h4": "Pas de licence, pas de contrat, pas de clé d'activation",
+        "h5": "Exportez votre travail depuis nisd2.eu et continuez à l'exploiter vous-même",
+        "h6": "Contact direct par e-mail et Signal"
       }
     },
+    "whyFree": "Pourquoi c'est gratuit : le code source est public sous AGPL-3.0 sur GitHub. Une licence nous aurait surtout indiqué qui exploite la plateforme. Ce n'est pas une raison pour vous envoyer une facture.",
     "consultantFootnote": "Besoin d'un consultant NIS2 ? Nous vous mettons en relation avec des spécialistes vérifiés, sans frais pour vous.",
     "consultantCta": "Demander un consultant"
   }

--- a/messages/pricing/it.json
+++ b/messages/pricing/it.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Prezzi - Piattaforma di conformità NIS2",
-      "description": "Due modi per utilizzare la piattaforma. In hosting su nis2.eu, gratuita per sempre. Self-hosting con licenza AGPL-3.0: paga quanto puoi, come licenza a vita una tantum."
+      "description": "La piattaforma è gratuita, in modo permanente. In hosting su nisd2.eu o in self-hosting sulla tua infrastruttura con licenza AGPL-3.0. Nessuna licenza a pagamento, nessuna attivazione, nessun lock-in."
     },
     "title": "Prezzi",
-    "subtitle": "Due modi per utilizzare la piattaforma. Scegline uno.",
+    "subtitle": "Gratuita, in modo permanente. L'unica scelta è chi la gestisce.",
     "free": {
-      "name": "In hosting su nis2.eu",
+      "name": "In hosting su nisd2.eu",
       "description": "La piattaforma completa, gestita da noi su infrastruttura UE.",
       "price": "€0",
       "priceSub": "per sempre",
@@ -22,22 +22,25 @@
         "f7": "Membri del team illimitati",
         "f8": "Registri dei rischi, degli asset e dei fornitori",
         "f9": "Assistenza ai moduli basata sull'IA",
-        "f10": "Nessun lock-in. Modello dati Open Source. Esporta in qualsiasi momento."
+        "f10": "Nessun lock-in. Modello dati aperto. Esporta in qualsiasi momento, anche verso il self-hosting."
       }
     },
     "selfHost": {
       "name": "Self-hosting",
-      "description": "Codice sorgente completo. Eseguila sulla tua infrastruttura, per sempre.",
-      "price": "Paga quanto puoi",
-      "priceSub": "una tantum, licenza a vita",
-      "cta": "Contattaci",
+      "description": "Codice sorgente completo. Sulla tua infrastruttura, in modo permanente.",
+      "price": "€0",
+      "priceSub": "per sempre",
+      "cta": "Vedi il codice sorgente",
       "features": {
         "h1": "Codice sorgente completo della piattaforma con licenza AGPL-3.0",
-        "h2": "Tutti gli aggiornamenti futuri inclusi",
-        "h3": "Eseguila sulla tua infrastruttura, con i tuoi dati",
-        "h4": "Contatto dedicato per il supporto via email e Signal"
+        "h2": "Tutti gli aggiornamenti futuri inclusi, in modo permanente",
+        "h3": "Sulla tua infrastruttura, con i tuoi dati",
+        "h4": "Nessuna licenza, nessun contratto, nessuna chiave di attivazione",
+        "h5": "Esporta il tuo lavoro da nisd2.eu e continua a gestirlo da solo",
+        "h6": "Contatto diretto via email e Signal"
       }
     },
+    "whyFree": "Perché è gratuita: il codice sorgente è pubblico su GitHub con licenza AGPL-3.0. Una licenza a pagamento ci avrebbe soprattutto mostrato chi usa la piattaforma. Non è un motivo per mandarti una fattura.",
     "consultantFootnote": "Hai bisogno di un consulente NIS2? Ti mettiamo in contatto con specialisti selezionati senza alcun costo per te.",
     "consultantCta": "Richiedi un consulente"
   }

--- a/messages/pricing/it.json
+++ b/messages/pricing/it.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prezzi - Piattaforma di conformità NIS2",
-      "description": "La piattaforma è gratuita, in modo permanente. In hosting su nisd2.eu o in self-hosting sulla tua infrastruttura con licenza AGPL-3.0. Nessuna licenza a pagamento, nessuna attivazione, nessun lock-in."
+      "description": "La piattaforma è gratuita, in modo permanente. In hosting su nisd2.eu o in self-hosting sulla tua infrastruttura, codice sorgente aperto con AGPL-3.0. Nessun contratto, nessuna attivazione, nessun lock-in."
     },
     "title": "Prezzi",
     "subtitle": "Gratuita, in modo permanente. L'unica scelta è chi la gestisce.",
@@ -32,15 +32,15 @@
       "priceSub": "per sempre",
       "cta": "Vedi il codice sorgente",
       "features": {
-        "h1": "Codice sorgente completo della piattaforma con licenza AGPL-3.0",
+        "h1": "Codice sorgente completo della piattaforma, aperto con AGPL-3.0",
         "h2": "Tutti gli aggiornamenti futuri inclusi, in modo permanente",
         "h3": "Sulla tua infrastruttura, con i tuoi dati",
-        "h4": "Nessuna licenza, nessun contratto, nessuna chiave di attivazione",
+        "h4": "Nessun contratto, nessuna chiave di attivazione, nessun account da noi",
         "h5": "Esporta il tuo lavoro da nisd2.eu e continua a gestirlo da solo",
         "h6": "Contatto diretto via email e Signal"
       }
     },
-    "whyFree": "Perché è gratuita: il codice sorgente è pubblico su GitHub con licenza AGPL-3.0. Una licenza a pagamento ci avrebbe soprattutto mostrato chi usa la piattaforma. Non è un motivo per mandarti una fattura.",
+    "whyFree": "Perché è gratuita: il codice sorgente è aperto su GitHub, verificabile e puoi eseguirlo tu. Contiamo di guadagnare con formazione e consulenza, non con la piattaforma.",
     "consultantFootnote": "Hai bisogno di un consulente NIS2? Ti mettiamo in contatto con specialisti selezionati senza alcun costo per te.",
     "consultantCta": "Richiedi un consulente"
   }

--- a/messages/pricing/nl.json
+++ b/messages/pricing/nl.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prijzen - NIS2-complianceplatform",
-      "description": "Het platform is gratis, blijvend. Gehost op nisd2.eu of in eigen beheer op uw eigen infrastructuur onder AGPL-3.0. Geen licentie, geen activering, geen lock-in."
+      "description": "Het platform is gratis, blijvend. Gehost op nisd2.eu of in eigen beheer op uw eigen infrastructuur, broncode open onder AGPL-3.0. Geen contract, geen activering, geen lock-in."
     },
     "title": "Prijzen",
     "subtitle": "Gratis, blijvend. U kiest alleen wie het draait.",
@@ -32,15 +32,15 @@
       "priceSub": "voor altijd",
       "cta": "Naar de broncode",
       "features": {
-        "h1": "Volledige platformbroncode onder AGPL-3.0",
+        "h1": "Volledige platformbroncode, open onder AGPL-3.0",
         "h2": "Alle toekomstige updates inbegrepen, blijvend",
         "h3": "Op uw eigen infrastructuur, met uw eigen data",
-        "h4": "Geen licentie, geen contract, geen activering",
+        "h4": "Geen contract, geen activering, geen account bij ons",
         "h5": "Uw werk op nisd2.eu exporteren en zelf verder draaien",
         "h6": "Direct contact via e-mail en Signal"
       }
     },
-    "whyFree": "Waarom gratis: de broncode staat onder AGPL-3.0 en is in te zien op GitHub. Een licentie had ons vooral laten zien wie het platform gebruikt. Dat is geen reden om u een factuur te sturen.",
+    "whyFree": "Waarom gratis: de broncode staat open op GitHub, controleerbaar en zelf te draaien. Geld verwachten wij te verdienen met trainingen en advies, niet met het platform.",
     "consultantFootnote": "Heeft u een NIS2-adviseur nodig? Wij verbinden u kosteloos met getoetste specialisten.",
     "consultantCta": "Adviseur aanvragen"
   }

--- a/messages/pricing/nl.json
+++ b/messages/pricing/nl.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Prijzen - NIS2-complianceplatform",
-      "description": "Twee manieren om het platform te gebruiken. Gehost op nis2.eu, voor altijd gratis. Self-hosting onder AGPL-3.0: betaal wat u kunt, als eenmalige, levenslange licentie."
+      "description": "Het platform is gratis, blijvend. Gehost op nisd2.eu of in eigen beheer op uw eigen infrastructuur onder AGPL-3.0. Geen licentie, geen activering, geen lock-in."
     },
     "title": "Prijzen",
-    "subtitle": "Twee manieren om het platform te gebruiken. Kies er één.",
+    "subtitle": "Gratis, blijvend. U kiest alleen wie het draait.",
     "free": {
-      "name": "Gehost op nis2.eu",
+      "name": "Gehost op nisd2.eu",
       "description": "Het volledige platform, door ons beheerd op EU-infrastructuur.",
       "price": "€ 0",
       "priceSub": "voor altijd",
@@ -22,22 +22,25 @@
         "f7": "Onbeperkt aantal teamleden",
         "f8": "Risico-, asset- en leveranciersregisters",
         "f9": "AI-ondersteund formulieren invullen",
-        "f10": "Geen lock-in. Open Source datamodel. Altijd exporteerbaar."
+        "f10": "Geen lock-in. Open datamodel. Altijd exporteerbaar, ook naar eigen beheer."
       }
     },
     "selfHost": {
-      "name": "Self-hosting",
-      "description": "Volledige broncode. Op uw eigen infrastructuur draaien, voor altijd.",
-      "price": "Betaal wat u kunt",
-      "priceSub": "eenmalig, levenslange licentie",
-      "cta": "Neem contact op",
+      "name": "Eigen beheer",
+      "description": "Volledige broncode. Op uw eigen infrastructuur, blijvend.",
+      "price": "€ 0",
+      "priceSub": "voor altijd",
+      "cta": "Naar de broncode",
       "features": {
         "h1": "Volledige platformbroncode onder AGPL-3.0",
-        "h2": "Alle toekomstige updates inbegrepen",
+        "h2": "Alle toekomstige updates inbegrepen, blijvend",
         "h3": "Op uw eigen infrastructuur, met uw eigen data",
-        "h4": "Vaste contactpersoon voor e-mail- en Signal-support"
+        "h4": "Geen licentie, geen contract, geen activering",
+        "h5": "Uw werk op nisd2.eu exporteren en zelf verder draaien",
+        "h6": "Direct contact via e-mail en Signal"
       }
     },
+    "whyFree": "Waarom gratis: de broncode staat onder AGPL-3.0 en is in te zien op GitHub. Een licentie had ons vooral laten zien wie het platform gebruikt. Dat is geen reden om u een factuur te sturen.",
     "consultantFootnote": "Heeft u een NIS2-adviseur nodig? Wij verbinden u kosteloos met getoetste specialisten.",
     "consultantCta": "Adviseur aanvragen"
   }

--- a/messages/pricing/pl.json
+++ b/messages/pricing/pl.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Cennik - Platforma zgodności z NIS2",
-      "description": "Platforma jest darmowa, na stałe. Hostowana na nisd2.eu albo we własnym hostingu na Twojej infrastrukturze na licencji AGPL-3.0. Bez licencji, bez aktywacji, bez lock-inu."
+      "description": "Platforma jest darmowa, na stałe. Hostowana na nisd2.eu albo we własnym hostingu na Twojej infrastrukturze, kod źródłowy otwarty na AGPL-3.0. Bez umowy, bez aktywacji, bez lock-inu."
     },
     "title": "Cennik",
     "subtitle": "Darmowa, na stałe. Wybierasz tylko, kto ją uruchamia.",
@@ -32,15 +32,15 @@
       "priceSub": "na zawsze",
       "cta": "Zobacz kod źródłowy",
       "features": {
-        "h1": "Pełny kod źródłowy platformy na licencji AGPL-3.0",
+        "h1": "Pełny kod źródłowy platformy, otwarty na AGPL-3.0",
         "h2": "Wszystkie przyszłe aktualizacje w cenie, na stałe",
         "h3": "Na własnej infrastrukturze, z własnymi danymi",
-        "h4": "Bez licencji, bez umowy, bez klucza aktywacyjnego",
+        "h4": "Bez umowy, bez klucza aktywacyjnego, bez konta u nas",
         "h5": "Wyeksportuj swoją pracę z nisd2.eu i prowadź ją dalej samodzielnie",
         "h6": "Bezpośredni kontakt przez e-mail i Signal"
       }
     },
-    "whyFree": "Dlaczego za darmo: kod źródłowy jest publiczny na GitHubie na licencji AGPL-3.0. Licencja pokazałaby nam głównie to, kto korzysta z platformy. To nie jest powód, żeby wystawiać Ci fakturę.",
+    "whyFree": "Dlaczego za darmo: kod źródłowy jest otwarty na GitHubie, można go sprawdzić i uruchomić samodzielnie. Zarabiać zamierzamy na szkoleniach i doradztwie, nie na platformie.",
     "consultantFootnote": "Potrzebujesz konsultanta NIS2? Łączymy Cię ze zweryfikowanymi specjalistami bez żadnych kosztów dla Ciebie.",
     "consultantCta": "Poproś o konsultanta"
   }

--- a/messages/pricing/pl.json
+++ b/messages/pricing/pl.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Cennik - Platforma zgodności z NIS2",
-      "description": "Dwa sposoby uruchomienia platformy. Hostowana na nis2.eu, darmowa na zawsze. Hosting własny na licencji AGPL-3.0: zapłać, ile możesz, jako jednorazowa licencja dożywotnia."
+      "description": "Platforma jest darmowa, na stałe. Hostowana na nisd2.eu albo we własnym hostingu na Twojej infrastrukturze na licencji AGPL-3.0. Bez licencji, bez aktywacji, bez lock-inu."
     },
     "title": "Cennik",
-    "subtitle": "Dwa sposoby uruchomienia platformy. Wybierz jeden.",
+    "subtitle": "Darmowa, na stałe. Wybierasz tylko, kto ją uruchamia.",
     "free": {
-      "name": "Hostowana na nis2.eu",
+      "name": "Hostowana na nisd2.eu",
       "description": "Pełna platforma, obsługiwana przez nas na infrastrukturze w UE.",
       "price": "0 €",
       "priceSub": "na zawsze",
@@ -22,22 +22,25 @@
         "f7": "Nieograniczona liczba członków zespołu",
         "f8": "Rejestry ryzyk, aktywów i dostawców",
         "f9": "Wsparcie formularzy oparte na AI",
-        "f10": "Kein Lock-in. Model danych Open Source. Eksport w dowolnym momencie."
+        "f10": "Bez lock-inu. Otwarty model danych. Eksport w dowolnym momencie, także do własnego hostingu."
       }
     },
     "selfHost": {
       "name": "Hosting własny",
-      "description": "Pełny kod źródłowy. Uruchom go na własnej infrastrukturze, na zawsze.",
-      "price": "Zapłać, ile możesz",
-      "priceSub": "jednorazowo, licencja dożywotnia",
-      "cta": "Skontaktuj się z nami",
+      "description": "Pełny kod źródłowy. Na własnej infrastrukturze, na stałe.",
+      "price": "0 €",
+      "priceSub": "na zawsze",
+      "cta": "Zobacz kod źródłowy",
       "features": {
         "h1": "Pełny kod źródłowy platformy na licencji AGPL-3.0",
-        "h2": "Wszystkie przyszłe aktualizacje w cenie",
-        "h3": "Uruchom na własnej infrastrukturze, z własnymi danymi",
-        "h4": "Wyznaczona osoba kontaktowa do wsparcia przez e-mail i Signal"
+        "h2": "Wszystkie przyszłe aktualizacje w cenie, na stałe",
+        "h3": "Na własnej infrastrukturze, z własnymi danymi",
+        "h4": "Bez licencji, bez umowy, bez klucza aktywacyjnego",
+        "h5": "Wyeksportuj swoją pracę z nisd2.eu i prowadź ją dalej samodzielnie",
+        "h6": "Bezpośredni kontakt przez e-mail i Signal"
       }
     },
+    "whyFree": "Dlaczego za darmo: kod źródłowy jest publiczny na GitHubie na licencji AGPL-3.0. Licencja pokazałaby nam głównie to, kto korzysta z platformy. To nie jest powód, żeby wystawiać Ci fakturę.",
     "consultantFootnote": "Potrzebujesz konsultanta NIS2? Łączymy Cię ze zweryfikowanymi specjalistami bez żadnych kosztów dla Ciebie.",
     "consultantCta": "Poproś o konsultanta"
   }

--- a/messages/pricing/pt.json
+++ b/messages/pricing/pt.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Preços - Plataforma de Conformidade NIS2",
-      "description": "Duas formas de utilizar a plataforma. Alojada em nis2.eu, gratuita para sempre. Autoalojamento sob AGPL-3.0: pague o que puder, como pagamento único com licença vitalícia."
+      "description": "A plataforma é gratuita, de forma permanente. Alojada em nisd2.eu ou em autoalojamento na sua própria infraestrutura sob AGPL-3.0. Sem licença, sem ativação, sem lock-in."
     },
     "title": "Preços",
-    "subtitle": "Duas formas de utilizar a plataforma. Escolha uma.",
+    "subtitle": "Gratuita, de forma permanente. Só escolhe quem a opera.",
     "free": {
-      "name": "Alojada em nis2.eu",
+      "name": "Alojada em nisd2.eu",
       "description": "A plataforma completa, operada por nós em infraestrutura da UE.",
       "price": "0 €",
       "priceSub": "para sempre",
@@ -22,22 +22,25 @@
         "f7": "Membros de equipa ilimitados",
         "f8": "Registos de riscos, ativos e fornecedores",
         "f9": "Assistência ao preenchimento de formulários com IA",
-        "f10": "Kein Lock-in. Modelo de dados Open Source. Exportação a qualquer momento."
+        "f10": "Sem lock-in. Modelo de dados aberto. Exportação a qualquer momento, incluindo para autoalojamento."
       }
     },
     "selfHost": {
       "name": "Autoalojamento",
-      "description": "Código-fonte completo. Execute-o na sua própria infraestrutura, para sempre.",
-      "price": "Pague o que puder",
-      "priceSub": "pagamento único, licença vitalícia",
-      "cta": "Fale connosco",
+      "description": "Código-fonte completo. Na sua própria infraestrutura, de forma permanente.",
+      "price": "0 €",
+      "priceSub": "para sempre",
+      "cta": "Ver o código-fonte",
       "features": {
         "h1": "Código-fonte completo da plataforma sob AGPL-3.0",
-        "h2": "Todas as atualizações futuras incluídas",
-        "h3": "Execute na sua própria infraestrutura, com os seus próprios dados",
-        "h4": "Contacto designado para apoio por email e Signal"
+        "h2": "Todas as atualizações futuras incluídas, de forma permanente",
+        "h3": "Na sua própria infraestrutura, com os seus próprios dados",
+        "h4": "Sem licença, sem contrato, sem chave de ativação",
+        "h5": "Exporte o seu trabalho de nisd2.eu e continue a operá-lo por si",
+        "h6": "Contacto direto por email e Signal"
       }
     },
+    "whyFree": "Porquê gratuita: o código-fonte é público no GitHub sob AGPL-3.0. Uma licença ter-nos-ia mostrado sobretudo quem usa a plataforma. Isso não é razão para lhe enviar uma fatura.",
     "consultantFootnote": "Precisa de um consultor NIS2? Colocamo-lo em contacto com especialistas verificados, sem qualquer custo para si.",
     "consultantCta": "Pedir um consultor"
   }

--- a/messages/pricing/pt.json
+++ b/messages/pricing/pt.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Preços - Plataforma de Conformidade NIS2",
-      "description": "A plataforma é gratuita, de forma permanente. Alojada em nisd2.eu ou em autoalojamento na sua própria infraestrutura sob AGPL-3.0. Sem licença, sem ativação, sem lock-in."
+      "description": "A plataforma é gratuita, de forma permanente. Alojada em nisd2.eu ou em autoalojamento na sua própria infraestrutura, código-fonte aberto sob AGPL-3.0. Sem contrato, sem ativação, sem lock-in."
     },
     "title": "Preços",
     "subtitle": "Gratuita, de forma permanente. Só escolhe quem a opera.",
@@ -32,15 +32,15 @@
       "priceSub": "para sempre",
       "cta": "Ver o código-fonte",
       "features": {
-        "h1": "Código-fonte completo da plataforma sob AGPL-3.0",
+        "h1": "Código-fonte completo da plataforma, aberto sob AGPL-3.0",
         "h2": "Todas as atualizações futuras incluídas, de forma permanente",
         "h3": "Na sua própria infraestrutura, com os seus próprios dados",
-        "h4": "Sem licença, sem contrato, sem chave de ativação",
+        "h4": "Sem contrato, sem chave de ativação, sem conta connosco",
         "h5": "Exporte o seu trabalho de nisd2.eu e continue a operá-lo por si",
         "h6": "Contacto direto por email e Signal"
       }
     },
-    "whyFree": "Porquê gratuita: o código-fonte é público no GitHub sob AGPL-3.0. Uma licença ter-nos-ia mostrado sobretudo quem usa a plataforma. Isso não é razão para lhe enviar uma fatura.",
+    "whyFree": "Porquê gratuita: o código-fonte está aberto no GitHub, verificável e pode operá-lo por si. Contamos ganhar com formação e consultoria, não com a plataforma.",
     "consultantFootnote": "Precisa de um consultor NIS2? Colocamo-lo em contacto com especialistas verificados, sem qualquer custo para si.",
     "consultantCta": "Pedir um consultor"
   }

--- a/messages/pricing/ro.json
+++ b/messages/pricing/ro.json
@@ -2,12 +2,12 @@
   "pricing": {
     "meta": {
       "title": "Prețuri - Platformă de conformitate NIS2",
-      "description": "Două moduri de a rula platforma. Găzduită la nis2.eu, gratuit pentru totdeauna. Auto-găzduire sub AGPL-3.0: plătiți cât puteți, ca licență pe viață cu plată unică."
+      "description": "Platforma este gratuită, permanent. Găzduită la nisd2.eu sau auto-găzduită pe propria infrastructură sub AGPL-3.0. Fără licență, fără activare, fără lock-in."
     },
     "title": "Prețuri",
-    "subtitle": "Două moduri de a rula platforma. Alegeți unul.",
+    "subtitle": "Gratuită, permanent. Alegeți doar cine o operează.",
     "free": {
-      "name": "Găzduită la nis2.eu",
+      "name": "Găzduită la nisd2.eu",
       "description": "Platforma completă, operată de noi pe infrastructură din UE.",
       "price": "0 €",
       "priceSub": "pentru totdeauna",
@@ -22,22 +22,25 @@
         "f7": "Membri de echipă nelimitați",
         "f8": "Registre de riscuri, active și furnizori",
         "f9": "Asistență la formulare bazată pe AI",
-        "f10": "Kein Lock-in. Model de date Open Source. Exportați oricând."
+        "f10": "Fără lock-in. Model de date deschis. Export oricând, inclusiv către auto-găzduire."
       }
     },
     "selfHost": {
       "name": "Auto-găzduire",
-      "description": "Cod sursă complet. Rulați-l pe propria infrastructură, pentru totdeauna.",
-      "price": "Plătiți cât puteți",
-      "priceSub": "plată unică, licență pe viață",
-      "cta": "Contactați-ne",
+      "description": "Cod sursă complet. Pe propria infrastructură, permanent.",
+      "price": "0 €",
+      "priceSub": "pentru totdeauna",
+      "cta": "Vezi codul sursă",
       "features": {
         "h1": "Cod sursă complet al platformei sub AGPL-3.0",
-        "h2": "Toate actualizările viitoare incluse",
-        "h3": "Rulați pe propria infrastructură, propriile dvs. date",
-        "h4": "Persoană de contact dedicată pentru suport prin e-mail și Signal"
+        "h2": "Toate actualizările viitoare incluse, permanent",
+        "h3": "Pe propria infrastructură, cu propriile date",
+        "h4": "Fără licență, fără contract, fără cheie de activare",
+        "h5": "Exportați lucrul dvs. din nisd2.eu și continuați să îl rulați singuri",
+        "h6": "Contact direct prin e-mail și Signal"
       }
     },
+    "whyFree": "De ce este gratuită: codul sursă este public pe GitHub sub AGPL-3.0. O licență ne-ar fi arătat mai ales cine folosește platforma. Acesta nu este un motiv să vă trimitem o factură.",
     "consultantFootnote": "Aveți nevoie de un consultant NIS2? Vă punem în legătură cu specialiști verificați, fără niciun cost pentru dvs.",
     "consultantCta": "Solicită un consultant"
   }

--- a/messages/pricing/ro.json
+++ b/messages/pricing/ro.json
@@ -2,7 +2,7 @@
   "pricing": {
     "meta": {
       "title": "Prețuri - Platformă de conformitate NIS2",
-      "description": "Platforma este gratuită, permanent. Găzduită la nisd2.eu sau auto-găzduită pe propria infrastructură sub AGPL-3.0. Fără licență, fără activare, fără lock-in."
+      "description": "Platforma este gratuită, permanent. Găzduită la nisd2.eu sau auto-găzduită pe propria infrastructură, cod sursă deschis sub AGPL-3.0. Fără contract, fără activare, fără lock-in."
     },
     "title": "Prețuri",
     "subtitle": "Gratuită, permanent. Alegeți doar cine o operează.",
@@ -32,15 +32,15 @@
       "priceSub": "pentru totdeauna",
       "cta": "Vezi codul sursă",
       "features": {
-        "h1": "Cod sursă complet al platformei sub AGPL-3.0",
+        "h1": "Cod sursă complet al platformei, deschis sub AGPL-3.0",
         "h2": "Toate actualizările viitoare incluse, permanent",
         "h3": "Pe propria infrastructură, cu propriile date",
-        "h4": "Fără licență, fără contract, fără cheie de activare",
+        "h4": "Fără contract, fără cheie de activare, fără cont la noi",
         "h5": "Exportați lucrul dvs. din nisd2.eu și continuați să îl rulați singuri",
         "h6": "Contact direct prin e-mail și Signal"
       }
     },
-    "whyFree": "De ce este gratuită: codul sursă este public pe GitHub sub AGPL-3.0. O licență ne-ar fi arătat mai ales cine folosește platforma. Acesta nu este un motiv să vă trimitem o factură.",
+    "whyFree": "De ce este gratuită: codul sursă este deschis pe GitHub, verificabil și îl puteți rula singuri. Ne așteptăm să câștigăm din instruire și consultanță, nu din platformă.",
     "consultantFootnote": "Aveți nevoie de un consultant NIS2? Vă punem în legătură cu specialiști verificați, fără niciun cost pentru dvs.",
     "consultantCta": "Solicită un consultant"
   }


### PR DESCRIPTION
The self-host tier sold a one-time "pay what you can" lifetime licence. The only thing that licence really bought us was knowing who runs the platform, and that is not a reason to send anyone an invoice. Both cards are now 0 EUR forever, and the page says why in one line instead of leaving "kostenlos" naked.

## Pricing page
- `selfHost.price` / `priceSub` become 0 EUR / forever in all ten locales
- two new self-host bullets: no licence, no contract, no activation key; and the export path from the hosted instance into your own
- CTA moves from the `mailto:...?subject=Self-Host%20License` to `/open-source`
- new `whyFree` line under the cards
- DE self-host card is now "Selbstbetrieb" rather than the hyphenated "Self-Hosting"

## Fixes found on the way
- the page named the wrong domain, **nis2.eu instead of nisd2.eu**, in all ten locales
- German "Kein Lock-in." was leaking into the `f10` bullet of seven non-German locales
- `/about` still listed self-host licensing under "where we charge"
- `buildSoftwareApplicationJsonLd` declared **Apache-2.0** in structured data; the repo is AGPL-3.0

## Verified
- `/pricing`, `/en/pricing`, `/nl/prijzen`, `/about`, `/open-source` all render 200 with the new copy
- key parity across the ten `messages/pricing/*.json` files: 33 keys each
- `tsc --noEmit` clean apart from three pre-existing missing-dep errors in workspace package configs

## Not in this PR
- `public/og/pricing-{de,en,nl}.png` still show the old card and need a re-render after deploy
- the Stripe payment link with the 10.000 EUR anchor is not referenced by the site, but should be deactivated