### PR TITLE
fix(audit): record the sign-off invalidations the trail was dropping

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,14 @@ bun run e2e                # full browser suite (first run builds the app)
 bun run e2e:ui             # same, with the Playwright UI
 bun run e2e:serve          # serve the state a run left behind, without wiping it
 bun run e2e:demo-evidence  # attach example evidence PDFs to that state
+bun run e2e:image          # same suite, against a published image in the self-host stack
 ```
+
+`bun run e2e` builds locally and serves with `next start`, which bakes the
+local environment into the bundle. `e2e:image` pulls the artifact a
+self-hoster actually gets and runs the same specs against
+`compose.self-host.yml`; it is the only path that catches build-time-frozen
+config. Nothing in CI runs it yet, so it is a manual gate before a release.
 
 ## Isolation
 
@@ -33,7 +40,7 @@ The harness cannot reach production by construction:
 |---|---|---|
 | L0 | `l0/` | No browser: all 49 requirements classify, personas match schemas |
 | smoke | `smoke.spec.ts`, `i18n-sidebar.spec.ts` | Journey renders 49 nodes, auth redirect, sidebar locale regression |
-| L1 | `l1/` | Every intake form filled via UI, saved, round-trip verified; assets |
+| L1 | `l1/` | Every intake form filled via UI, saved, round-trip verified; assets and the audit row their writes invalidate; the first-login tour |
 | L2 | `l2/` | Module CRUD sweep, the 9 bespoke editors, evidence upload round-trip, edit/delete, validation |
 | L3 | `l3/` | Sign-off semantics incl. N-of-M with two sessions, cross-tenant isolation |
 | L4 | `l4/grand-tour.spec.ts` | Walks all 49 journey items to a fully signed-off 49/49 |

--- a/e2e/l1/assets.spec.ts
+++ b/e2e/l1/assets.spec.ts
@@ -10,6 +10,7 @@ import { assetInsertSchema } from "@/schema/validators";
 import { introspectSchema } from "@/lib/forms/schema-introspect";
 import { generateValue } from "../lib/value-factory";
 import { fillFields } from "../lib/form-driver";
+import { e2eQuery } from "../lib/db";
 
 const metas = introspectSchema(
   assetInsertSchema as Parameters<typeof introspectSchema>[0],
@@ -83,4 +84,24 @@ test.describe("asset inventory: grouped large-company entries", () => {
       ).toBeVisible({ timeout: 20_000 });
     });
   }
+
+  // Writing an asset reverts the requirements that reference the module, and
+  // that reversal has to reach the audit trail. It did not: module-recheck
+  // passed the module key "asset" as entity_id, a uuid column, so every insert
+  // failed and logAudit only console.errored it. The suite stayed green for
+  // weeks because nothing asserted the row. Runs last in the file so the three
+  // creates above have already triggered the revert (workers: 1, serial).
+  test("the revert those writes caused is recorded in the audit trail", async () => {
+    const rows = await e2eQuery<{ entity_id: string | null; description: string }>(
+      `SELECT entity_id, description
+         FROM audit_log
+        WHERE action = 'requirement.sign_off_invalidated'
+          AND entity_type = 'module'
+        ORDER BY created_at DESC`,
+    );
+    expect(rows.length, "sign_off_invalidated rows written").toBeGreaterThan(0);
+    // The module key belongs in the description, never in the uuid column.
+    expect(rows[0].entity_id).toBeNull();
+    expect(rows[0].description).toContain("reverted");
+  });
 });

--- a/lib/compliance/module-recheck.ts
+++ b/lib/compliance/module-recheck.ts
@@ -101,7 +101,13 @@ async function revertSignOffs(
     userId: ctx.userId,
     action: "requirement.sign_off_invalidated",
     entityType: "module",
-    entityId: moduleRef,
+    // audit_log.entity_id is a uuid column and moduleRef is a module key
+    // ("asset", "supplier"). Passing it made every insert fail on
+    // 22P02 invalid input syntax, and logAudit only console.errors, so the
+    // trail recorded no sign_off_invalidated event at all. The module key
+    // is carried by entityType + description, which is where /audit reads
+    // it from; nothing queries entity_id for this action.
+    entityId: null,
     description: `${moduleRef} ${reasonText} — reverted ${reverted.length} requirement(s): ${reverted.map((r) => r.code).join(", ")}`,
     previousValue: reverted,
     newValue: { status: "needs_review" },

--- a/packages/isms-trpc/src/audit/log-audit.ts
+++ b/packages/isms-trpc/src/audit/log-audit.ts
@@ -17,8 +17,27 @@ export interface AuditEntry {
 
 export type AuditDb = NodePgDatabase<Record<string, never>>;
 
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function createLogAudit(db: AuditDb) {
-  return async function logAudit(entry: AuditEntry): Promise<void> {
+  return async function logAudit(input: AuditEntry): Promise<void> {
+    // audit_log.entity_id is a uuid column, and AuditEntry types it as a
+    // plain string, so a caller passing a non-uuid key compiles and then
+    // fails the insert at runtime. Losing the whole row over one nullable
+    // field is the wrong trade for an accountability trail, so drop the
+    // bad id, keep the event, and make the caller bug visible.
+    // module-recheck.ts did exactly this and cost the trail every
+    // requirement.sign_off_invalidated event.
+    const entityIdIsUsable = input.entityId === null || UUID.test(input.entityId);
+    if (!entityIdIsUsable) {
+      console.warn("[audit] dropping non-uuid entityId, row kept", {
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+      });
+    }
+    const entry: AuditEntry = entityIdIsUsable ? input : { ...input, entityId: null };
+
     const checksum = computeChecksum(entry);
     try {
       await db.insert(auditLog).values({


### PR DESCRIPTION
## What was wrong

`revertSignOffs` in `lib/compliance/module-recheck.ts` passed the module key (`"asset"`, `"patch_record"`) as `entityId`, but `audit_log.entity_id` is a `uuid` column. Every insert failed on `22P02 invalid input syntax`, `logAudit` caught it and only `console.error`ed, so the tamper-evident trail held **zero** `requirement.sign_off_invalidated` events — the record that a data change reverted somebody's sign-off.

Known since 2026-08-20, still live on `main` today. Invisible because the failure path writes to stderr and returns.

Observed on a clean run of the current `main`:

```
[audit] failed to write audit_log row {
  action: 'requirement.sign_off_invalidated',
  entityType: 'module',
  entityId: 'asset',
  error: 'Failed query: insert into "audit_log" ...'
}
```

## The fix

The module key was never a uuid, and it is already carried by `entityType` plus the description (`asset data changed — reverted 4 requirement(s): 2.2, 4.4, 10.2`), which is where `/audit` reads it from. Nothing queries `entity_id` for this action, so it becomes `null`.

Two changes so it stays fixed:

1. **`packages/isms-trpc/src/audit/log-audit.ts`** — `logAudit` coerces a non-uuid `entityId` to `null`, warns, and writes the row anyway. `AuditEntry` types `entityId` as a plain `string`, so any of the ~40 call sites can reproduce this by hand; losing an accountability event over one nullable field is the wrong trade for a trail NIS 2 requires. The checksum is computed **after** the coercion, so it still describes the stored row. The run surfaced no other offenders.

2. **`e2e/l1/assets.spec.ts`** — the suite drove this path on every run and stayed green because nothing asserted the row. It now queries `audit_log` after the asset writes and fails if the invalidation event is missing, or if the module key is back in the uuid column.

## Verification

Full local suite against the hermetic stack, before and after:

| | audit rows dropped | result |
|---|---|---|
| `main` (baseline) | 2 | 92 passed, 4.0m |
| this branch | 0 | 93 passed, 3.7m |

The two rows that the baseline dropped now land:

```
              action              | entity_type | entity_id |            description
----------------------------------+-------------+-----------+------------------------------------
 requirement.sign_off_invalidated | module      |           | asset data changed — reverted 4 ...
 requirement.sign_off_invalidated | module      |           | patch_record data changed — rever...
```

`bun run typecheck` clean. `bun run test:l0` 114 passed.

## Also in here

`e2e/README.md` documents `bun run e2e:image` (added in #111, undocumented) and notes that no workflow runs it, so it is a manual gate before a release.

## Not fixed here, worth a decision

- The `main` ruleset requires one approving review but **no status checks** — neither `build` nor `e2e` can block a merge. That is the mechanism behind #88 merging red on 26.08.
- `e2e.yml` triggers only on `pull_request`, never on push to `main`, so two independently-green PRs can break `main` unseen.
- `scripts/e2e-against-image.sh` is not wired into any workflow; the release gate only checks the image boots and reports the right version.