### PR TITLE
legal: replace the UG with Simon Orzel across the codebase

### DIFF
--- a/app/[locale]/(info)/datenschutz/page.tsx
+++ b/app/[locale]/(info)/datenschutz/page.tsx
@@ -50,8 +50,6 @@ export default async function DatenschutzPage() {
           <CardContent className="space-y-1 text-sm text-muted-foreground">
             <p>{t("datenschutz.responsible.p1")}</p>
             <p className="mt-3 font-medium text-foreground">{t("datenschutz.responsible.company")}</p>
-            <p>{t("datenschutz.responsible.represented")}</p>
-            <p>{t("datenschutz.responsible.registration")}</p>
             <p>{t("datenschutz.responsible.address")}</p>
             <p>{t("datenschutz.responsible.emailLabel")}: {t("datenschutz.responsible.email")}</p>
           </CardContent>

--- a/app/[locale]/(info)/ethik/page.tsx
+++ b/app/[locale]/(info)/ethik/page.tsx
@@ -36,10 +36,9 @@ export default async function EthikPage({
         <h2>Conflicts of interest</h2>
         <p>
           We disclose every commercial relationship that could shape what we
-          write. The founders' direct financial interests (in the
-          Kardashev Catalyst UG that publishes nisd2.eu) are public via the
-          Impressum. We do not own equity in NIS 2 consultancies, audit
-          firms, or competing GRC platforms.
+          write. The direct financial interest behind nisd2.eu (Simon Orzel,
+          who publishes it) is public via the Impressum. We do not own equity
+          in NIS 2 consultancies, audit firms, or competing GRC platforms.
         </p>
 
         <h2>Advertising and sponsorships</h2>
@@ -80,10 +79,10 @@ export default async function EthikPage({
       <h2>Interessenkonflikte</h2>
       <p>
         Wir legen jede kommerzielle Beziehung offen, die unsere Inhalte
-        beeinflussen könnte. Die direkten finanziellen Interessen der Gründer
-        (an der Kardashev Catalyst UG, die nisd2.eu betreibt) sind über das
-        Impressum öffentlich. Wir halten keine Beteiligungen an
-        NIS 2 Beratungen, Auditfirmen oder konkurrierenden GRC-Plattformen.
+        beeinflussen könnte. Das direkte finanzielle Interesse hinter nisd2.eu
+        (Simon Orzel, der die Website betreibt) ist über das Impressum
+        öffentlich. Wir halten keine Beteiligungen an NIS 2 Beratungen,
+        Auditfirmen oder konkurrierenden GRC-Plattformen.
       </p>
 
       <h2>Werbung und Sponsorings</h2>

--- a/app/[locale]/(info)/finanzierung/page.tsx
+++ b/app/[locale]/(info)/finanzierung/page.tsx
@@ -33,12 +33,10 @@ export default async function FinanzierungPage({
       <div className="prose prose-sm max-w-none">
         <h1>How we are funded</h1>
 
-        <h2>Operating company</h2>
+        <h2>Operator</h2>
         <p>
-          The wiki and the NIS 2 platform are operated by Kardashev Catalyst UG
-          (haftungsbeschränkt), incorporated on 11 March 2026 in Germany. The
-          UG is co-owned by its two founders (Simon Orzel and Cory Hisey). No
-          external shareholders, no VC investment.
+          The wiki and the NIS 2 platform are operated by Simon Orzel in
+          Germany. No external shareholders, no VC investment.
         </p>
 
         <h2>Revenue today (2026)</h2>
@@ -81,12 +79,10 @@ export default async function FinanzierungPage({
     <div className="prose prose-sm max-w-none">
       <h1>Finanzierung</h1>
 
-      <h2>Betreibergesellschaft</h2>
+      <h2>Betreiber</h2>
       <p>
-        Wiki und NIS 2 Plattform werden von der Kardashev Catalyst UG
-        (haftungsbeschränkt) betrieben, gegründet am 11. März 2026 in
-        Deutschland. Die UG gehört zu je 50 % den beiden Gründern Simon Orzel
-        und Cory Hisey. Keine externen Gesellschafter, kein VC-Investment.
+        Wiki und NIS 2 Plattform werden von Simon Orzel in Deutschland
+        betrieben. Keine externen Gesellschafter, kein VC-Investment.
       </p>
 
       <h2>Einnahmen heute (2026)</h2>

--- a/courses/LICENSE
+++ b/courses/LICENSE
@@ -1,7 +1,7 @@
 Course content licence
 ======================
 
-Copyright (c) 2026 Kardashev Catalyst UG (haftungsbeschränkt)
+Copyright (c) 2026 Simon Orzel
 
 The course content in this directory is licensed under the
 Creative Commons Attribution 4.0 International License (CC BY 4.0).

--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -878,8 +878,8 @@ async function seed() {
     createUser: true,
   });
 
-  // Operating-company dogfood (Kardashev Catalyst UG) lives in the
-  // private notebook now: ~/repositories/NIS2/business/dogfood-seed-nisd2.ts.
+  // Operator dogfood seed lives in the private notebook now:
+  // ~/repositories/NIS2/business/dogfood-seed-nisd2.ts.
   // Audit P-3 (2026-06-10). The public seed stops at Dev GmbH.
 
   // ------------------------------------------------------------------

--- a/lib/content/authors.ts
+++ b/lib/content/authors.ts
@@ -6,8 +6,8 @@
  * components — always import from here.
  *
  * Founder direction (2026-05-29): publisher and worksFor both resolve
- * to the NISD2 brand. Legal entity (Kardashev Catalyst UG) stays out
- * of structured data — it lives in Impressum where it belongs.
+ * to the NISD2 brand, never to the operator behind it — that name
+ * belongs in the Impressum, not in an author byline.
  */
 
 export interface DocsAuthor {

--- a/lib/gdpr/certificate.ts
+++ b/lib/gdpr/certificate.ts
@@ -63,7 +63,7 @@ NISD2
 # Data Erasure Certificate
 
 **Case reference:** ${esc(row.caseRef)}
-**Controller:** Kardashev Catalyst UG (haftungsbeschränkt), Köln. Contact: contact@nisd2.eu
+**Controller:** Simon Orzel, Köln. Contact: contact@nisd2.eu
 
 This document records the erasure of personal data carried out under the EU
 General Data Protection Regulation (GDPR), Article 17 (right to erasure).

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -620,7 +620,7 @@ export function buildSiteGraphJsonLd(_locale: Locale): Record<string, unknown> {
         "@type": "Organization",
         "@id": `${baseUrl}/#organization`,
         name: "NISD2",
-        legalName: "Kardashev Catalyst UG (haftungsbeschränkt)",
+        legalName: "Simon Orzel",
         url: `${baseUrl}/`,
         logo: {
           "@type": "ImageObject" as const,

--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Správce údajů",
         "p1": "Správcem zpracování údajů na těchto webových stránkách je:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Zastoupená: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Německo",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Naposledy aktualizováno: červen 2026.",
       "intro": {
         "heading": "Přehled",
-        "p1": "Tento dokument popisuje technická a organizační opatření, která skutečně zavedla společnost Kardashev Catalyst UG (haftungsbeschränkt) jako provozovatel platformy NISD2.eu. Jde o poctivý soupis, nikoli o seznam přání. Uvádíme jen to, co je již zavedeno.",
+        "p1": "Tento dokument popisuje technická a organizační opatření, která skutečně zavedl Simon Orzel jako provozovatel platformy NISD2.eu. Jde o poctivý soupis, nikoli o seznam přání. Uvádíme jen to, co je již zavedeno.",
         "p2": "Opatření jsou v souladu s IT-Grundschutz (BSI) a budou rozšiřována s tím, jak platforma poroste."
       },
       "hosting": {

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Verantwortlicher",
         "p1": "Der Verantwortliche für die Datenverarbeitung auf dieser Website ist:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Vertreten durch: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Deutschland",
         "emailLabel": "E-Mail",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Stand: Juni 2026.",
       "intro": {
         "heading": "Überblick",
-        "p1": "Dieses Dokument beschreibt die technischen und organisatorischen Maßnahmen, die die Kardashev Catalyst UG (haftungsbeschränkt) als Betreiber der NISD2.eu-Plattform tatsächlich umsetzt. Es ist eine ehrliche Bestandsaufnahme, keine Wunschliste - wir nennen nur, was bereits implementiert ist.",
+        "p1": "Dieses Dokument beschreibt die technischen und organisatorischen Maßnahmen, die Simon Orzel als Betreiber der NISD2.eu-Plattform tatsächlich umsetzt. Es ist eine ehrliche Bestandsaufnahme, keine Wunschliste - wir nennen nur, was bereits implementiert ist.",
         "p2": "Die Maßnahmen orientieren sich an IT-Grundschutz (BSI) und werden mit dem Wachstum der Plattform erweitert."
       },
       "hosting": {

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Responsible Party",
         "p1": "The responsible party for data processing on this website is:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Represented by: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germany",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Last updated: June 2026.",
       "intro": {
         "heading": "Overview",
-        "p1": "This document describes the technical and organisational measures actually implemented by Kardashev Catalyst UG (haftungsbeschränkt) as operator of the NISD2.eu platform. It is an honest inventory, not a wish list - we list only what is already in place.",
+        "p1": "This document describes the technical and organisational measures actually implemented by Simon Orzel as operator of the NISD2.eu platform. It is an honest inventory, not a wish list - we list only what is already in place.",
         "p2": "The measures are aligned with IT-Grundschutz (BSI) and will be extended as the platform grows."
       },
       "hosting": {

--- a/messages/info/es.json
+++ b/messages/info/es.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Responsable del tratamiento",
         "p1": "El responsable del tratamiento de datos en este sitio web es:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Representada por: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Alemania",
         "emailLabel": "Correo electrónico",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Última actualización: junio de 2026.",
       "intro": {
         "heading": "Resumen",
-        "p1": "Este documento describe las medidas técnicas y organizativas efectivamente implementadas por Kardashev Catalyst UG (haftungsbeschränkt) como operadora de la plataforma NISD2.eu. Es un inventario honesto, no una lista de deseos: enumeramos solo lo que ya está implantado.",
+        "p1": "Este documento describe las medidas técnicas y organizativas efectivamente implementadas por Simon Orzel como operador de la plataforma NISD2.eu. Es un inventario honesto, no una lista de deseos: enumeramos solo lo que ya está implantado.",
         "p2": "Las medidas están alineadas con IT-Grundschutz (BSI) y se ampliarán a medida que crezca la plataforma."
       },
       "hosting": {

--- a/messages/info/fr.json
+++ b/messages/info/fr.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Responsable du traitement",
         "p1": "Le responsable du traitement des données sur ce site web est :",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Représentée par : Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germany",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Dernière mise à jour : juin 2026.",
       "intro": {
         "heading": "Vue d'ensemble",
-        "p1": "Ce document décrit les mesures techniques et organisationnelles effectivement mises en œuvre par Kardashev Catalyst UG (haftungsbeschränkt) en tant qu'exploitant de la plateforme NISD2.eu. Il s'agit d'un inventaire honnête, et non d'une liste de souhaits : nous ne mentionnons que ce qui est déjà en place.",
+        "p1": "Ce document décrit les mesures techniques et organisationnelles effectivement mises en œuvre par Simon Orzel en tant qu'exploitant de la plateforme NISD2.eu. Il s'agit d'un inventaire honnête, et non d'une liste de souhaits : nous ne mentionnons que ce qui est déjà en place.",
         "p2": "Les mesures sont alignées sur IT-Grundschutz (BSI) et seront étendues à mesure que la plateforme se développe."
       },
       "hosting": {

--- a/messages/info/it.json
+++ b/messages/info/it.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Titolare del trattamento",
         "p1": "Il titolare del trattamento dei dati su questo sito web è:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Rappresentata da: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germania",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Ultimo aggiornamento: giugno 2026.",
       "intro": {
         "heading": "Panoramica",
-        "p1": "Questo documento descrive le misure tecniche e organizzative effettivamente implementate da Kardashev Catalyst UG (haftungsbeschränkt) in qualità di gestore della piattaforma NISD2.eu. È un inventario onesto, non una lista di desideri: elenchiamo soltanto ciò che è già in atto.",
+        "p1": "Questo documento descrive le misure tecniche e organizzative effettivamente implementate da Simon Orzel in qualità di gestore della piattaforma NISD2.eu. È un inventario onesto, non una lista di desideri: elenchiamo soltanto ciò che è già in atto.",
         "p2": "Le misure sono allineate con IT-Grundschutz (BSI) e saranno ampliate man mano che la piattaforma cresce."
       },
       "hosting": {

--- a/messages/info/nl.json
+++ b/messages/info/nl.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Responsible Party",
         "p1": "The responsible party for data processing on this website is:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Represented by: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germany",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Last updated: June 2026.",
       "intro": {
         "heading": "Overview",
-        "p1": "This document describes the technical and organisational measures actually implemented by Kardashev Catalyst UG (haftungsbeschränkt) as operator of the NISD2.eu platform. It is an honest inventory, not a wish list - we list only what is already in place.",
+        "p1": "This document describes the technical and organisational measures actually implemented by Simon Orzel as operator of the NISD2.eu platform. It is an honest inventory, not a wish list - we list only what is already in place.",
         "p2": "The measures are aligned with IT-Grundschutz (BSI) and will be extended as the platform grows."
       },
       "hosting": {

--- a/messages/info/pl.json
+++ b/messages/info/pl.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Administrator danych",
         "p1": "Administratorem danych przetwarzanych w ramach tej witryny jest:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Reprezentowana przez: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Niemcy",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Ostatnia aktualizacja: czerwiec 2026.",
       "intro": {
         "heading": "Przegląd",
-        "p1": "Niniejszy dokument opisuje środki techniczne i organizacyjne faktycznie wdrożone przez Kardashev Catalyst UG (haftungsbeschränkt) jako operatora platformy NISD2.eu. Jest to rzetelny wykaz, a nie lista życzeń - wymieniamy wyłącznie to, co już jest wdrożone.",
+        "p1": "Niniejszy dokument opisuje środki techniczne i organizacyjne faktycznie wdrożone przez Simona Orzela jako operatora platformy NISD2.eu. Jest to rzetelny wykaz, a nie lista życzeń - wymieniamy wyłącznie to, co już jest wdrożone.",
         "p2": "Środki są zgodne z IT-Grundschutz (BSI) i będą rozszerzane wraz z rozwojem platformy."
       },
       "hosting": {

--- a/messages/info/pt.json
+++ b/messages/info/pt.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Responsável pelo Tratamento",
         "p1": "O responsável pelo tratamento de dados neste sítio web é:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Representada por: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Alemanha",
         "emailLabel": "Email",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Última atualização: junho de 2026.",
       "intro": {
         "heading": "Síntese",
-        "p1": "Este documento descreve as medidas técnicas e organizativas efetivamente implementadas pela Kardashev Catalyst UG (haftungsbeschränkt) na qualidade de operadora da plataforma NISD2.eu. Trata-se de um inventário honesto, não de uma lista de desejos. Listamos apenas o que já está implementado.",
+        "p1": "Este documento descreve as medidas técnicas e organizativas efetivamente implementadas por Simon Orzel na qualidade de operador da plataforma NISD2.eu. Trata-se de um inventário honesto, não de uma lista de desejos. Listamos apenas o que já está implementado.",
         "p2": "As medidas estão alinhadas com o IT-Grundschutz (BSI) e serão alargadas à medida que a plataforma cresce."
       },
       "hosting": {

--- a/messages/info/ro.json
+++ b/messages/info/ro.json
@@ -548,9 +548,7 @@
       "responsible": {
         "heading": "Operatorul de date",
         "p1": "Operatorul responsabil de prelucrarea datelor pe acest site este:",
-        "company": "Kardashev Catalyst UG (haftungsbeschränkt)",
-        "represented": "Reprezentat de: Simon Orzel (Geschäftsführer)",
-        "registration": "Amtsgericht Köln, HRB 126993",
+        "company": "Simon Orzel",
         "address": "Trierer Str. 6, 50676 Köln, Germania",
         "emailLabel": "E-mail",
         "email": "contact@nisd2.eu"
@@ -693,7 +691,7 @@
       "lastUpdated": "Ultima actualizare: iunie 2026.",
       "intro": {
         "heading": "Prezentare generală",
-        "p1": "Acest document descrie măsurile tehnice și organizatorice efectiv implementate de Kardashev Catalyst UG (haftungsbeschränkt) în calitate de operator al platformei NISD2.eu. Este un inventar onest, nu o listă de dorințe. Enumerăm doar ceea ce există deja.",
+        "p1": "Acest document descrie măsurile tehnice și organizatorice efectiv implementate de Simon Orzel în calitate de operator al platformei NISD2.eu. Este un inventar onest, nu o listă de dorințe. Enumerăm doar ceea ce există deja.",
         "p2": "Măsurile sunt aliniate cu IT-Grundschutz (BSI) și vor fi extinse pe măsură ce platforma crește."
       },
       "hosting": {

--- a/packages/grc-data-model/LICENSE
+++ b/packages/grc-data-model/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Kardashev Catalyst UG (haftungsbeschränkt)
+Copyright (c) 2026 Simon Orzel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/grc-data-model/README.md
+++ b/packages/grc-data-model/README.md
@@ -84,7 +84,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md). Issue templates for [incorrect mappi
 
 ## Maintainer
 
-Maintained by [Kardashev Catalyst UG (haftungsbeschränkt)](https://www.nisd2.eu/impressum) for [nisd2.eu](https://www.nisd2.eu) — a free EU NIS2 compliance platform. Contact: [contact@nisd2.eu](mailto:contact@nisd2.eu).
+Maintained by [Simon Orzel](https://www.nisd2.eu/impressum) for [nisd2.eu](https://www.nisd2.eu) — a free EU NIS2 compliance platform. Contact: [contact@nisd2.eu](mailto:contact@nisd2.eu).
 
 ## Licence
 

--- a/packages/grc-data-model/package.json
+++ b/packages/grc-data-model/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/NISD2/grc-data-model/issues"
   },
-  "author": "Kardashev Catalyst UG (haftungsbeschränkt) <contact@nisd2.eu> (https://nisd2.eu)",
+  "author": "Simon Orzel <contact@nisd2.eu> (https://nisd2.eu)",
   "keywords": [
     "nis2",
     "gdpr",

--- a/packages/incident-notification-schema/LICENSE
+++ b/packages/incident-notification-schema/LICENSE
@@ -15,7 +15,7 @@ You are free to share, adapt, and use the content commercially, provided you
 give appropriate credit. Suggested attribution:
 
     "Based on the NIS 2 Incident Notification Schema by
-     Kardashev Catalyst UG / nisd2.eu, licensed under CC BY 4.0.
+     Simon Orzel / nisd2.eu, licensed under CC BY 4.0.
      https://github.com/NISD2/nis2-incident-notification-schema"
 
 ------------------------------------------------------------------------------
@@ -27,7 +27,7 @@ All source code (everything in `src/`, plus build configuration files such as
 
     MIT License
 
-    Copyright (c) 2026 Kardashev Catalyst UG (haftungsbeschränkt)
+    Copyright (c) 2026 Simon Orzel
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/packages/incident-notification-schema/README.md
+++ b/packages/incident-notification-schema/README.md
@@ -155,4 +155,4 @@ applicable national authority's requirements.
 
 ## Maintainer
 
-Maintained by [Kardashev Catalyst UG (haftungsbeschränkt)](https://www.nisd2.eu/impressum) for [nisd2.eu](https://www.nisd2.eu) — a free EU NIS 2 compliance platform. Contact: [contact@nisd2.eu](mailto:contact@nisd2.eu).
+Maintained by [Simon Orzel](https://www.nisd2.eu/impressum) for [nisd2.eu](https://www.nisd2.eu) — a free EU NIS 2 compliance platform. Contact: [contact@nisd2.eu](mailto:contact@nisd2.eu).

--- a/packages/incident-notification-schema/package.json
+++ b/packages/incident-notification-schema/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/NISD2/nis2-incident-notification-schema/issues"
   },
-  "author": "Kardashev Catalyst UG (haftungsbeschränkt) <contact@nisd2.eu> (https://nisd2.eu)",
+  "author": "Simon Orzel <contact@nisd2.eu> (https://nisd2.eu)",
   "keywords": [
     "nis2",
     "incident-notification",

--- a/packages/nis2-supply-chain-questionnaire-schema/LICENSE
+++ b/packages/nis2-supply-chain-questionnaire-schema/LICENSE
@@ -13,7 +13,7 @@ descriptions, and the substantive content of the README) is licensed under
 You are free to share, adapt, and use the content commercially, provided you
 give appropriate credit. Suggested attribution:
 
-    "Based on the NIS2 Supplier Questionnaire by Kardashev Catalyst UG /
+    "Based on the NIS2 Supplier Questionnaire by Simon Orzel /
      nisd2.eu, licensed under CC BY 4.0.
      https://github.com/NISD2/nis2-supplier-questionnaire"
 
@@ -26,7 +26,7 @@ files such as `tsconfig.json` and `package.json`) is licensed under
 
     MIT License
 
-    Copyright (c) 2026 Kardashev Catalyst UG (haftungsbeschränkt)
+    Copyright (c) 2026 Simon Orzel
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),

--- a/packages/nis2-supply-chain-questionnaire-schema/SECURITY.md
+++ b/packages/nis2-supply-chain-questionnaire-schema/SECURITY.md
@@ -24,5 +24,5 @@ For non-security bugs, open a normal issue.
 
 ## Maintainers
 
-- Kardashev Catalyst UG (haftungsbeschränkt) — operator of nisd2.eu
+- Simon Orzel — operator of nisd2.eu
 - Primary contact: contact@nisd2.eu

--- a/packages/nis2-supply-chain-questionnaire-schema/package.json
+++ b/packages/nis2-supply-chain-questionnaire-schema/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/NISD2/nis2-supply-chain-questionnaire-schema/issues"
   },
-  "author": "Kardashev Catalyst UG (haftungsbeschränkt) <contact@nisd2.eu> (https://nisd2.eu)",
+  "author": "Simon Orzel <contact@nisd2.eu> (https://nisd2.eu)",
   "keywords": [
     "nis2",
     "supply-chain",


### PR DESCRIPTION
Follow-up to #133, which took Kardashev Catalyst UG (haftungsbeschränkt) off the Impressum only and left `/impressum` and `/datenschutz` disagreeing about who runs the site. This removes the entity everywhere.

After this, `grep -ri 'kardashev\|catalyst\|HRB 126993\|DER3306\|DE462889433'` over the repo returns nothing.

## Legal pages

- **`/datenschutz`** — the GDPR controller block now names Simon Orzel, and `represented` / `registration` are dropped in all ten locales, matching the Impressum. The page stops rendering those two lines.
- **TOMs intro** — names him as operator in all ten locales.

The TOMs sentence was written around a company noun, so a plain find-and-replace would have left broken grammar. Each locale was adjusted:

| Locale | Change beyond the name |
| --- | --- |
| `cs` | drops `společnost`, verb `zavedla` → masculine `zavedl` |
| `de` | drops the article: `die die Kardashev…` → `die Simon Orzel` |
| `es` | `operadora` → `operador` |
| `pt` | `pela` → `por`, `operadora` → `operador` |
| `pl` | declines to `przez Simona Orzela` |
| `en` `nl` `fr` `it` `ro` | name only; surrounding grammar already neutral |

**Worth a native-speaker glance:** cs, pl, pt, es, ro. The changes are small and in the same syntactic slot, but agreement and declension are outside what I can verify.

## Public prose

- **`/finanzierung`** — the section described an operating company: incorporation date, and a 50/50 split between two founders. None of that survives the entity. It now states the operator and keeps the funding disclosure the section exists for ("No external shareholders, no VC investment"). Heading `Operating company` → `Operator`, `Betreibergesellschaft` → `Betreiber`.
- **`/ethik`** — disclosed "the founders' direct financial interests (in the Kardashev Catalyst UG that publishes nisd2.eu)"; now discloses the single interest there is.

## Machine-readable and licensing

- `lib/seo.ts` — `Organization.legalName` in the site-wide JSON-LD
- `lib/gdpr/certificate.ts` — the **Controller** line on every GDPR erasure certificate
- Copyright holder on `courses/LICENSE` and the `LICENSE` of `grc-data-model`, `incident-notification-schema`, `nis2-supply-chain-questionnaire-schema`, plus the CC BY attribution strings inside two of them
- `author` field in those three `package.json` files, and the "Maintained by" line in their READMEs / SECURITY.md

Two comments mentioned the entity in passing and now name the role instead (`drizzle/seed.ts`, `lib/content/authors.ts`).

## Please look at this one

`/finanzierung` no longer states that **Cory Hisey** co-owns the operating company — that sentence had no referent once the UG goes. He is untouched as an author in `lib/content/authors.ts`. If he still holds a stake in whatever replaces the UG, that page needs a sentence I don't have the facts to write.

## Verification

- `bun run build` — clean, 70/70 static pages generated
- `bun run typecheck` — clean
- `biome check` on the 7 touched source files — 6 errors vs **8** at `main` for the same files (pre-existing formatting drift; this PR reduces it)
- All ten `messages/info/*.json` still parse; each lost exactly the same 2 keys, and the locale key-set grouping is byte-identical to `main` (the de/en/nl drift is pre-existing)
