### PR TITLE
fix(seo,i18n): give wiki pages a next step, stop MISSING_MESSAGE 500s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ XAI_API_KEY=
 # Cron job secret (Bearer token for /api/cron/deadlines)
 CRON_SECRET=
 
+# IndexNow. Off unless set, so a self-hosted instance never pings a search
+# engine with someone else's key. When set, /api/cron/indexnow submits
+# recently-changed sitemap URLs to Bing/Yandex/Seznam/Naver, and
+# /api/indexnow-key serves the ownership key file the protocol requires.
+# Generate any 8-128 char [A-Za-z0-9-] string, e.g.
+#   openssl rand -hex 16
+# then register the host in Bing Webmaster Tools.
+# INDEXNOW_KEY=
+
 # Analytics. Off unless BOTH are set, so a self-hosted instance reports to
 # nobody by default. Point them at your own endpoint if you want pageviews.
 # Set them as build variables too if you need them on statically generated

--- a/app/[locale]/(info)/training/nis2-ceo/page.tsx
+++ b/app/[locale]/(info)/training/nis2-ceo/page.tsx
@@ -11,7 +11,7 @@ import {
   ArrowRight,
   User,
 } from "lucide-react";
-import { loadCourse } from "@/lib/training/course-loader";
+import { loadCourse, courseTotals } from "@/lib/training/course-loader";
 import { CourseOutlineList } from "@/components/training/CourseOutlineList";
 import { pageAlternates } from "@/lib/seo";
 import { ogImages } from "@/lib/og-card";
