### PR TITLE
fix(e2e): assert the journey lander contract that #127 shipped

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -13,18 +13,43 @@ test("journey renders all 49 NIS2 requirement nodes", async ({ page }) => {
 });
 
 /**
- * Proves the smoke above is not passing vacuously: without the session,
- * the default-deny middleware must bounce /journey to the signin form.
+ * Proves the smoke above is not passing vacuously: without a session the
+ * journey must not render.
+ *
+ * How that is enforced for the /journey root changed in #127. Anonymous
+ * visitors used to meet the signin form; they now land on /start, the
+ * public pre-login page, because /start had recorded zero visits while
+ * nothing linked to it. Default-deny is unchanged everywhere else:
+ * ANONYMOUS_LANDERS in proxy.ts is keyed on the exact stripped path, so
+ * only the root is diverted and every deeper app URL still walls to
+ * signin with callbackUrl preserved.
+ *
+ * Both halves are asserted. The lander on its own no longer proves
+ * anything about auth, and the wall on its own would not notice the
+ * lander regressing back to a login form.
+ *
+ * de is the default locale under localePrefix "as-needed", so the lander
+ * target carries no locale prefix: /de/journey resolves to /start.
  */
 test.describe("unauthenticated", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
-  test("journey redirects to signin without a session", async ({ page }) => {
+  test("the journey root lands anonymous visitors on /start", async ({
+    page,
+  }) => {
     await page.goto("/de/journey");
+    await page.waitForURL(/\/start$/, { timeout: 15_000 });
+    await expect(page.locator('[data-testid^="journey-node-"]')).toHaveCount(
+      0,
+    );
+  });
+
+  test("a deeper app URL still walls to signin with callbackUrl", async ({
+    page,
+  }) => {
+    await page.goto("/de/risks");
     await page.waitForURL(/\/auth\/signin/, { timeout: 15_000 });
+    expect(page.url()).toContain("callbackUrl");
     await expect(page.locator("#email")).toBeVisible();
-    await expect(
-      page.locator('[data-testid^="journey-node-"]'),
-    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What this fixes

`main`'s e2e suite is red, and has been since #127 merged.

#127 deliberately changed what an anonymous hit on the `/journey` root does, adding to `proxy.ts`:

```ts
const ANONYMOUS_LANDER_TARGETS: Record<string, string> = {
  "/portal/supplier": "/supplier-portal",
  "/journey": "/start",
};
```

It did not update `e2e/smoke.spec.ts`, which still asserted the old contract:

```ts
await page.goto("/de/journey");
await page.waitForURL(/\/auth\/signin/, { timeout: 15_000 });
```

## Why nobody was told

#127 was merged 100 seconds after it was opened, while its checks were still pending. Its `e2e` check went red afterwards. `e2e.yml` triggers on `pull_request` only, never on push to `main`, so the suite has not run against `main` since.

Every PR opened since inherits the failure. #125 and #126 are pure `bun.lock` regenerations and both fail on this test, which is what surfaced it.

## The change

The code is right and the test was stale, so the test moves.

Rather than just repointing the URL, the unauthenticated case splits in two. `ANONYMOUS_LANDERS` is keyed on the exact stripped path, so `/journey` diverts to `/start` while deeper app URLs still wall to signin with `callbackUrl` preserved. Asserting only the lander would stop proving anything about auth, which is the whole reason the original test existed; asserting only the wall would not notice the lander regressing back to a login form.

`de` is the default locale under `localePrefix: "as-needed"`, so the lander target carries no prefix: `/de/journey` resolves to `/start`.

## Verification

Not run locally: the suite needs Postgres, a seeded database and a production build. CI is the check. If this goes green, #125 and #126 should go green on rebase too.

## Worth deciding separately

`e2e.yml` running on `pull_request` only is the reason this stayed invisible for the whole afternoon. Adding `push: branches: [main]` would make a merge-with-pending-checks report itself. Left out of this PR to keep it to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J93t7LS29yZq2app1Pqsmn
