### PR TITLE
docs: trim the search trigger to 32px

### DIFF
--- a/components/docs/DocsSearch.tsx
+++ b/components/docs/DocsSearch.tsx
@@ -106,7 +106,7 @@ export function DocsSearchTrigger() {
       // next to the full navigation tree, and a flex item shrinks past its
       // height when the column overflows. Without it the button collapsed
       // onto its own icon and label.
-      className="flex h-9 w-full shrink-0 items-center gap-2 rounded-md border border-border bg-muted/40 pl-3 pr-2.5 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-muted"
+      className="flex h-8 w-full shrink-0 items-center gap-2 rounded-md border border-border bg-muted/40 pl-3 pr-2.5 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-muted"
     >
       <Search className="size-3.5 shrink-0" aria-hidden="true" />
       <span>Search docs</span>


### PR DESCRIPTION
The search button in the docs sidebar, half a size down from 36px.

`shrink-0` stays. The collapse it prevents was the flex column squashing
the button next to the navigation tree, not the height being wrong: with
`h-10` and no `shrink-0` it rendered at roughly 24px.

Verified: 32px measured in the browser, one `[role=dialog]` on ⌘K,
typecheck clean, 135 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hP7JS91eemzhX3m1pdzuE