### PR TITLE
legal(impressum): name Simon Orzel as the responsible party

### DIFF
--- a/app/[locale]/(info)/impressum/page.tsx
+++ b/app/[locale]/(info)/impressum/page.tsx
@@ -44,10 +44,6 @@ export default async function ImpressumPage() {
           <CardContent className="space-y-1 text-sm text-muted-foreground">
             <p className="font-medium text-foreground">{t("impressum.responsible.company")}</p>
             <p>{t("impressum.responsible.address")}</p>
-            <p>{t("impressum.responsible.represented")}</p>
-            <p>{t("impressum.responsible.registration")}</p>
-            <p>{t("impressum.responsible.euid")}</p>
-            <p>{t("impressum.responsible.vatId")}</p>
             <p>{t("impressum.responsible.emailLabel")}: {t("impressum.responsible.email")}</p>
           </CardContent>
         </Card>

--- a/app/[locale]/(info)/vermittlung/page.tsx
+++ b/app/[locale]/(info)/vermittlung/page.tsx
@@ -25,20 +25,12 @@ const sectionKeys = ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10"
 /**
  * Provider block. The company VALUES are held once, in the `info.impressum`
  * namespace that renders /impressum. The field LIST is not shared, though,
- * and had already drifted: euid ships in all ten locales and renders on
- * /impressum but was missing here, on the page that presents the Anbieter
- * block for a commission-bearing commercial offer. Adding an identifier to
- * /impressum still will not reach this page, so keep the two in step by hand
- * or derive both from one list.
+ * so a key added to or dropped from `impressum.responsible` does not reach
+ * this page on its own -- and naming one that no longer exists renders the
+ * key path instead of the value. Keep the two in step by hand, or derive
+ * both from one list.
  */
-const providerKeys = [
-  "company",
-  "represented",
-  "address",
-  "registration",
-  "euid",
-  "vatId",
-] as const;
+const providerKeys = ["company", "address"] as const;
 
 export default async function ReferralTermsPage() {
   const t = await getTranslations("help");

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -506,11 +506,7 @@
       "subtitle": "Právní informace podle § 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informace podle § 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Zastoupení: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "DIČ podle § 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Německo",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -499,18 +499,14 @@
     },
     "impressum": {
       "meta": {
-        "title": "Impressum - Kardashev Catalyst UG",
-        "description": "Impressum der Kardashev Catalyst UG (haftungsbeschränkt) - Betreiber von NISD2.eu. Angaben gemäß § 5 DDG und Kontaktdaten."
+        "title": "Impressum - NISD2.eu",
+        "description": "Impressum von NISD2.eu. Angaben gemäß § 5 DDG und Kontaktdaten."
       },
       "title": "Impressum",
       "subtitle": "Angaben gemäß § 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Angaben gemäß § 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Vertreten durch: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "USt-IdNr. gemäß § 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Deutschland",
         "emailLabel": "E-Mail",
         "email": "contact@nisd2.eu"

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -506,11 +506,7 @@
       "subtitle": "Legal notice pursuant to Section 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Information pursuant to Section 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Represented by: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "VAT ID pursuant to Section 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germany",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -506,11 +506,7 @@
       "subtitle": "Aviso legal conforme al artículo 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Información conforme al artículo 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Representada por: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "NIF-IVA conforme al artículo 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Alemania",
         "emailLabel": "Correo electrónico",
         "email": "contact@nisd2.eu"

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -506,11 +506,7 @@
       "subtitle": "Mentions légales conformément au paragraphe 5 du DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informations conformément au paragraphe 5 du DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Représentée par : Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID : DER3306.HRB126993",
-        "vatId": "Numéro de TVA conformément au paragraphe 27a de l'UStG : DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Allemagne",
         "emailLabel": "Courriel",
         "email": "contact@nisd2.eu"

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -506,11 +506,7 @@
       "subtitle": "Note legali ai sensi dell'articolo 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informazioni ai sensi dell'articolo 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Rappresentata da: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "Partita IVA ai sensi dell'articolo 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germania",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -506,11 +506,7 @@
       "subtitle": "Legal notice pursuant to Section 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Information pursuant to Section 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Represented by: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "VAT ID pursuant to Section 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germany",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -506,11 +506,7 @@
       "subtitle": "Nota prawna zgodnie z § 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informacje zgodnie z § 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Reprezentowana przez: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "NIP UE zgodnie z § 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Niemcy",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -506,11 +506,7 @@
       "subtitle": "Aviso legal nos termos do § 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informações nos termos do § 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Representada por: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "Número de IVA nos termos do § 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Alemanha",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -506,11 +506,7 @@
       "subtitle": "Notă juridică conform Secțiunii 5 DDG (Digitale-Dienste-Gesetz).",
       "responsible": {
         "heading": "Informații conform Secțiunii 5 DDG",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Reprezentată de: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
-        "euid": "EUID: DER3306.HRB126993",
-        "vatId": "Cod TVA conform Secțiunii 27a UStG: DE462889433",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germania",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"


### PR DESCRIPTION
Takes Kardashev Catalyst UG (haftungsbeschränkt) off the Impressum and puts Simon Orzel there instead, across all ten locales.

## What changed

`info.impressum.responsible` now reads:

```
Angaben gemäß § 5 DDG

Simon Orzel
Trierer Str. 6, 50676 Köln, Deutschland
E-Mail: contact@nisd2.eu
```

Four fields are gone, because they describe the UG and not a natural person:

| Field | Was |
| --- | --- |
| `represented` | Vertreten durch: Simon Orzel (Geschäftsführer) |
| `registration` | Amtsgericht Köln, HRB 126993 |
| `euid` | EUID: DER3306.HRB126993 |
| `vatId` | USt-IdNr. gemäß § 27a UStG: DE462889433 |

`address`, `emailLabel`, `email` and the whole § 18(2) MStV block already named Simon Orzel and are untouched, as are the dispute / liability / links / copyright sections. The German `meta.title` and `meta.description` named the UG and now match the other nine locales in naming NISD2.eu.

## Why /vermittlung is in the diff

`/vermittlung` renders its Anbieter block from the same `info.impressum.responsible` keys — the values have one home, the field list does not. Its `providerKeys` list named `represented`, `registration`, `euid` and `vatId`, so leaving it alone would have rendered the key paths in place of the deleted values. It is trimmed to `["company", "address"]` and now shows Simon Orzel too.

## Still naming Kardashev Catalyst UG — deliberately out of scope

This PR was scoped to the Impressum, so these were left alone and now disagree with it:

- `info.datenschutz.responsible.company` — the privacy policy's controller, all ten locales
- `info.toms.intro.p1` — the TOMs page, all ten locales
- `lib/seo.ts` — `legalName` on the site-wide Organization JSON-LD
- `/ethik`, `/finanzierung`, `lib/gdpr/certificate.ts`, `courses/LICENSE` and the three package `LICENSE`/`package.json` files

The privacy-policy controller is the one worth a decision soon: after this merges, /impressum says the operator is Simon Orzel while /datenschutz says the controller is the UG.

## Verification

- `bun run build` — clean
- `bun run typecheck` — clean
- `biome check` on the two touched pages — 4 errors, identical to the same files at `main` (pre-existing formatting drift in regions this PR does not touch)
- Audited every `impressum.responsible.*` reference in the codebase; all surviving references resolve to keys that still exist, and no deleted key is referenced anywhere
