### PR TITLE
courses: state the CC BY licence on the book's imprint page

### DIFF
--- a/courses/nis2-ceo/pdf-book/nis2-management-training-de.tex
+++ b/courses/nis2-ceo/pdf-book/nis2-management-training-de.tex
@@ -290,7 +290,7 @@ Dieses Buch ist eine druckfertige Version der NIS2-Schulung für Leitungsorgane,
 \noindent\textbf{Bestehensschwelle.} Jedes Quiz erfordert 75\,\% zum Bestehen.
 
 \vspace{6pt}
-\noindent $\copyright$ NISD2. Alle Rechte vorbehalten.
+\noindent\textbf{Lizenz.} $\copyright$ 2026 Kardashev Catalyst UG (haftungsbeschränkt). Dieses Material steht unter der Lizenz Creative Commons Namensnennung 4.0 International (CC BY 4.0), \texttt{creativecommons.org/licenses/by/4.0/}. Sie dürfen es weitergeben, kürzen, übersetzen, bearbeiten und das Ergebnis unter Ihrem eigenen Namen veröffentlichen, auch gewerblich. Einzige Bedingung ist die Quellenangabe. Kammern, Verbände und Bildungseinrichtungen sind dazu ausdrücklich eingeladen.
 \end{small}
 \vspace*{\fill}
 \newpage

--- a/courses/nis2-ceo/pdf-book/nis2-management-training.tex
+++ b/courses/nis2-ceo/pdf-book/nis2-management-training.tex
@@ -325,7 +325,7 @@ This book is a print-ready version of the NIS2 Management Training course availa
 \noindent\textbf{Passing score.} Each lesson quiz requires 75\% to pass.
 
 \vspace{6pt}
-\noindent $\copyright$ NISD2. All rights reserved.
+\noindent\textbf{Licence.} $\copyright$ 2026 Kardashev Catalyst UG (haftungsbeschränkt). This material is licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0), \texttt{creativecommons.org/licenses/by/4.0/}. You may share, shorten, translate and adapt it, and publish the result under your own name, including commercially. Attribution is the only condition. Chambers of commerce, associations and educational institutions are expressly invited to do so.
 \end{small}
 \vspace*{\fill}
 \newpage


### PR DESCRIPTION
## Why

#130 licensed everything under `courses/` as CC BY 4.0. The course book's imprint page still reads **"© NISD2. Alle Rechte vorbehalten."**

Those two statements now contradict each other in `main`, and the book is precisely the artefact we send to chambers of commerce who are deciding whether they may redistribute the material to their member companies. IHK Schwaben has that question open in writing right now. Page two of the attachment currently answers it "no".

## History, so the churn is legible

These exact two lines were part of #130 and were reverted before it merged, on the expectation that the LaTeX pipeline was about to be deleted in a parallel branch. #131 landed instead: it rebuilt the *generated* documents — certificate, compliance report, gap assessment, policy, supplier questionnaire — on a shared React PDF design system, and left `courses/nis2-ceo/pdf-book/*.tex` untouched. So the fix is still needed, and it no longer risks a modify/delete conflict with anything.

## What changed

Two lines, one per language. The all-rights-reserved sentence becomes the licence grant, matching `courses/LICENSE` and the wording already used on the supplier questionnaire PDF.

## Known gap

The **compiled PDFs still carry the old line**. No LaTeX toolchain here, so they cannot be rebuilt in this environment — `sudo apt install texlive-latex-recommended texlive-latex-extra texlive-lang-german`, then `pdflatex nis2-management-training-de.tex` twice.

Until then the outreach draft names the discrepancy in the email rather than hiding it, which for a reviewing desk reads better than a silent mismatch.

If the book later moves off LaTeX onto the new PDF system, the replacement template needs this text carried over deliberately — a verbatim port of the old imprint page would reintroduce the very sentence this removes.

## Blast radius

Two typesetting sources. No application code, no runtime behaviour, no build, no deploy.