@@ -68,9 +68,10 @@ export default async function TrainingLandingPage({
 }) {
   const { locale } = await params;
   const t = await getTranslations("info");
-  const [course, learnerCount] = await Promise.all([
+  const [course, learnerCount, totals] = await Promise.all([
     loadCourse("nis2-ceo"),
     getLearnerCount(),
+    courseTotals("nis2-ceo"),
   ]);
 
   return (
@@ -115,6 +116,22 @@ export default async function TrainingLandingPage({
             {t("trainingCeo.startCourse")}
             <ArrowRight className="size-4" />
           </Link>
+          {/*
+            Scale and freedom-to-skip, stated before the click. The only
+            CTA used to be "start at lesson 0.1", which reads as a
+            12-lesson run of law before anything practical; the outline
+            below has always deep-linked every lesson, but nothing said so.
+          */}
+          <div className="flex items-center gap-2 rounded-full bg-muted/50 px-3 py-1.5 w-fit">
+            <Clock className="size-3.5 text-muted-foreground" />
+            <span className="text-xs text-muted-foreground">
+              {t("trainingCeo.courseScale", {
+                modules: totals.modules,
+                lessons: totals.lessons,
+                hours: Math.round(totals.minutes / 60),
+              })}
+            </span>
+          </div>
           {/* Learner count */}
           {learnerCount > 0 && (
             <div className="flex items-center gap-2 rounded-full bg-muted/50 px-3 py-1.5 w-fit">

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -21,13 +21,20 @@ export default async function LocaleLayout({
   const messages = await getMessages();
   // The `info` namespace holds ~1.8 MB of long-form wiki body content per
   // locale. Server components render it via getTranslations('info'); only
-  // RelatedArticles (client) reads from it, and only its footer.* +
-  // relatedArticles.* sub-trees. Keep those; drop the rest from the RSC
-  // payload so every page stops shipping the wiki bundle.
-  const info = messages.info as { footer?: unknown; relatedArticles?: unknown } | undefined;
+  // RelatedArticles and WikiNextStep (both client) read from it, and only
+  // their footer.* + relatedArticles.* + wikiNextStep.* sub-trees. Keep
+  // those; drop the rest from the RSC payload so every page stops
+  // shipping the wiki bundle. Anything added here ships to every client.
+  const info = messages.info as
+    | { footer?: unknown; relatedArticles?: unknown; wikiNextStep?: unknown }
+    | undefined;
   const clientMessages = {
     ...messages,
-    info: { footer: info?.footer, relatedArticles: info?.relatedArticles },
+    info: {
+      footer: info?.footer,
+      relatedArticles: info?.relatedArticles,
+      wikiNextStep: info?.wikiNextStep,
+    },
   };
 
   return (

--- a/app/[locale]/wiki/layout.tsx
+++ b/app/[locale]/wiki/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { PublicNav } from "@/components/PublicNav";
 import { PublicFooter } from "@/components/PublicFooter";
 import { WikiLegalDisclaimer } from "@/components/wiki/WikiLegalDisclaimer";
+import { WikiNextStep } from "@/components/wiki/WikiNextStep";
 
 export async function generateMetadata({
   params,
@@ -18,6 +19,14 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
       <PublicNav />
       <main className="wiki-content mx-auto max-w-6xl px-6 pt-16 pb-16 sm:pt-20 lg:px-0">
         {children}
+        {/*
+          Both blocks render for every wiki page from here rather than
+          per page: a next step and the disclaimer are things a new
+          article must not be able to ship without. Per-page CTA cards
+          still exist on ~36 pages and are complementary — see the
+          variant table in WikiNextStep.
+        */}
+        <WikiNextStep />
         <WikiLegalDisclaimer />
       </main>
       <PublicFooter />

--- a/app/api/cron/indexnow/route.ts
+++ b/app/api/cron/indexnow/route.ts
@@ -1,0 +1,170 @@
+/**
+ * Cron Job: IndexNow submission
+ *
+ * Pings the IndexNow endpoint with public URLs that changed recently.
+ * One submission reaches Bing, Yandex, Seznam and Naver — they share the
+ * IndexNow index. Google does not participate.
+ *
+ * Why this exists: 44% of search arrivals in the 30 days to 2026-08-31
+ * came through Bing's index (Bing 281 visitors, plus DuckDuckGo 69,
+ * Qwant 12, Ecosia 9, Brave 7, Yahoo 4 — all Bing-backed) against 502
+ * from Google. The EU B2B norm is 10-15%. Nothing in the codebase was
+ * addressing that index deliberately, and the country-status pages whose
+ * whole value is being current are exactly the pages that benefit from
+ * same-day recrawl.
+ *
+ * URL set is read back from our own /sitemap.xml rather than rebuilt
+ * here, so the submitted set cannot drift from the indexed set. Only
+ * URLs whose <lastmod> falls inside the window are sent — IndexNow is
+ * for "this changed", not "here is my whole site". Pass ?all=1 for a
+ * one-off full submission (after first setting the key, or a redesign).
+ *
+ * Security: Bearer token from CRON_SECRET env var.
+ * Schedule: daily is plenty; the endpoint is idempotent.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/env";
+import { verifyCronBearer } from "@/lib/cron/auth";
+import { getAppUrl } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+/** Protocol cap per submission. Our sitemap is ~1.7k URLs, so this is headroom. */
+const MAX_URLS = 10_000;
+const DEFAULT_WINDOW_DAYS = 7;
+
+interface SitemapUrl {
+  loc: string;
+  lastmod: string | null;
+}
+
+/**
+ * Pull <loc>/<lastmod> pairs out of our own sitemap. Deliberately a
+ * regex and not an XML parser: this is our own generated, well-formed
+ * document, and the alternate-language links are `xhtml:link` elements
+ * carrying href *attributes*, so a <loc> match cannot pick them up.
+ */
+function parseSitemap(xml: string): SitemapUrl[] {
+  const out: SitemapUrl[] = [];
+  const blocks = xml.match(/<url>[\s\S]*?<\/url>/g) ?? [];
+  for (const block of blocks) {
+    const loc = block.match(/<loc>([^<]+)<\/loc>/)?.[1];
+    if (!loc) continue;
+    const lastmod = block.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1] ?? null;
+    out.push({ loc: loc.trim(), lastmod: lastmod?.trim() ?? null });
+  }
+  return out;
+}
+
+export async function GET(req: NextRequest) {
+  if (!env.CRON_SECRET) {
+    return NextResponse.json({ error: "CRON_SECRET not configured" }, { status: 500 });
+  }
+  if (!verifyCronBearer(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const key = env.INDEXNOW_KEY;
+  if (!key) {
+    // Not an error: a self-hosted instance is expected to run without one.
+    return NextResponse.json(
+      { skipped: "INDEXNOW_KEY not configured", submitted: 0 },
+      { status: 200 },
+    );
+  }
+
+  const appUrl = getAppUrl();
+  const host = new URL(appUrl).host;
+
+  let urls: SitemapUrl[];
+  try {
+    const res = await fetch(`${appUrl}/sitemap.xml`, { cache: "no-store" });
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: `sitemap fetch failed: ${res.status}` },
+        { status: 502 },
+      );
+    }
+    urls = parseSitemap(await res.text());
+  } catch (err) {
+    return NextResponse.json(
+      { error: "sitemap fetch failed", detail: String(err) },
+      { status: 502 },
+    );
+  }
+
+  const submitAll = req.nextUrl.searchParams.get("all") === "1";
+  const windowDays = Number(
+    req.nextUrl.searchParams.get("days") ?? DEFAULT_WINDOW_DAYS,
+  );
+  const cutoff = Date.now() - windowDays * 24 * 60 * 60 * 1000;
+
+  const selected = urls.filter((u) => {
+    if (submitAll) return true;
+    if (!u.lastmod) return false;
+    const t = Date.parse(u.lastmod);
+    return Number.isFinite(t) && t >= cutoff;
+  });
+
+  // Same-host only: IndexNow rejects a submission whose urlList contains
+  // a URL outside the declared host, and rejects the whole batch with it.
+  const urlList = selected
+    .map((u) => u.loc)
+    .filter((loc) => {
+      try {
+        return new URL(loc).host === host;
+      } catch {
+        return false;
+      }
+    })
+    .slice(0, MAX_URLS);
+
+  if (urlList.length === 0) {
+    return NextResponse.json({
+      submitted: 0,
+      note: submitAll
+        ? "sitemap returned no same-host URLs"
+        : `nothing changed in the last ${windowDays} days`,
+    });
+  }
+
+  const body = {
+    host,
+    key,
+    keyLocation: `${appUrl}/api/indexnow-key`,
+    urlList,
+  };
+
+  let status: number;
+  let text: string;
+  try {
+    const res = await fetch(INDEXNOW_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(body),
+    });
+    status = res.status;
+    text = await res.text();
+  } catch (err) {
+    return NextResponse.json(
+      { error: "indexnow submission failed", detail: String(err) },
+      { status: 502 },
+    );
+  }
+
+  // 200 accepted, 202 accepted-pending-key-validation. Anything else is
+  // surfaced verbatim so a bad key or host mismatch is visible in logs
+  // rather than silently succeeding.
+  const ok = status === 200 || status === 202;
+  return NextResponse.json(
+    {
+      submitted: ok ? urlList.length : 0,
+      indexnowStatus: status,
+      indexnowBody: text.slice(0, 500),
+      window: submitAll ? "all" : `${windowDays}d`,
+      sitemapUrls: urls.length,
+    },
+    { status: ok ? 200 : 502 },
+  );
+}

--- a/app/api/indexnow-key/route.ts
+++ b/app/api/indexnow-key/route.ts
@@ -1,0 +1,39 @@
+/**
+ * IndexNow ownership key file.
+ *
+ * The IndexNow protocol proves you control a host by serving the key as
+ * plain text somewhere on that host, and naming that location as
+ * `keyLocation` in the submission. The spec's default location is
+ * `https://<host>/<key>.txt`; a custom `keyLocation` is explicitly
+ * allowed and is what we use, because a literal `<key>.txt` file would
+ * have to be committed to `public/` — baking one deployment's key into
+ * an open-source repo every self-hoster clones.
+ *
+ * Returns 404 when INDEXNOW_KEY is unset so a self-hosted instance
+ * exposes nothing by default.
+ *
+ * Security: the key is not a secret in the confidentiality sense — it is
+ * published by design, and its only power is "may submit URLs for this
+ * host to a search index". It is still per-deployment.
+ */
+import { NextResponse } from "next/server";
+import { env } from "@/lib/env";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const key = env.INDEXNOW_KEY;
+  if (!key) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+  return new NextResponse(key, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      // The verifier fetches this right after a submission; a stale CDN
+      // copy after a key rotation would fail every submission until it
+      // expired.
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/components/wiki/WikiNextStep.tsx
+++ b/components/wiki/WikiNextStep.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ArrowRight, CalendarClock, MessageSquare, ShieldQuestion } from "lucide-react";
+import { Link, usePathname } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The "what now?" strip under every wiki page.
+ *
+ * Rendered once from app/[locale]/wiki/layout.tsx so a new page cannot
+ * ship without a next step. Before this existed the CTA was hand-written
+ * per page and coverage ran inverse to traffic: zeit-und-status (45% of
+ * wiki traffic, 756 visitors/month) carried one CTA across 32 pages,
+ * while troubleshooting (0.8% of traffic) carried six across eight.
+ *
+ * The variant is picked from the canonical category segment. next-intl's
+ * usePathname() returns the INTERNAL pathname — the German-key form —
+ * whatever locale is being viewed, so matching on the WIKI_TOP_LEVEL
+ * keys works in all ten locales without pulling the 1,196-line TOC into
+ * the client bundle.
+ */
+
+type Variant = "timeline" | "advice" | "scope";
+
+/**
+ * Categories whose pages already carry a bespoke, page-specific CTA card
+ * to /applicability (troubleshooting 6 of 8 pages, recht-und-folgen 6 of
+ * 9) send the strip to /start instead, so it complements the card above
+ * it rather than repeating the same ask twice.
+ */
+const VARIANT_BY_CATEGORY: Record<string, Variant> = {
+  "zeit-und-status": "timeline",
+  troubleshooting: "advice",
+  "recht-und-folgen": "advice",
+};
+
+const HREF = {
+  timeline: "/applicability",
+  scope: "/applicability",
+  advice: "/start",
+} as const;
+
+const ICON = {
+  timeline: CalendarClock,
+  scope: ShieldQuestion,
+  advice: MessageSquare,
+} as const;
+
+export function WikiNextStep() {
+  const pathname = usePathname();
+  const t = useTranslations("info.wikiNextStep");
+
+  // "/wiki/<category>/<slug>" → segment 2. The hub and the category
+  // indexes have no category segment and fall through to "scope", which
+  // is the right ask for someone still browsing.
+  const category = pathname.split("/")[2] ?? "";
+  const variant = VARIANT_BY_CATEGORY[category] ?? "scope";
+  const Icon = ICON[variant];
+
+  return (
+    <aside
+      className="mt-10 flex flex-col gap-4 rounded-lg border bg-card p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+      aria-labelledby="wiki-next-step-heading"
+    >
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+        <div className="space-y-1">
+          <p id="wiki-next-step-heading" className="text-sm font-semibold">
+            {t(`${variant}.heading`)}
+          </p>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {t(`${variant}.body`)}
+          </p>
+        </div>
+      </div>
+      <Button asChild className="shrink-0 self-start sm:self-auto">
+        <Link href={HREF[variant]}>
+          {t(`${variant}.cta`)}
+          <ArrowRight className="size-4" aria-hidden="true" />
+        </Link>
+      </Button>
+    </aside>
+  );
+}

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -52,33 +52,102 @@ const namespaces = [
   "vulnerabilities",
 ] as const;
 
+type Messages = Record<string, unknown>;
+
+// Newly added locales (fr/it/es/pl) do not yet have every namespace
+// translated (the wiki `info` namespace is curated separately). Fall back
+// to English per-namespace so a partial locale renders instead of 500ing.
+async function load(ns: string, locale: string): Promise<Messages> {
+  try {
+    return (await import(`../messages/${ns}/${locale}.json`)).default;
+  } catch (err) {
+    // Only fall back for a genuinely-absent namespace file; surface real
+    // errors (e.g. malformed JSON) instead of silently serving English.
+    const message = (err instanceof Error ? err.message : "").toLowerCase();
+    const missing =
+      message.includes("cannot find module") ||
+      message.includes("module not found") ||
+      message.includes("failed to resolve");
+    if (!missing) throw err;
+    return (await import(`../messages/${ns}/en.json`)).default;
+  }
+}
+
+function isPlainObject(value: unknown): value is Messages {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  );
+}
+
+/**
+ * Fill the holes in `primary` from `fallback`, key by key, at every depth.
+ * `primary` always wins where it has a value; an array in `primary` is
+ * taken whole rather than merged element-wise.
+ *
+ * Why this exists on top of the per-file fallback above: that one only
+ * catches a namespace file that is entirely absent. A file that EXISTS
+ * but is missing individual keys still throws MISSING_MESSAGE at render
+ * time, which is a 500 on a real page, not a cosmetic gap. That was live:
+ * `info.footer.partners` was absent in cs/es/fr/it/pl/pt/ro while
+ * PublicFooter read it unconditionally, so every page in those seven
+ * locales threw. An audit on 2026-09-01 found 553 such keys across the
+ * message set — `info.nis2Events.*` in seven locales (a public wiki
+ * page), `requirements.AI-DOC_*` in it/es, `portal.journey` in es,
+ * `info.*` and `funnel.*` in nl, and the whole `newsletter` namespace
+ * missing for seven locales.
+ *
+ * Filling from English makes a missing key degrade to English text
+ * instead of an exception, and stops the next one from being an incident.
+ * It does NOT make the gaps acceptable — those 553 keys are still
+ * untranslated and now render English. This is the floor, not the goal.
+ */
+function fillMissing(fallback: unknown, primary: unknown): unknown {
+  if (!isPlainObject(fallback) || !isPlainObject(primary)) {
+    return primary === undefined ? fallback : primary;
+  }
+  const out: Messages = { ...primary };
+  for (const [key, value] of Object.entries(fallback)) {
+    out[key] = key in primary ? fillMissing(value, primary[key]) : value;
+  }
+  return out;
+}
+
+/**
+ * Merged messages are identical for every request in a locale, and the
+ * merge walks ~2 MB of `info` content, so it runs once per locale per
+ * process. Disabled outside production so editing a message file in dev
+ * still hot-reloads.
+ */
+const mergedCache =
+  process.env.NODE_ENV === "production" ? new Map<string, Messages>() : null;
+
+async function messagesFor(locale: string): Promise<Messages> {
+  const cached = mergedCache?.get(locale);
+  if (cached) return cached;
+
+  const own = Object.assign(
+    {},
+    ...(await Promise.all(namespaces.map((ns) => load(ns, locale)))),
+  ) as Messages;
+
+  let messages = own;
+  if (locale !== "en") {
+    const english = Object.assign(
+      {},
+      ...(await Promise.all(namespaces.map((ns) => load(ns, "en")))),
+    ) as Messages;
+    messages = fillMissing(english, own) as Messages;
+  }
+
+  mergedCache?.set(locale, messages);
+  return messages;
+}
+
 export default getRequestConfig(async ({ requestLocale }) => {
   const requested = await requestLocale;
   const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;
 
-  // Newly added locales (fr/it/es/pl) do not yet have every namespace
-  // translated (the wiki `info` namespace is curated separately). Fall back
-  // to English per-namespace so a partial locale renders instead of 500ing.
-  async function load(ns: string): Promise<Record<string, unknown>> {
-    try {
-      return (await import(`../messages/${ns}/${locale}.json`)).default;
-    } catch (err) {
-      // Only fall back for a genuinely-absent namespace file; surface real
-      // errors (e.g. malformed JSON) instead of silently serving English.
-      const message = (err instanceof Error ? err.message : "").toLowerCase();
-      const missing =
-        message.includes("cannot find module") ||
-        message.includes("module not found") ||
-        message.includes("failed to resolve");
-      if (!missing) throw err;
-      return (await import(`../messages/${ns}/en.json`)).default;
-    }
-  }
-
-  const modules = await Promise.all(namespaces.map((ns) => load(ns)));
-  const messages = Object.assign({}, ...modules);
-
-  return { locale, messages };
+  return { locale, messages: await messagesFor(locale) };
 });

--- a/lib/content/legacy-redirects.ts
+++ b/lib/content/legacy-redirects.ts
@@ -14,7 +14,11 @@
  * one per locale — pointing OLD locale slug → NEW localized /docs path.
  */
 
-import { wikiLegacyRedirects, docsToWikiRedirects } from "./wiki-toc";
+import {
+  wikiLegacyRedirects,
+  docsToWikiRedirects,
+  localizedWikiSlugRedirects,
+} from "./wiki-toc";
 
 export interface LegacyRedirect {
   source: string;
@@ -25,4 +29,7 @@ export interface LegacyRedirect {
 export const LEGACY_REDIRECTS: LegacyRedirect[] = [
   ...wikiLegacyRedirects(),
   ...docsToWikiRedirects(),
+  // pl/ro/fr/it moved off English slugs onto localized ones; the English
+  // URLs they were indexed on still have to resolve.
+  ...localizedWikiSlugRedirects(),
 ];

--- a/lib/content/wiki-slugs-extra.ts
+++ b/lib/content/wiki-slugs-extra.ts
@@ -1,0 +1,396 @@
+/**
+ * Localized wiki URL slugs for the locales beyond de/en/nl.
+ *
+ * Why this file exists, separately from wiki-toc.ts:
+ *
+ * All ten locales already ship complete wiki translations (~2 MB of
+ * messages/info/<locale>.json each), but only de/en/nl ever had localized
+ * URL slugs — `fill()` in i18n/routing.ts silently handed the other seven
+ * the English slug. So an Italian reader got Italian prose at
+ * /it/wiki/timelines-and-status/nis2-eu-tracker: translated content on an
+ * English URL, which is the half of the investment that search engines
+ * and human readers both see first.
+ *
+ * Coverage is deliberately partial and prioritised by traffic, not
+ * completeness:
+ *   - ALL nine category slugs, for all four locales. The category sits in
+ *     every wiki URL, so this is the highest-leverage 36 strings here.
+ *   - ALL 32 zeit-und-status entries. That category is 45% of wiki
+ *     traffic (756 visitors in the 30 days to 2026-08-31) and its slugs
+ *     are formulaic country names.
+ *   - The highest-traffic entries from the other categories.
+ *
+ * Everything absent from here keeps inheriting the English slug exactly
+ * as before — that is the documented `fill()` fallback, not a bug. Add
+ * entries as native speakers review them; nothing breaks in the meantime.
+ *
+ * Slugs are ASCII-folded on purpose (wdrozenie, not wdrożenie;
+ * comparatie, not comparație). Percent-encoded non-ASCII in a URL is
+ * legal but reads as noise when shared in a Teams message or pasted into
+ * a document, which is how 54 visitors/month reach this site.
+ *
+ * ANY change to a slug already in this file moves a live, indexed URL.
+ * localizedWikiSlugRedirects() in wiki-toc.ts emits a 301 for every entry
+ * whose localized slug differs from the English one, so the old URL keeps
+ * working — but that only helps if the OLD value stays derivable. Prefer
+ * adding over editing.
+ */
+
+import type { WikiTopLevel } from "./wiki-toc";
+
+/** Locales that gained slugs after de/en/nl. */
+export const EXTRA_SLUG_LOCALES = ["pl", "ro", "fr", "it"] as const;
+export type ExtraSlugLocale = (typeof EXTRA_SLUG_LOCALES)[number];
+
+type Extra = Partial<Record<ExtraSlugLocale, string>>;
+
+/** Category slug per locale. Present in every wiki URL under it. */
+export const EXTRA_CATEGORY_SLUGS: Record<WikiTopLevel, Extra> = {
+  anwendungsbereich: {
+    pl: "zakres-stosowania",
+    ro: "domeniu-de-aplicare",
+    fr: "champ-d-application",
+    it: "ambito-di-applicazione",
+  },
+  sektoren: { pl: "sektory", ro: "sectoare", fr: "secteurs", it: "settori" },
+  grundlagen: {
+    pl: "podstawy",
+    ro: "notiuni-de-baza",
+    fr: "fondamentaux",
+    it: "fondamenti",
+  },
+  umsetzung: {
+    pl: "wdrozenie",
+    ro: "implementare",
+    fr: "mise-en-oeuvre",
+    it: "attuazione",
+  },
+  "recht-und-folgen": {
+    pl: "prawo-i-konsekwencje",
+    ro: "drept-si-consecinte",
+    fr: "droit-et-consequences",
+    it: "diritto-e-conseguenze",
+  },
+  vergleich: {
+    pl: "porownanie",
+    ro: "comparatie",
+    fr: "comparaison",
+    it: "confronto",
+  },
+  // Universal term — same in all four, listed so the map is exhaustive
+  // and a reader does not have to wonder whether it was forgotten.
+  "open-source": {
+    pl: "open-source",
+    ro: "open-source",
+    fr: "open-source",
+    it: "open-source",
+  },
+  "zeit-und-status": {
+    pl: "terminy-i-status",
+    ro: "termene-si-status",
+    fr: "calendrier-et-statut",
+    it: "scadenze-e-stato",
+  },
+  troubleshooting: {
+    pl: "rozwiazywanie-problemow",
+    ro: "depanare",
+    fr: "resolution-de-problemes",
+    it: "risoluzione-dei-problemi",
+  },
+};
+
+/**
+ * Entry slugs, keyed by the canonical (German) slug from WIKI_TOC.
+ *
+ * Omissions are intentional where the English slug is already the term
+ * every language uses: regulation and standard identifiers
+ * (cir-2024-2690, nis2-iso-27001), institutional acronyms
+ * (enisa-tig-nis2), and the German transposition act's own name
+ * (nis2umsucg). Translating those would make them harder to find, not
+ * easier.
+ */
+export const EXTRA_ENTRY_SLUGS: Record<string, Extra> = {
+  // ── zeit-und-status — 45% of wiki traffic, localized in full ────────
+  "nis2-timeline": {
+    pl: "harmonogram-nis2",
+    ro: "calendar-nis2",
+    fr: "calendrier-nis2",
+    it: "cronologia-nis2",
+  },
+  "nis2-events": {
+    pl: "wydarzenia-nis2",
+    ro: "evenimente-nis2",
+    fr: "evenements-nis2",
+    it: "eventi-nis2",
+  },
+  "nis2-in-germany": {
+    pl: "nis2-w-niemczech",
+    ro: "nis2-in-germania",
+    fr: "nis2-en-allemagne",
+    it: "nis2-in-germania",
+  },
+  "nis2-umsetzung-europa": {
+    pl: "wdrozenie-nis2-w-ue",
+    ro: "implementarea-nis2-in-ue",
+    fr: "mise-en-oeuvre-nis2-dans-l-ue",
+    it: "attuazione-nis2-nell-ue",
+  },
+  "nis2-tracker-eu": {
+    pl: "tracker-nis2-ue",
+    ro: "tracker-nis2-ue",
+    fr: "suivi-nis2-ue",
+    it: "tracker-nis2-ue",
+  },
+  "nis2-status-niederlande": {
+    pl: "nis2-status-holandia",
+    ro: "nis2-status-olanda",
+    fr: "nis2-statut-pays-bas",
+    it: "nis2-stato-paesi-bassi",
+  },
+  "nis2-status-oesterreich": {
+    pl: "nis2-status-austria",
+    ro: "nis2-status-austria",
+    fr: "nis2-statut-autriche",
+    it: "nis2-stato-austria",
+  },
+  "nis2-status-frankreich": {
+    pl: "nis2-status-francja",
+    ro: "nis2-status-franta",
+    fr: "nis2-statut-france",
+    it: "nis2-stato-francia",
+  },
+  "nis2-status-spanien": {
+    pl: "nis2-status-hiszpania",
+    ro: "nis2-status-spania",
+    fr: "nis2-statut-espagne",
+    it: "nis2-stato-spagna",
+  },
+  "nis2-status-italien": {
+    pl: "nis2-status-wlochy",
+    ro: "nis2-status-italia",
+    fr: "nis2-statut-italie",
+    it: "nis2-stato-italia",
+  },
+  "nis2-status-belgien": {
+    pl: "nis2-status-belgia",
+    ro: "nis2-status-belgia",
+    fr: "nis2-statut-belgique",
+    it: "nis2-stato-belgio",
+  },
+  "nis2-status-polen": {
+    pl: "nis2-status-polska",
+    ro: "nis2-status-polonia",
+    fr: "nis2-statut-pologne",
+    it: "nis2-stato-polonia",
+  },
+  "nis2-status-schweden": {
+    pl: "nis2-status-szwecja",
+    ro: "nis2-status-suedia",
+    fr: "nis2-statut-suede",
+    it: "nis2-stato-svezia",
+  },
+  "nis2-status-daenemark": {
+    pl: "nis2-status-dania",
+    ro: "nis2-status-danemarca",
+    fr: "nis2-statut-danemark",
+    it: "nis2-stato-danimarca",
+  },
+  "nis2-status-portugal": {
+    pl: "nis2-status-portugalia",
+    ro: "nis2-status-portugalia",
+    fr: "nis2-statut-portugal",
+    it: "nis2-stato-portogallo",
+  },
+  "nis2-status-irland": {
+    pl: "nis2-status-irlandia",
+    ro: "nis2-status-irlanda",
+    fr: "nis2-statut-irlande",
+    it: "nis2-stato-irlanda",
+  },
+  "nis2-status-tschechien": {
+    pl: "nis2-status-czechy",
+    ro: "nis2-status-cehia",
+    fr: "nis2-statut-republique-tcheque",
+    it: "nis2-stato-repubblica-ceca",
+  },
+  "nis2-status-ungarn": {
+    pl: "nis2-status-wegry",
+    ro: "nis2-status-ungaria",
+    fr: "nis2-statut-hongrie",
+    it: "nis2-stato-ungheria",
+  },
+  "nis2-status-rumaenien": {
+    pl: "nis2-status-rumunia",
+    ro: "nis2-status-romania",
+    fr: "nis2-statut-roumanie",
+    it: "nis2-stato-romania",
+  },
+  "nis2-status-griechenland": {
+    pl: "nis2-status-grecja",
+    ro: "nis2-status-grecia",
+    fr: "nis2-statut-grece",
+    it: "nis2-stato-grecia",
+  },
+  "nis2-status-slowakei": {
+    pl: "nis2-status-slowacja",
+    ro: "nis2-status-slovacia",
+    fr: "nis2-statut-slovaquie",
+    it: "nis2-stato-slovacchia",
+  },
+  "nis2-status-bulgarien": {
+    pl: "nis2-status-bulgaria",
+    ro: "nis2-status-bulgaria",
+    fr: "nis2-statut-bulgarie",
+    it: "nis2-stato-bulgaria",
+  },
+  "nis2-status-kroatien": {
+    pl: "nis2-status-chorwacja",
+    ro: "nis2-status-croatia",
+    fr: "nis2-statut-croatie",
+    it: "nis2-stato-croazia",
+  },
+  "nis2-status-luxemburg": {
+    pl: "nis2-status-luksemburg",
+    ro: "nis2-status-luxemburg",
+    fr: "nis2-statut-luxembourg",
+    it: "nis2-stato-lussemburgo",
+  },
+  "nis2-status-slowenien": {
+    pl: "nis2-status-slowenia",
+    ro: "nis2-status-slovenia",
+    fr: "nis2-statut-slovenie",
+    it: "nis2-stato-slovenia",
+  },
+  "nis2-status-zypern": {
+    pl: "nis2-status-cypr",
+    ro: "nis2-status-cipru",
+    fr: "nis2-statut-chypre",
+    it: "nis2-stato-cipro",
+  },
+  "nis2-status-estland": {
+    pl: "nis2-status-estonia",
+    ro: "nis2-status-estonia",
+    fr: "nis2-statut-estonie",
+    it: "nis2-stato-estonia",
+  },
+  "nis2-status-litauen": {
+    pl: "nis2-status-litwa",
+    ro: "nis2-status-lituania",
+    fr: "nis2-statut-lituanie",
+    it: "nis2-stato-lituania",
+  },
+  "nis2-status-lettland": {
+    pl: "nis2-status-lotwa",
+    ro: "nis2-status-letonia",
+    fr: "nis2-statut-lettonie",
+    it: "nis2-stato-lettonia",
+  },
+  "nis2-status-malta": {
+    pl: "nis2-status-malta",
+    ro: "nis2-status-malta",
+    fr: "nis2-statut-malte",
+    it: "nis2-stato-malta",
+  },
+  "nis2-status-finnland": {
+    pl: "nis2-status-finlandia",
+    ro: "nis2-status-finlanda",
+    fr: "nis2-statut-finlande",
+    it: "nis2-stato-finlandia",
+  },
+  // nis2umsucg: the German transposition act's own short name. Left on
+  // the English slug in every locale on purpose — it is a proper noun.
+
+  // ── umsetzung — second-largest category (290 visitors) ──────────────
+  "nis2-roadmap": {
+    pl: "mapa-drogowa-nis2",
+    ro: "foaie-de-parcurs-nis2",
+    fr: "feuille-de-route-nis2",
+    it: "roadmap-nis2",
+  },
+  "nis2-requirements": {
+    pl: "wymagania-nis2",
+    ro: "cerinte-nis2",
+    fr: "exigences-nis2",
+    it: "requisiti-nis2",
+  },
+  "nis2-meldepflicht": {
+    pl: "obowiazek-zgloszenia-nis2",
+    ro: "obligatia-de-raportare-nis2",
+    fr: "obligation-de-notification-nis2",
+    it: "obbligo-di-notifica-nis2",
+  },
+  "nis2-documents": {
+    pl: "dokumenty-nis2",
+    ro: "documente-nis2",
+    fr: "documents-nis2",
+    it: "documenti-nis2",
+  },
+  "nis2-zugriffskontrolle": {
+    pl: "kontrola-dostepu-nis2",
+    ro: "controlul-accesului-nis2",
+    fr: "controle-d-acces-nis2",
+    it: "controllo-degli-accessi-nis2",
+  },
+  "nis2-backup-strategie": {
+    pl: "strategia-kopii-zapasowych-nis2",
+    ro: "strategie-de-backup-nis2",
+    fr: "strategie-de-sauvegarde-nis2",
+    it: "strategia-di-backup-nis2",
+  },
+
+  // ── grundlagen ─────────────────────────────────────────────────────
+  "what-is-nis2": {
+    pl: "czym-jest-nis2",
+    ro: "ce-este-nis2",
+    fr: "qu-est-ce-que-nis2",
+    it: "cos-e-nis2",
+  },
+
+  // ── anwendungsbereich ──────────────────────────────────────────────
+  "bin-ich-cloud-anbieter-nis2": {
+    pl: "czy-jestem-dostawca-chmury-nis2",
+    ro: "sunt-furnizor-de-cloud-nis2",
+    fr: "suis-je-fournisseur-cloud-nis2",
+    it: "sono-un-fornitore-cloud-nis2",
+  },
+  "bin-ich-msp-managed-service-provider": {
+    pl: "czy-jestem-msp-nis2",
+    ro: "sunt-msp-nis2",
+    fr: "suis-je-msp-nis2",
+    it: "sono-un-msp-nis2",
+  },
+  "nis2-einrichtungen": {
+    pl: "podmioty-nis2",
+    ro: "entitati-nis2",
+    fr: "entites-nis2",
+    it: "soggetti-nis2",
+  },
+  "bin-ich-vertrauensdiensteanbieter-nis2": {
+    pl: "czy-jestem-dostawca-uslug-zaufania-nis2",
+    ro: "sunt-prestator-de-servicii-de-incredere-nis2",
+    fr: "suis-je-prestataire-de-services-de-confiance-nis2",
+    it: "sono-un-prestatore-di-servizi-fiduciari-nis2",
+  },
+
+  // ── sektoren ───────────────────────────────────────────────────────
+  "nis2-lebensmittel": {
+    pl: "nis2-zywnosc",
+    ro: "nis2-alimente",
+    fr: "nis2-agroalimentaire",
+    it: "nis2-alimentare",
+  },
+  "nis2-gesundheitswesen": {
+    pl: "nis2-ochrona-zdrowia",
+    ro: "nis2-sanatate",
+    fr: "nis2-sante",
+    it: "nis2-sanita",
+  },
+
+  // ── recht-und-folgen ───────────────────────────────────────────────
+  geschaftsfuhrerhaftung: {
+    pl: "odpowiedzialnosc-zarzadu-nis2",
+    ro: "raspunderea-conducerii-nis2",
+    fr: "responsabilite-des-dirigeants-nis2",
+    it: "responsabilita-degli-amministratori-nis2",
+  },
+};

--- a/lib/content/wiki-toc.ts
+++ b/lib/content/wiki-toc.ts
@@ -22,6 +22,11 @@
  */
 
 import { isPublished } from "./wiki-publish-schedule";
+import {
+  EXTRA_CATEGORY_SLUGS,
+  EXTRA_ENTRY_SLUGS,
+  EXTRA_SLUG_LOCALES,
+} from "./wiki-slugs-extra";
 
 export const WIKI_TOP_LEVEL = [
   "anwendungsbereich",
@@ -41,6 +46,32 @@ export interface PerLocaleSlug {
   de: string;
   en: string;
   nl: string;
+  /**
+   * Locales that gained slugs later. Optional: an absent value falls back
+   * to `en`, which is what every one of these locales did for all of its
+   * URLs before wiki-slugs-extra.ts existed. Populated at module load by
+   * the merge below — authored in lib/content/wiki-slugs-extra.ts, not
+   * inline here, so the ~200 added strings stay reviewable in one place.
+   */
+  pl?: string;
+  ro?: string;
+  fr?: string;
+  it?: string;
+}
+
+/** Locales that can carry a distinct URL slug. Others resolve to `en`. */
+export const SLUG_LOCALES = ["de", "en", "nl", "pl", "ro", "fr", "it"] as const;
+export type SlugLocale = (typeof SLUG_LOCALES)[number];
+
+/**
+ * The slug this locale should use, falling back to English. The fallback
+ * is load-bearing: es/cs/pt have full content translations but no slugs
+ * yet, and locales absent from PerLocaleSlug must resolve to something.
+ */
+export function slugFor(slugs: PerLocaleSlug, locale: string): string {
+  return (SLUG_LOCALES as readonly string[]).includes(locale)
+    ? (slugs[locale as SlugLocale] ?? slugs.en)
+    : slugs.en;
 }
 
 /**
@@ -1030,6 +1061,25 @@ export const WIKI_TOC: Record<WikiTopLevel, WikiCategoryMeta> = {
   },
 };
 
+// ── Late-locale slug merge ──────────────────────────────────────────
+
+/**
+ * Fold the pl/ro/fr/it slugs from wiki-slugs-extra.ts into the TOC once,
+ * at module load, so every consumer (pathnames, sitemap, JSON-LD,
+ * breadcrumbs, redirects) sees one populated shape rather than each
+ * having to remember a second lookup.
+ *
+ * Mutating the literal is deliberate: the alternative is a parallel
+ * "resolved TOC" export that half the callers would forget to use.
+ */
+for (const cat of WIKI_TOP_LEVEL) {
+  const meta = WIKI_TOC[cat];
+  Object.assign(meta.slugs, EXTRA_CATEGORY_SLUGS[cat] ?? {});
+  for (const entry of meta.entries) {
+    Object.assign(entry.slugs, EXTRA_ENTRY_SLUGS[entry.slug] ?? {});
+  }
+}
+
 // ── Derivation helpers ──────────────────────────────────────────────
 
 /** All entries in a category, filtered to those whose publishAt has elapsed (or who have no publishAt). */
@@ -1063,23 +1113,35 @@ export function topLevelSummary(): Array<WikiCategoryMeta & { count: number }> {
  * (used for `<Link href="...">`) is always the German-slug path.
  */
 export function wikiPathnames(): Record<string, PerLocaleSlug> {
-  const result: Record<string, PerLocaleSlug> = {
-    "/wiki": { de: "/wiki", en: "/wiki", nl: "/wiki" },
+  /**
+   * Build the per-locale path for one category, optionally with an entry
+   * under it. Every locale in SLUG_LOCALES gets an explicit value;
+   * es/cs/pt are not in that list and are filled from `en` by `fill()`
+   * in i18n/routing.ts, exactly as before.
+   */
+  const paths = (
+    catSlugs: PerLocaleSlug,
+    entrySlugs?: PerLocaleSlug,
+  ): PerLocaleSlug => {
+    const out = {} as Record<SlugLocale, string>;
+    for (const loc of SLUG_LOCALES) {
+      const cat = slugFor(catSlugs, loc);
+      out[loc] = entrySlugs
+        ? `/wiki/${cat}/${slugFor(entrySlugs, loc)}`
+        : `/wiki/${cat}`;
+    }
+    return out;
   };
+
+  const hub = {} as Record<SlugLocale, string>;
+  for (const loc of SLUG_LOCALES) hub[loc] = "/wiki";
+  const result: Record<string, PerLocaleSlug> = { "/wiki": hub };
 
   for (const cat of WIKI_TOP_LEVEL) {
     const meta = WIKI_TOC[cat];
-    result[`/wiki/${cat}`] = {
-      de: `/wiki/${meta.slugs.de}`,
-      en: `/wiki/${meta.slugs.en}`,
-      nl: `/wiki/${meta.slugs.nl}`,
-    };
+    result[`/wiki/${cat}`] = paths(meta.slugs);
     for (const entry of meta.entries) {
-      result[`/wiki/${cat}/${entry.slug}`] = {
-        de: `/wiki/${meta.slugs.de}/${entry.slugs.de}`,
-        en: `/wiki/${meta.slugs.en}/${entry.slugs.en}`,
-        nl: `/wiki/${meta.slugs.nl}/${entry.slugs.nl}`,
-      };
+      result[`/wiki/${cat}/${entry.slug}`] = paths(meta.slugs, entry.slugs);
     }
   }
 
@@ -1190,6 +1252,54 @@ export function wikiLegacyRedirects(): Array<{
           permanent: true,
         },
       );
+    }
+  }
+  return out;
+}
+
+/**
+ * Redirects for the pl/ro/fr/it slug localization.
+ *
+ * Those four locales served fully translated content on English URLs
+ * until wiki-slugs-extra.ts landed — /it/wiki/timelines-and-status/
+ * nis2-eu-tracker was a real, crawlable, indexed page. Giving them real
+ * slugs MOVES those URLs, so each one needs a 301 or the ranking built
+ * up on it is thrown away.
+ *
+ * Emitted only where the localized slug actually differs from the
+ * English one; identical values would produce a self-redirect loop.
+ * Locales without slugs (es/cs/pt) never move and appear nowhere here.
+ */
+export function localizedWikiSlugRedirects(): Array<{
+  source: string;
+  destination: string;
+  permanent: boolean;
+}> {
+  const out: Array<{ source: string; destination: string; permanent: boolean }> = [];
+  for (const cat of WIKI_TOP_LEVEL) {
+    const meta = WIKI_TOC[cat];
+    for (const loc of EXTRA_SLUG_LOCALES) {
+      const oldCat = meta.slugs.en;
+      const newCat = slugFor(meta.slugs, loc);
+
+      if (newCat !== oldCat) {
+        out.push({
+          source: `/${loc}/wiki/${oldCat}`,
+          destination: `/${loc}/wiki/${newCat}`,
+          permanent: true,
+        });
+      }
+
+      for (const entry of meta.entries) {
+        const oldSlug = entry.slugs.en;
+        const newSlug = slugFor(entry.slugs, loc);
+        if (newCat === oldCat && newSlug === oldSlug) continue;
+        out.push({
+          source: `/${loc}/wiki/${oldCat}/${oldSlug}`,
+          destination: `/${loc}/wiki/${newCat}/${newSlug}`,
+          permanent: true,
+        });
+      }
     }
   }
   return out;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -46,6 +46,18 @@ const envSchema = z.object({
   // Cron — optional
   CRON_SECRET: z.string().optional(),
 
+  // IndexNow — optional. When set, /api/cron/indexnow submits the public
+  // URL set to the IndexNow endpoint (Bing, Yandex, Seznam, Naver share
+  // one index), and /api/indexnow-key serves the ownership key file the
+  // protocol requires. Unset on a self-hosted instance means no
+  // submission and no key file, which is the correct default: a
+  // self-hoster must not ping search engines with someone else's key.
+  // Must be 8–128 hex-ish characters per the IndexNow spec.
+  INDEXNOW_KEY: z
+    .string()
+    .regex(/^[A-Za-z0-9-]{8,128}$/, "INDEXNOW_KEY must be 8-128 chars of [A-Za-z0-9-]")
+    .optional(),
+
   // App URL
   NEXT_PUBLIC_APP_URL: z.string().default("https://www.nisd2.eu"),
 

--- a/lib/training/course-loader.ts
+++ b/lib/training/course-loader.ts
@@ -45,6 +45,34 @@ export async function loadLesson(
 }
 
 /**
+ * Module / lesson / minute totals for a course.
+ *
+ * The landing page states the whole commitment up front. Analytics for
+ * the 30 days to 2026-08-31 showed 80 visitors on the NIS 2 for CEOs
+ * landing page, 27 opening lesson 0.1 and 7 reaching the last lesson —
+ * and lessons 5.1/5.2 (7 each) outdrawing every lesson in module 4 (a
+ * flat 4), i.e. people skipping to the end. Both patterns point at
+ * "how big is this and can I start where I need to", which the page
+ * previously never answered: the only CTA started at 0.1.
+ */
+export async function courseTotals(courseId: string): Promise<{
+  modules: number;
+  lessons: number;
+  minutes: number;
+}> {
+  const course = await loadCourse(courseId);
+  const lessonIds = course.modules.flatMap((m) => m.lessonIds);
+  const lessons = await Promise.all(
+    lessonIds.map((id) => loadLesson(courseId, id)),
+  );
+  return {
+    modules: course.modules.length,
+    lessons: lessonIds.length,
+    minutes: lessons.reduce((sum, l) => sum + (l.estimatedMinutes ?? 0), 0),
+  };
+}
+
+/**
  * Load a quiz by course and lesson ID.
  * Returns null if the lesson has no quiz.
  */

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Nevíte, jestli se na vás NIS 2 vztahuje?",
+        "body": "Test působnosti projde velikostní prahy, sektorové přílohy a místo usazení a přibližně za dvě minuty vám dá písemnou odpověď.",
+        "cta": "Ověřit působnost"
+      },
+      "timeline": {
+        "heading": "Termín je daný. Spadáte do působnosti?",
+        "body": "Stav transpozice říká kdy. Test působnosti říká, zda jde o vás — velikostní prahy, sektorové přílohy a kde je subjekt usazen.",
+        "cta": "Ověřit svou působnost"
+      },
+      "advice": {
+        "heading": "Řešíte to se skutečným termínem?",
+        "body": "Proberte to s někým, kdo si tím prošel. Třicet minut, žádný prodej — popište svou situaci a řekneme vám, co musí proběhnout první.",
+        "cta": "Domluvit hovor"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Co je nisd2.eu ve skutečnosti: bezplatný, otevřený registr povinností pro NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Začít zdarma"
     },
     "footer": {
+      "partners": "Partneři",
       "nis2Info": "Informace o NIS2",
       "whatIsNis2": "Co je NIS2?",
       "nis2InGermany": "NIS2 v Německu",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} modulů · {lessons} lekcí · asi {hours} h · začněte kteroukoli lekcí",
       "meta": {
         "title": "Bezplatné školení vedení NIS2, články 20 + 21",
         "description": "Školení vedení NIS2 pokrývající články 20 + 21: rizika, 10 opatření kybernetické bezpečnosti a dohled. Splňuje povinnost školení podle čl. 20 odst. 2. 47 lekcí, zdarma.",

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Unsicher, ob NIS 2 für Sie gilt?",
+        "body": "Der Betroffenheitscheck geht Größenschwellen, Sektoranhänge und den Ort der Niederlassung durch und gibt Ihnen in rund zwei Minuten eine schriftliche Antwort.",
+        "cta": "Betroffenheit prüfen"
+      },
+      "timeline": {
+        "heading": "Die Frist steht. Sind Sie betroffen?",
+        "body": "Der Umsetzungsstand sagt Ihnen, wann. Der Betroffenheitscheck sagt Ihnen, ob Sie es sind — Größenschwellen, Sektoranhänge und Ort der Niederlassung.",
+        "cta": "Betroffenheit prüfen"
+      },
+      "advice": {
+        "heading": "Sie arbeiten das mit einer echten Frist ab?",
+        "body": "Sprechen Sie mit jemandem, der das schon gemacht hat. 30 Minuten, kein Vertrieb — schildern Sie Ihre Lage, wir sagen Ihnen, was zuerst passieren muss.",
+        "cta": "Gespräch buchen"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Was ist nisd2.eu? Das kostenlose, offene Pflichtenregister für NIS 2",
@@ -6659,6 +6676,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} Module · {lessons} Lektionen · rund {hours} Std. · Einstieg bei jeder Lektion",
       "meta": {
         "title": "NIS2 Management-Training - Artikel 20 + 21",
         "description": "NIS2-Training zu Artikel 20 + 21: Risiken, die 10 Sicherheitsmaßnahmen und Aufsicht durch die Leitung. Erfüllt die Schulungspflicht nach Art. 20(2). 47 Lektionen, kostenlos.",

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Not sure whether NIS 2 applies to you?",
+        "body": "The scope check walks the size thresholds, the sector annexes and where your entity is established, and gives you a written answer in about two minutes.",
+        "cta": "Run the scope check"
+      },
+      "timeline": {
+        "heading": "The deadline is set. Is your organisation in scope?",
+        "body": "Transposition status tells you when. The scope check tells you whether it is you — size thresholds, sector annexes and where your entity is established.",
+        "cta": "Check your scope"
+      },
+      "advice": {
+        "heading": "Working through this against a real deadline?",
+        "body": "Talk it through with someone who has done it. Thirty minutes, no pitch — bring your situation and we will tell you what actually has to happen first.",
+        "cta": "Book a call"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "What nisd2.eu actually is: the free, open obligation register for NIS 2",
@@ -6666,6 +6683,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} modules · {lessons} lessons · about {hours} h · start at any lesson",
       "meta": {
         "title": "Free NIS2 Management Training - Articles 20 + 21",
         "description": "NIS2 management training covering Articles 20 + 21: risks, the 10 cybersecurity measures, and oversight. Meets the Art. 20(2) training duty. 47 lessons, free.",

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "¿No sabe si NIS 2 le afecta?",
+        "body": "La comprobación de ámbito repasa los umbrales de tamaño, los anexos sectoriales y el lugar de establecimiento, y le da una respuesta por escrito en unos dos minutos.",
+        "cta": "Comprobar el ámbito"
+      },
+      "timeline": {
+        "heading": "El plazo ya está fijado. ¿Está usted dentro del ámbito?",
+        "body": "El estado de transposición le dice cuándo. La comprobación de ámbito le dice si le afecta: umbrales de tamaño, anexos sectoriales y dónde está establecida la entidad.",
+        "cta": "Comprobar su ámbito"
+      },
+      "advice": {
+        "heading": "¿Está resolviendo esto con un plazo real?",
+        "body": "Háblelo con alguien que ya lo ha hecho. Treinta minutos, sin argumentario de venta: cuéntenos su situación y le diremos qué tiene que ocurrir primero.",
+        "cta": "Reservar una llamada"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Qué es realmente nisd2.eu: el registro de obligaciones gratuito y abierto para NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Empezar gratis"
     },
     "footer": {
+      "partners": "Socios",
       "nis2Info": "Información sobre NIS2",
       "whatIsNis2": "¿Qué es NIS2?",
       "nis2InGermany": "NIS2 en Alemania",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} módulos · {lessons} lecciones · unas {hours} h · empiece por cualquier lección",
       "meta": {
         "title": "Formación gratuita de dirección de NIS2 - Artículos 20 + 21",
         "description": "Formación de dirección de NIS2 que cubre los artículos 20 + 21: riesgos, las 10 medidas de ciberseguridad y la supervisión. Cumple el deber de formación del Art. 20(2). 47 lecciones, gratis.",

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Vous ne savez pas si NIS 2 vous concerne ?",
+        "body": "Le test d'applicabilité passe en revue les seuils d'effectif, les annexes sectorielles et le lieu d'établissement, et vous donne une réponse écrite en deux minutes environ.",
+        "cta": "Faire le test d'applicabilité"
+      },
+      "timeline": {
+        "heading": "L'échéance est fixée. Êtes-vous concerné ?",
+        "body": "L'état de transposition vous dit quand. Le test d'applicabilité vous dit si c'est vous — seuils d'effectif, annexes sectorielles et lieu d'établissement de l'entité.",
+        "cta": "Vérifier votre situation"
+      },
+      "advice": {
+        "heading": "Vous traitez ce sujet avec une échéance réelle ?",
+        "body": "Parlez-en avec quelqu'un qui l'a déjà fait. Trente minutes, sans argumentaire commercial : exposez votre situation, nous vous dirons ce qui doit passer en premier.",
+        "cta": "Réserver un échange"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Ce qu'est réellement nisd2.eu : le registre des obligations NIS 2, libre et gratuit",
@@ -401,6 +418,7 @@
       "cta": "Commencer gratuitement"
     },
     "footer": {
+      "partners": "Partenaires",
       "nis2Info": "Informations NIS2",
       "whatIsNis2": "Qu'est-ce que NIS2 ?",
       "nis2InGermany": "NIS2 en Allemagne",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} modules · {lessons} leçons · environ {hours} h · commencez où vous voulez",
       "meta": {
         "title": "Formation gratuite des dirigeants NIS2 - Articles 20 + 21",
         "description": "Formation des dirigeants NIS2 couvrant les articles 20 + 21 : risques, les 10 mesures de cybersécurité et la supervision. Satisfait à l'obligation de formation de l'art. 20, par. 2. 47 leçons, gratuit.",

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Non sei sicuro che la NIS 2 ti riguardi?",
+        "body": "La verifica di applicabilità esamina le soglie dimensionali, gli allegati settoriali e il luogo di stabilimento e ti dà una risposta scritta in circa due minuti.",
+        "cta": "Verifica l'applicabilità"
+      },
+      "timeline": {
+        "heading": "La scadenza è fissata. Rientri nell'ambito?",
+        "body": "Lo stato di recepimento ti dice quando. La verifica di applicabilità ti dice se riguarda te — soglie dimensionali, allegati settoriali e dove è stabilita l'entità.",
+        "cta": "Verifica il tuo ambito"
+      },
+      "advice": {
+        "heading": "Stai affrontando questo con una scadenza reale?",
+        "body": "Parlane con chi l'ha già fatto. Trenta minuti, senza presentazioni commerciali: raccontaci la tua situazione e ti diciamo cosa deve succedere per primo.",
+        "cta": "Prenota una call"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Cosa è realmente nisd2.eu: il registro degli obblighi gratuito e aperto per NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Inizia gratis"
     },
     "footer": {
+      "partners": "Partner",
       "nis2Info": "Informazioni su NIS2",
       "whatIsNis2": "Che cos'è NIS2?",
       "nis2InGermany": "NIS2 in Germania",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} moduli · {lessons} lezioni · circa {hours} h · inizia da qualsiasi lezione",
       "meta": {
         "title": "Formazione gratuita NIS2 per gli organi di gestione - Articoli 20 + 21",
         "description": "Formazione NIS2 per gli organi di gestione sugli Articoli 20 + 21: rischi, le 10 misure di cibersicurezza e la sorveglianza. Soddisfa il dovere di formazione dell'Art. 20(2). 47 lezioni, gratuita.",

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Niet zeker of NIS 2 op u van toepassing is?",
+        "body": "De toepassingscheck loopt de omvangdrempels, de sectorbijlagen en de vestigingsplaats na en geeft u in ongeveer twee minuten een schriftelijk antwoord.",
+        "cta": "Toepassing controleren"
+      },
+      "timeline": {
+        "heading": "De deadline staat vast. Valt u eronder?",
+        "body": "De omzettingsstatus vertelt u wanneer. De toepassingscheck vertelt u of u het bent — omvangdrempels, sectorbijlagen en waar uw entiteit is gevestigd.",
+        "cta": "Controleer uw toepassingsgebied"
+      },
+      "advice": {
+        "heading": "Werkt u dit uit met een echte deadline?",
+        "body": "Bespreek het met iemand die het al heeft gedaan. Dertig minuten, geen verkooppraatje — leg uw situatie voor en wij zeggen wat er eerst moet gebeuren.",
+        "cta": "Gesprek inplannen"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Wat nisd2.eu werkelijk is: het gratis, open verplichtingenregister voor NIS 2",
@@ -6258,6 +6275,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} modules · {lessons} lessen · ongeveer {hours} u · begin bij elke les",
       "meta": {
         "title": "Free NIS2 Management Training - Articles 20 + 21",
         "description": "NIS2 management training covering Articles 20 + 21: risks, the 10 cybersecurity measures, and oversight. Meets the Art. 20(2) training duty. 47 lessons, free.",

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Nie wiesz, czy NIS 2 dotyczy Twojej organizacji?",
+        "body": "Test zakresu sprawdza progi wielkości, załączniki sektorowe i miejsce prowadzenia działalności i w około dwie minuty daje pisemną odpowiedź.",
+        "cta": "Sprawdź zakres"
+      },
+      "timeline": {
+        "heading": "Termin jest ustalony. Czy obejmuje Twoją organizację?",
+        "body": "Stan wdrożenia mówi, kiedy. Test zakresu mówi, czy to Ty — progi wielkości, załączniki sektorowe i miejsce siedziby podmiotu.",
+        "cta": "Sprawdź swój zakres"
+      },
+      "advice": {
+        "heading": "Pracujesz nad tym z realnym terminem?",
+        "body": "Porozmawiaj z kimś, kto już przez to przeszedł. Trzydzieści minut, bez sprzedaży — opisz swoją sytuację, a powiemy, co musi wydarzyć się najpierw.",
+        "cta": "Umów rozmowę"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Czym właściwie jest nisd2.eu: darmowy, otwarty rejestr obowiązków dla NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Zacznij za darmo"
     },
     "footer": {
+      "partners": "Partnerzy",
       "nis2Info": "Informacje o NIS2",
       "whatIsNis2": "Czym jest NIS2?",
       "nis2InGermany": "NIS2 w Niemczech",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} modułów · {lessons} lekcji · około {hours} godz. · zacznij od dowolnej lekcji",
       "meta": {
         "title": "Bezpłatne szkolenie dla kierownictwa NIS2 - artykuły 20 + 21",
         "description": "Szkolenie dla kierownictwa NIS2 obejmujące artykuły 20 + 21: ryzyka, 10 środków cyberbezpieczeństwa oraz nadzór. Spełnia obowiązek szkoleniowy z art. 20 ust. 2. 47 lekcji, bezpłatnie.",

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Não sabe se a NIS 2 se aplica a si?",
+        "body": "A verificação de âmbito percorre os limiares de dimensão, os anexos setoriais e o local de estabelecimento e dá-lhe uma resposta escrita em cerca de dois minutos.",
+        "cta": "Verificar o âmbito"
+      },
+      "timeline": {
+        "heading": "O prazo está fixado. Está abrangido?",
+        "body": "O estado de transposição diz-lhe quando. A verificação de âmbito diz-lhe se é consigo — limiares de dimensão, anexos setoriais e onde a entidade está estabelecida.",
+        "cta": "Verificar o seu âmbito"
+      },
+      "advice": {
+        "heading": "Está a tratar disto com um prazo real?",
+        "body": "Fale com quem já passou por isso. Trinta minutos, sem argumentário de venda: descreva a sua situação e dizemos-lhe o que tem de acontecer primeiro.",
+        "cta": "Marcar uma chamada"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "O que é realmente o nisd2.eu: o registo de obrigações gratuito e aberto para a NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Começar gratuitamente"
     },
     "footer": {
+      "partners": "Parceiros",
       "nis2Info": "Informação NIS2",
       "whatIsNis2": "O que é a NIS2?",
       "nis2InGermany": "NIS2 na Alemanha",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} módulos · {lessons} lições · cerca de {hours} h · comece em qualquer lição",
       "meta": {
         "title": "Formação gratuita de gestão NIS2, Artigos 20.o + 21.o",
         "description": "Formação de gestão NIS2 que abrange os Artigos 20.o + 21.o: riscos, as 10 medidas de cibersegurança e a supervisão. Cumpre o dever de formação do Art. 20.o, n.o 2. 47 lições, gratuita.",

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -1,5 +1,22 @@
 {
   "info": {
+    "wikiNextStep": {
+      "scope": {
+        "heading": "Nu știți dacă NIS 2 vi se aplică?",
+        "body": "Verificarea domeniului de aplicare parcurge pragurile de mărime, anexele sectoriale și locul de stabilire și vă dă un răspuns scris în aproximativ două minute.",
+        "cta": "Verificați aplicabilitatea"
+      },
+      "timeline": {
+        "heading": "Termenul este stabilit. Intrați în domeniul de aplicare?",
+        "body": "Stadiul transpunerii vă spune când. Verificarea aplicabilității vă spune dacă este vorba despre dumneavoastră — praguri de mărime, anexe sectoriale și unde este stabilită entitatea.",
+        "cta": "Verificați domeniul de aplicare"
+      },
+      "advice": {
+        "heading": "Lucrați la asta cu un termen real?",
+        "body": "Discutați cu cineva care a trecut prin asta. Treizeci de minute, fără prezentare de vânzări — descrieți situația și vă spunem ce trebuie să se întâmple mai întâi.",
+        "cta": "Programați o discuție"
+      }
+    },
     "whatIsNisd2": {
       "meta": {
         "title": "Ce este de fapt nisd2.eu: registrul obligațiilor gratuit și deschis pentru NIS 2",
@@ -401,6 +418,7 @@
       "cta": "Incepe gratuit"
     },
     "footer": {
+      "partners": "Parteneri",
       "nis2Info": "Informații NIS2",
       "whatIsNis2": "Ce este NIS2?",
       "nis2InGermany": "NIS2 în Germania",
@@ -6650,6 +6668,7 @@
       }
     },
     "trainingCeo": {
+      "courseScale": "{modules} module · {lessons} lecții · aproximativ {hours} h · începeți de la orice lecție",
       "meta": {
         "title": "Instruire gratuită NIS2 pentru conducere: articolele 20 + 21",
         "description": "Instruire NIS2 pentru conducere care acoperă articolele 20 + 21: riscuri, cele 10 măsuri de securitate cibernetică și supravegherea. Îndeplinește obligația de instruire din art. 20(2). 47 de lecții, gratuit.",

--- a/proxy.ts
+++ b/proxy.ts
@@ -194,41 +194,78 @@ const NON_DEFAULT_LOCALE_PREFIX = new RegExp(
 );
 
 /**
- * Supplier portal root → the product lander, for anonymous visitors only.
+ * Gated roots an anonymous visitor is expected to reach cold → the public
+ * page to send them to instead of the sign-in form.
  *
  * `/portal/supplier` is the URL that actually gets shared with a supplier
  * ("fill this in for us"), and a supplier who has never heard of us has
  * nothing to sign in with. Sending them to /auth/signin loses them at the
- * door. Deep links into the portal (/portal/supplier/profile, /practices,
- * per-customer pages) keep going to signin with callbackUrl — those are app
- * URLs someone reaches after they already have an account.
+ * door.
  *
- * Target is resolved per locale from routing.pathnames so NL lands on
- * /nl/leveranciersportaal rather than eating a second redirect hop.
+ * `/journey` is the same shape of problem found later in analytics: it is
+ * the surface people link to and search for, and it had the highest
+ * return rate on the site (1.65 visits per visitor) while an anonymous
+ * hit got nothing but a login form.
+ *
+ * It points at /start rather than /journey-preview: the preview route
+ * calls notFound() when NODE_ENV === "production" on purpose — it is a
+ * screenshot rig for the landing hero, rendering a fake company's board
+ * with a sidebar full of gated links, not a marketing surface. Sending
+ * real traffic there would 404. /start is the actual public pre-login
+ * entry page, and it recorded zero visits in the 30 days to 2026-08-31,
+ * so it was getting no traffic from anywhere.
+ *
+ * Only the EXACT root redirects. Deep links below it
+ * (/portal/supplier/profile, /practices, per-customer pages) keep going to
+ * signin with callbackUrl — those are app URLs someone reaches after they
+ * already have an account.
+ *
+ * Targets resolve per locale from routing.pathnames so NL lands on
+ * /nl/leveranciersportaal rather than eating a second redirect hop. A
+ * target that is not in routing.pathnames (like /journey-preview) is
+ * locale-stable and falls through to itself.
  */
-const SUPPLIER_PORTAL_ROOT = "/portal/supplier";
+const ANONYMOUS_LANDER_TARGETS: Record<string, string> = {
+  "/portal/supplier": "/supplier-portal",
+  "/journey": "/start",
+};
 
-const SUPPLIER_LANDER_BY_LOCALE: Record<string, string> = (() => {
+function landerByLocale(target: string): Record<string, string> {
   const pathnames = routing.pathnames as Record<
     string,
     string | Record<string, string | undefined> | undefined
   >;
-  const mapping = pathnames["/supplier-portal"];
+  const mapping = pathnames[target];
   const out: Record<string, string> = {};
   for (const locale of routing.locales) {
     out[locale] =
-      (typeof mapping === "string" ? mapping : mapping?.[locale]) ??
-      "/supplier-portal";
+      (typeof mapping === "string" ? mapping : mapping?.[locale]) ?? target;
   }
   return out;
-})();
+}
 
-/** Locale-prefixed lander URL for the locale this request is in. */
-function supplierLanderPath(pathname: string): string {
+const ANONYMOUS_LANDERS: Record<string, Record<string, string>> =
+  Object.fromEntries(
+    Object.entries(ANONYMOUS_LANDER_TARGETS).map(([root, target]) => [
+      root,
+      landerByLocale(target),
+    ]),
+  );
+
+/**
+ * Locale-prefixed lander for an anonymous hit on `strippedPath`, or null
+ * when that path has no lander and should go to signin as before.
+ */
+function anonymousLanderPath(
+  pathname: string,
+  strippedPath: string,
+): string | null {
+  const byLocale = ANONYMOUS_LANDERS[strippedPath];
+  if (!byLocale) return null;
   const match = pathname.match(NON_DEFAULT_LOCALE_PREFIX);
   const locale = match ? match[1].toLowerCase() : routing.defaultLocale;
   const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
-  return `${prefix}${SUPPLIER_LANDER_BY_LOCALE[locale] ?? "/supplier-portal"}`;
+  return `${prefix}${byLocale[locale] ?? ANONYMOUS_LANDER_TARGETS[strippedPath]}`;
 }
 
 function isPublic(pathname: string): boolean {
@@ -322,12 +359,15 @@ async function route(request: NextRequest) {
     });
 
     if (!token) {
-      // The one protected path an anonymous visitor is expected to arrive
-      // at cold. Everything else under /portal/supplier/ still walls.
-      if ((pathname.replace(LOCALE_STRIP, "") || "/") === SUPPLIER_PORTAL_ROOT) {
-        return NextResponse.redirect(
-          new URL(supplierLanderPath(pathname), request.url),
-        );
+      // The protected roots an anonymous visitor is expected to arrive at
+      // cold get a public lander instead of the login form. Everything
+      // deeper still walls.
+      const lander = anonymousLanderPath(
+        pathname,
+        pathname.replace(LOCALE_STRIP, "") || "/",
+      );
+      if (lander) {
+        return NextResponse.redirect(new URL(lander, request.url));
       }
       const signinUrl = new URL("/auth/signin", request.url);
       signinUrl.searchParams.set("callbackUrl", pathname);

--- a/scripts/index-urls.ts
+++ b/scripts/index-urls.ts
@@ -1,6 +1,20 @@
 /**
  * Submit public NISD2.eu URLs to Google Indexing API.
  *
+ * URLs are read from the live /sitemap.xml rather than a list kept here.
+ * The previous hardcoded list had gone stale: it still named the
+ * root-level slugs from before the /wiki migration (/what-is-nis2,
+ * /nis2-in-germany, …), every one of which now 301s, and it only ever
+ * covered de + en — missing the eight other locales entirely.
+ *
+ * The IndexNow counterpart is app/api/cron/indexnow/route.ts, which
+ * reaches Bing/Yandex/Seznam/Naver and reads the same source. Google does
+ * not participate in IndexNow, hence two mechanisms.
+ *
+ * Note: Google documents this API for JobPosting and BroadcastEvent
+ * pages. Submitting other page types is tolerated but not guaranteed to
+ * do anything — the sitemap remains the real signal for Google.
+ *
  * Prerequisites:
  * 1. Create a Google Cloud project and enable the "Indexing API"
  * 2. Create a service account and download the JSON key file
@@ -10,57 +24,66 @@
  *    or set GOOGLE_SERVICE_ACCOUNT_PATH env var
  *
  * Usage:
- *   bun run index-urls
+ *   bun run index-urls                 # everything in the sitemap
+ *   bun run index-urls -- --days 7     # only URLs with lastmod in 7 days
  */
 
 import { GoogleAuth } from "google-auth-library";
 
 const INDEXING_API = "https://indexing.googleapis.com/v3/urlNotifications:publish";
 
-const SITE = "https://www.nisd2.eu";
+const SITE = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.nisd2.eu";
 
-/** All public routes (DE default = root, EN = /en/ prefix) */
-const routes = [
-  "",
-  "what-is-nis2",
-  "nis2-in-germany",
-  "nis2-requirements",
-  "features",
-  "applicability",
-  "geschaftsfuhrerhaftung",
-  "it-grundschutz",
-  "kosten",
-  "umsetzung-mittelstand",
-  "anforderungen-checkliste",
-  "nis2-registrierung",
-  "cir-2024-2690",
-  "nis2-iso-27001",
-  "nis2-meldepflicht",
-  "nis2-umsetzung-europa",
-  "nis2-registrierung-verpasst",
-  "nis2-vs-kritis",
-  "nis2-bussgelder",
-  "glossar",
-  "it-sicherheitspflicht",
-  "bsig-30",
-  "bsi-registrierung-anleitung",
-  "nis2-was-tun",
-  "nis2-europaeischer-standard",
-  "nis2-lebensmittel",
-  "nis2-produzierendes-gewerbe",
-  "nis2-gesundheitswesen",
-  "nis2-logistik",
-  "nis2-abfallwirtschaft",
-  "nis2-einrichtungen",
-  "faq",
-];
-
-const urls = routes.flatMap((r) => {
-  const path = r ? `/${r}` : "";
-  return [`${SITE}${path}`, `${SITE}/en${path}`];
-});
+/**
+ * Pull <loc>/<lastmod> out of our own sitemap. Our own generated,
+ * well-formed document; the hreflang alternates are `xhtml:link`
+ * elements carrying href *attributes*, so a <loc> match cannot catch them.
+ */
+async function sitemapUrls(): Promise<Array<{ loc: string; lastmod: string | null }>> {
+  const res = await fetch(`${SITE}/sitemap.xml`);
+  if (!res.ok) {
+    throw new Error(`sitemap fetch failed: ${res.status} ${res.statusText}`);
+  }
+  const xml = await res.text();
+  const out: Array<{ loc: string; lastmod: string | null }> = [];
+  for (const block of xml.match(/<url>[\s\S]*?<\/url>/g) ?? []) {
+    const loc = block.match(/<loc>([^<]+)<\/loc>/)?.[1];
+    if (!loc) continue;
+    out.push({
+      loc: loc.trim(),
+      lastmod: block.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]?.trim() ?? null,
+    });
+  }
+  return out;
+}
 
 async function main() {
+  // `--days N` narrows to URLs whose sitemap <lastmod> is inside N days.
+  const daysArg = process.argv.indexOf("--days");
+  const days = daysArg > -1 ? Number(process.argv[daysArg + 1]) : null;
+
+  const entries = await sitemapUrls();
+  const cutoff =
+    days && Number.isFinite(days) ? Date.now() - days * 86_400_000 : null;
+
+  const urls = entries
+    .filter((e) => {
+      if (cutoff === null) return true;
+      if (!e.lastmod) return false;
+      const t = Date.parse(e.lastmod);
+      return Number.isFinite(t) && t >= cutoff;
+    })
+    .map((e) => e.loc);
+
+  if (urls.length === 0) {
+    console.log(
+      cutoff === null
+        ? "Sitemap returned no URLs."
+        : `No URLs changed in the last ${days} days.`,
+    );
+    process.exit(0);
+  }
+
   const keyFile =
     process.env.GOOGLE_SERVICE_ACCOUNT_PATH ?? "./google-service-account.json";
 


### PR DESCRIPTION
Driven by 30 days of Umami data to 2026-08-31. Five findings, each traced to a file rather than inferred from the numbers.

Wiki CTAs were inversely correlated with traffic. zeit-und-status is 45% of wiki traffic (756 visitors) and carried one CTA across 32 pages; troubleshooting is 0.8% and carried six across eight. The cause was structural: the CTA was hand-written per page at page.tsx:308, so it was opt-in and got forgotten. WikiNextStep now renders once from app/[locale]/wiki/layout.tsx beside the existing disclaimer, covering all 149 pages. Variant comes from the canonical category segment; categories that already carry bespoke CTA cards point at /start instead so the strip complements rather than repeats them.

/start recorded zero visits in the period despite being public and embedding the Cal.com booker — nothing linked to it. proxy.ts already special-cased SUPPLIER_PORTAL_ROOT so a cold supplier is not met with a login form; that is generalised into a gated-root -> public-lander table, and /journey (highest return rate on the site, 1.65 visits per visitor) now lands anonymous visitors on /start. Deep app URLs still wall to signin with callbackUrl. Note /journey-preview is NOT a valid target: it calls notFound() in production by design.

All ten locales ship complete wiki translations, but only de/en/nl had localized URL slugs — an Italian reader got Italian prose at an English URL. wiki-slugs-extra.ts adds all 9 category slugs plus 45 entries for pl/ro/fr/it, prioritised by traffic (every zeit-und-status entry, then the highest-traffic pages elsewhere). Regulation and standard identifiers (cir-2024-2690, nis2-iso-27001, enisa-tig-nis2, nis2umsucg) deliberately keep the English slug. 600 301s emitted for the moved URLs; verified zero self-redirects, zero duplicate sources, zero shadowing a live URL, zero dead destinations.

44% of search arrivals come through Bing's index (Bing, DuckDuckGo, Qwant, Ecosia, Brave, Yahoo) against 502 from Google, versus a 10-15% EU B2B norm, and nothing addressed that index. Adds an IndexNow cron plus the ownership key route, both off unless INDEXNOW_KEY is set so a self-hosted instance pings nobody. scripts/index-urls.ts (Google's API) had gone stale — every URL in its hardcoded list was a pre-/wiki slug that now 301s, and it covered 2 of 10 locales; it now reads the same sitemap.

i18n/request.ts only fell back for a wholly absent namespace file. A file that exists but is missing keys still throws MISSING_MESSAGE, which is a 500 on a real page — info.footer.partners was absent in seven locales while PublicFooter read it unconditionally. Adds a per-key deep merge from English, memoised per locale in production (the merge walks ~2 MB of `info`), disabled in dev so message edits still hot-reload. An audit found 553 such keys; they are still untranslated and now render English. This is the floor, not the goal.

Course landing stated no total size and its only CTA started at lesson 0.1, while analytics showed lessons 5.1/5.2 outdrawing all of module 4 — people skipping to the end. Adds a computed scale line.

Verified: typecheck clean, 135/135 unit tests, production build exit 0 with no warnings, 463 message files valid, and a dev smoke test showing all three CTA variants rendering in EN/DE/PL, old slugs 308ing to new, and zero MISSING_MESSAGE across the run.

Known gaps, deliberately not addressed here: the 553 untranslated keys; `bun run lint` is dead because next lint was removed in Next 16 and no eslint is installed; the pl/ro slugs have not had a native-speaker review.