### PR TITLE
fix(supplier-portal): show customers the service and the incidents meant for them

### DIFF
--- a/app/[locale]/supplier-access/[token]/page.tsx
+++ b/app/[locale]/supplier-access/[token]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import { api } from "@/lib/trpc/server";
 import { SecurityProfilePage } from "@/components/supplier-portal/SecurityProfilePage";
 import { CustomerAccessShell } from "@/components/supplier-portal/CustomerAccessShell";
+import { SharedServicesSection } from "@/components/supplier-portal/SharedServicesSection";
+import { SharedIncidentsSection } from "@/components/supplier-portal/SharedIncidentsSection";
 
 /**
  * Token-gated customer access page.
@@ -95,6 +97,22 @@ export default async function SupplierAccessPage({ params }: PageProps) {
         mode="view"
         supplierName={data.supplierCompany?.name ?? null}
       />
+
+      {/*
+        The two per-customer halves of the payload. getByToken has always
+        returned them, scoped to this relationship, and nothing rendered
+        them: `managedAssets` was destructured and dropped, `recentEvents`
+        had no renderer anywhere. That left the customer view showing only
+        the company-wide questionnaire, while the portal's own marketing
+        page promises "die Systeme, die Sie für ihn betreuen" and a per
+        customer incident feed.
+      */}
+      <div className="space-y-10 max-w-4xl mx-auto">
+        <hr className="border-muted" />
+        <SharedServicesSection services={data.managedAssets} />
+        <hr className="border-muted" />
+        <SharedIncidentsSection incidents={data.recentEvents} />
+      </div>
     </CustomerAccessShell>
   );
 }

--- a/components/supplier-portal/CustomerAccessShell.tsx
+++ b/components/supplier-portal/CustomerAccessShell.tsx
@@ -8,6 +8,7 @@
  * with the Revoke access button. The bearer token is the only credential.
  */
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { Loader2, LogOut, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ export function CustomerAccessShell({
   customerEmail: string;
 }) {
   const router = useRouter();
+  const t = useTranslations("supplierPortal.customerView");
   const [revoked, setRevoked] = useState(false);
 
   const revoke = trpc.supplierPortal.public.revoke.useMutation({
@@ -36,10 +38,8 @@ export function CustomerAccessShell({
         <Card className="max-w-md w-full">
           <CardContent className="py-10 text-center space-y-4">
             <CheckCircle2 className="h-12 w-12 text-green-600 mx-auto" />
-            <h1 className="text-xl font-semibold">Access revoked</h1>
-            <p className="text-sm text-muted-foreground">
-              You will no longer receive notifications from this supplier.
-            </p>
+            <h1 className="text-xl font-semibold">{t("revokedTitle")}</h1>
+            <p className="text-sm text-muted-foreground">{t("revokedBody")}</p>
           </CardContent>
         </Card>
       </div>
@@ -51,11 +51,12 @@ export function CustomerAccessShell({
       <header className="border-b bg-background sticky top-0 z-30">
         <div className="mx-auto max-w-4xl px-4 sm:px-6 py-3 flex items-center justify-between gap-4">
           <div className="text-xs text-muted-foreground">
-            Shared with you as <strong>{customerEmail}</strong>
+            {t("sharedWith")} <strong>{customerEmail}</strong>
           </div>
           <Button
             variant="outline"
             size="sm"
+            data-testid="revoke-access"
             onClick={() => revoke.mutate({ token })}
             disabled={revoke.isPending}
           >
@@ -64,7 +65,7 @@ export function CustomerAccessShell({
             ) : (
               <>
                 <LogOut className="h-3 w-3 mr-1" />
-                Revoke access
+                {t("revoke")}
               </>
             )}
           </Button>

--- a/components/supplier-portal/SecurityProfilePage.tsx
+++ b/components/supplier-portal/SecurityProfilePage.tsx
@@ -15,6 +15,7 @@
  *
  * Server component — receives the data already loaded by the route.
  */
+import { getTranslations } from "next-intl/server";
 import { ShieldCheck } from "lucide-react";
 import {
   SecurityProfileForm,
@@ -42,12 +43,13 @@ interface SecurityProfilePageProps {
   supplierName?: string | null;
 }
 
-export function SecurityProfilePage({
+export async function SecurityProfilePage({
   profile,
   certifications,
   mode,
   supplierName,
 }: SecurityProfilePageProps) {
+  const t = await getTranslations("supplierPortal.customerView");
   // ENISA TIG §5.1.2 selection-criteria shortcut: if the supplier has filled
   // in their own BSI registration ID, they are themselves directly regulated
   // under NIS2 — meaning the customer can shortcut a chunk of supplier
@@ -60,7 +62,7 @@ export function SecurityProfilePage({
       {supplierName && (
         <header className="space-y-2">
           <div className="text-xs uppercase tracking-wide text-muted-foreground">
-            Security profile
+            {t("securityProfile")}
           </div>
           <h1 className="text-3xl font-semibold tracking-tight">
             {supplierName}
@@ -68,7 +70,7 @@ export function SecurityProfilePage({
           {isNis2Regulated && (
             <div className="inline-flex items-center gap-2 rounded-full border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30 px-3 py-1 text-xs font-medium text-green-800 dark:text-green-200">
               <ShieldCheck className="h-3 w-3" />
-              Directly NIS2-regulated
+              {t("nis2Regulated")}
               <span className="text-green-700 dark:text-green-300 font-mono">
                 · BSI {profile.bsiRegistrationId}
               </span>
@@ -76,10 +78,7 @@ export function SecurityProfilePage({
           )}
           {mode === "view" && isNis2Regulated && (
             <p className="text-xs text-muted-foreground max-w-2xl">
-              This supplier is itself a NIS2-regulated entity with a registered
-              BSI ID. Per ENISA TIG §5.1.2, you may use this fact to satisfy a
-              significant portion of your supplier-selection-criteria
-              obligations under CIR 2024/2690.
+              {t("nis2RegulatedNote")}
             </p>
           )}
         </header>

--- a/components/supplier-portal/SharedIncidentsSection.tsx
+++ b/components/supplier-portal/SharedIncidentsSection.tsx
@@ -1,0 +1,86 @@
+/**
+ * Read-only view of the incidents a supplier has broadcast to ONE customer,
+ * rendered on the token-gated /supplier-access/[token] page.
+ *
+ * Same story as SharedServicesSection: public.getByToken already returns
+ * these, scoped to the caller's relationship via incident_broadcast and
+ * reduced to notification columns (the supplier's post-mortem — root cause,
+ * countermeasures, financial damage — is deliberately not in the payload).
+ * Nothing rendered them, so the supplier's own marketing page promised a
+ * feed the customer could not see.
+ *
+ * This is the customer-side half of what CustomerIncidentsSection publishes.
+ */
+import { getTranslations, getFormatter } from "next-intl/server";
+import { AlertCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { RouterOutputs } from "@/lib/trpc/client";
+
+type TokenView = NonNullable<
+  RouterOutputs["supplierPortal"]["public"]["getByToken"]
+>;
+export type SharedIncident = TokenView["recentEvents"][number];
+
+/** Only "significant" earns the loud variant; the rest stay quiet. */
+const severityVariant = (severity: string) =>
+  severity === "significant" ? "destructive" : "secondary";
+
+export async function SharedIncidentsSection({
+  incidents,
+}: {
+  incidents: readonly SharedIncident[];
+}) {
+  const [t, format] = await Promise.all([
+    getTranslations("supplierPortal.customerView"),
+    getFormatter(),
+  ]);
+
+  const date = (value: Date | string | null) =>
+    value ? format.dateTime(new Date(value), { dateStyle: "medium" }) : null;
+
+  return (
+    <section className="space-y-4" data-testid="shared-incidents">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold tracking-tight">{t("incidentsTitle")}</h2>
+        <p className="text-sm text-muted-foreground max-w-2xl">{t("incidentsIntro")}</p>
+      </div>
+
+      {incidents.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t("incidentsEmpty")}</p>
+      ) : (
+        <ul className="space-y-3">
+          {incidents.map((incident) => {
+            const discovered = date(incident.discoveredAt);
+            const resolved = date(incident.resolvedAt);
+            return (
+              <li key={incident.id} className="rounded-lg border bg-background p-4 space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <AlertCircle className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span className="font-medium">{incident.title}</span>
+                  <Badge variant={severityVariant(incident.severity)}>
+                    {t(`severity.${incident.severity}`)}
+                  </Badge>
+                </div>
+
+                {incident.description && (
+                  <p className="text-sm text-muted-foreground">{incident.description}</p>
+                )}
+
+                <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                  {discovered && (
+                    <span>
+                      {t("discovered")}: {discovered}
+                    </span>
+                  )}
+                  <span>
+                    {resolved ? `${t("resolved")}: ${resolved}` : t("ongoing")}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/components/supplier-portal/SharedServicesSection.tsx
+++ b/components/supplier-portal/SharedServicesSection.tsx
@@ -1,0 +1,154 @@
+/**
+ * Read-only view of the services a supplier has declared for ONE customer,
+ * rendered on the token-gated /supplier-access/[token] page.
+ *
+ * public.getByToken already returns these, scoped to the caller's
+ * relationship and reduced to the declaration columns (the supplier's own
+ * hostnames, patch dates and privileged-account counts are deliberately not
+ * in the payload). They were simply never rendered, so a customer saw the
+ * company-wide questionnaire and nothing about their own service.
+ *
+ * The supplier edits the same data at
+ * /portal/supplier/customers/[relationshipId]/assets via CustomerAssetsSection.
+ * This is the customer's half: no mutations, no tRPC, props only.
+ *
+ * Labels are reused, not restated: the offering fields already carry
+ * supplierPortal.fields.* + fieldDescriptions.* in all ten locales, and the
+ * asset-level security fields carry assets.fields.*.
+ */
+import { getTranslations } from "next-intl/server";
+import { Server } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { RouterOutputs } from "@/lib/trpc/client";
+
+type TokenView = NonNullable<
+  RouterOutputs["supplierPortal"]["public"]["getByToken"]
+>;
+export type SharedService = TokenView["managedAssets"][number];
+
+/** Which declarations apply depends on what kind of service this is. */
+const BRANCH_FIELDS = {
+  saas: ["saasHostingRegion"],
+  on_prem: [
+    "onPremSbomProvided",
+    "onPremSignedReleases",
+    "onPremVulnerabilityDisclosurePolicy",
+    "onPremPatchSlaCriticalHours",
+  ],
+  pro_services: [
+    "proServicesBackgroundCheckScope",
+    "proServicesNdaInPlace",
+    "proServicesCustomerPremisesPolicy",
+  ],
+  managed: [
+    "managedPrivilegedAccessMgmt",
+    "managedSessionRecording",
+    "managedOnCall24x7",
+  ],
+} as const satisfies Record<string, readonly (keyof SharedService)[]>;
+
+/** Asset-level security facts, declared per service rather than per company. */
+const ASSET_FIELDS = [
+  "hasMfa",
+  "encryptionAtRest",
+  "encryptionInTransit",
+  "hasBackup",
+  "rto",
+  "rpo",
+  "processesPersonalData",
+] as const satisfies readonly (keyof SharedService)[];
+
+type Row = { readonly key: string; readonly label: string; readonly value: string };
+
+export async function SharedServicesSection({
+  services,
+}: {
+  services: readonly SharedService[];
+}) {
+  const [t, tField, tAsset, tCommon] = await Promise.all([
+    getTranslations("supplierPortal.customerView"),
+    getTranslations("supplierPortal.fields"),
+    getTranslations("assets.fields"),
+    getTranslations("common"),
+  ]);
+
+  const format = (value: unknown): string | null => {
+    if (value === null || value === undefined || value === "") return null;
+    if (typeof value === "boolean") return value ? tCommon("yes") : tCommon("no");
+    return String(value);
+  };
+
+  const rowsFor = (service: SharedService): readonly Row[] => {
+    const branch =
+      service.serviceType && service.serviceType in BRANCH_FIELDS
+        ? BRANCH_FIELDS[service.serviceType as keyof typeof BRANCH_FIELDS]
+        : [];
+    const offering = ["dataProcessingLocations" as const, ...branch].map((key) => ({
+      key: String(key),
+      label: tField(key),
+      raw: service[key],
+    }));
+    const shared = ASSET_FIELDS.map((key) => ({
+      key: String(key),
+      label: tAsset(key),
+      raw: service[key],
+    }));
+    // An unanswered declaration renders as nothing rather than a row of
+    // "not specified" repeated fifteen times.
+    return [...offering, ...shared].flatMap<Row>(({ key, label, raw }) => {
+      const value = format(raw);
+      return value === null ? [] : [{ key, label, value }];
+    });
+  };
+
+  return (
+    <section className="space-y-4" data-testid="shared-services">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold tracking-tight">{t("servicesTitle")}</h2>
+        <p className="text-sm text-muted-foreground max-w-2xl">{t("servicesIntro")}</p>
+      </div>
+
+      {services.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t("servicesEmpty")}</p>
+      ) : (
+        <ul className="space-y-4">
+          {services.map((service) => {
+            const rows = rowsFor(service);
+            return (
+              <li key={service.id} className="rounded-lg border bg-background p-4 space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Server className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <span className="font-medium">{service.name}</span>
+                  {service.serviceType && (
+                    <Badge variant="secondary">
+                      {t(`serviceTypes.${service.serviceType}`)}
+                    </Badge>
+                  )}
+                </div>
+
+                {service.serviceDescription && (
+                  <p className="text-sm text-muted-foreground">
+                    {service.serviceDescription}
+                  </p>
+                )}
+
+                {rows.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">{t("nothingDeclared")}</p>
+                ) : (
+                  <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2 text-sm">
+                    {rows.map((row) => (
+                      <div key={row.key} className="flex justify-between gap-3">
+                        <dt className="text-muted-foreground">{row.label}</dt>
+                        <dd className="text-right font-medium">{row.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/messages/supplierPortal/cs.json
+++ b/messages/supplierPortal/cs.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Podrobnosti o profesionálních službách",
       "sectionManaged": "Podrobnosti o řízených službách"
     },
+    "customerView": {
+      "securityProfile": "Bezpečnostní profil",
+      "sharedWith": "Sdíleno s vámi jako",
+      "revoke": "Ukončit přístup",
+      "revokedTitle": "Přístup ukončen",
+      "revokedBody": "Od tohoto dodavatele již nebudete dostávat oznámení.",
+      "nis2Regulated": "Sám podléhá NIS2",
+      "nis2RegulatedNote": "Tento dodavatel sám spadá pod NIS2 a je registrován u BSI. Podle ENISA TIG §5.1.2 se na to můžete opřít u podstatné části svého hodnocení dodavatele podle CIR 2024/2690.",
+      "servicesTitle": "Systémy, které pro vás tento dodavatel provozuje",
+      "servicesIntro": "Tyto údaje platí pouze pro vaši spolupráci. Ostatní zákazníci téhož dodavatele vidí své vlastní systémy, nikoli tyto.",
+      "servicesEmpty": "Zatím pro vás nebyl zaznamenán žádný systém.",
+      "nothingDeclared": "K tomuto systému zatím nebyly poskytnuty žádné údaje.",
+      "incidentsTitle": "Incidenty, které vám byly nahlášeny",
+      "incidentsIntro": "Pouze incidenty, které vám tento dodavatel nahlásil. Jejich sledování patří k článku 21 odst. 2 písm. d) NIS2.",
+      "incidentsEmpty": "Dosud vám nebyl nahlášen žádný incident.",
+      "discovered": "Zjištěno",
+      "resolved": "Vyřešeno",
+      "ongoing": "Dosud neuzavřeno",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software u vás",
+        "pro_services": "Odborné služby",
+        "managed": "Spravovaná služba"
+      },
+      "severity": {
+        "near_miss": "Téměř incident",
+        "incident": "Incident",
+        "significant": "Významný incident"
+      }
+    },
     "fields": {
       "legalName": "Obchodní firma",
       "registeredAddress": "Sídlo zapsané v rejstříku",

--- a/messages/supplierPortal/de.json
+++ b/messages/supplierPortal/de.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Dienstleistungen: Details",
       "sectionManaged": "Managed Services: Details"
     },
+    "customerView": {
+      "securityProfile": "Sicherheitsprofil",
+      "sharedWith": "Freigegeben für",
+      "revoke": "Zugriff beenden",
+      "revokedTitle": "Zugriff beendet",
+      "revokedBody": "Sie erhalten keine Meldungen mehr von diesem Lieferanten.",
+      "nis2Regulated": "Direkt NIS2-reguliert",
+      "nis2RegulatedNote": "Dieser Lieferant fällt selbst unter NIS2 und ist beim BSI registriert. Nach ENISA TIG §5.1.2 können Sie das für einen großen Teil Ihrer Lieferantenprüfung nach CIR 2024/2690 heranziehen.",
+      "servicesTitle": "Systeme, die dieser Lieferant für Sie betreut",
+      "servicesIntro": "Diese Angaben gelten nur für Ihre Zusammenarbeit. Andere Kunden desselben Lieferanten sehen ihre eigenen Systeme, nicht diese.",
+      "servicesEmpty": "Für Sie ist bisher kein System eingetragen.",
+      "nothingDeclared": "Zu diesem System liegen noch keine Angaben vor.",
+      "incidentsTitle": "Vorfälle, die Ihnen gemeldet wurden",
+      "incidentsIntro": "Nur Vorfälle, die dieser Lieferant an Sie gemeldet hat. Die laufende Übersicht gehört zu Artikel 21 Absatz 2 Buchstabe d NIS2.",
+      "incidentsEmpty": "Bisher wurde Ihnen kein Vorfall gemeldet.",
+      "discovered": "Entdeckt",
+      "resolved": "Behoben",
+      "ongoing": "Noch nicht abgeschlossen",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software bei Ihnen",
+        "pro_services": "Dienstleistung",
+        "managed": "Managed Service"
+      },
+      "severity": {
+        "near_miss": "Beinahevorfall",
+        "incident": "Vorfall",
+        "significant": "Erheblicher Vorfall"
+      }
+    },
     "fields": {
       "legalName": "Firmierung (Rechtsname)",
       "registeredAddress": "Geschäftsanschrift",

--- a/messages/supplierPortal/en.json
+++ b/messages/supplierPortal/en.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Professional services details",
       "sectionManaged": "Managed service details"
     },
+    "customerView": {
+      "securityProfile": "Security profile",
+      "sharedWith": "Shared with you as",
+      "revoke": "End access",
+      "revokedTitle": "Access ended",
+      "revokedBody": "You will no longer receive notifications from this supplier.",
+      "nis2Regulated": "Directly regulated under NIS2",
+      "nis2RegulatedNote": "This supplier is itself in scope of NIS2 and registered with the BSI. Under ENISA TIG §5.1.2 you may rely on that for a large part of your supplier assessment under CIR 2024/2690.",
+      "servicesTitle": "Systems this supplier runs for you",
+      "servicesIntro": "These answers apply to your relationship only. Other customers of the same supplier see their own systems, not these.",
+      "servicesEmpty": "No system has been recorded for you yet.",
+      "nothingDeclared": "No details have been provided for this system yet.",
+      "incidentsTitle": "Incidents reported to you",
+      "incidentsIntro": "Only incidents this supplier reported to you. Keeping track of them is part of Article 21(2)(d) NIS2.",
+      "incidentsEmpty": "No incident has been reported to you so far.",
+      "discovered": "Discovered",
+      "resolved": "Resolved",
+      "ongoing": "Not yet closed",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software on your premises",
+        "pro_services": "Professional services",
+        "managed": "Managed service"
+      },
+      "severity": {
+        "near_miss": "Near miss",
+        "incident": "Incident",
+        "significant": "Significant incident"
+      }
+    },
     "fields": {
       "legalName": "Legal name",
       "registeredAddress": "Registered address",

--- a/messages/supplierPortal/es.json
+++ b/messages/supplierPortal/es.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Detalles de servicios profesionales",
       "sectionManaged": "Detalles de servicios gestionados"
     },
+    "customerView": {
+      "securityProfile": "Perfil de seguridad",
+      "sharedWith": "Compartido con usted como",
+      "revoke": "Finalizar el acceso",
+      "revokedTitle": "Acceso finalizado",
+      "revokedBody": "Ya no recibirá notificaciones de este proveedor.",
+      "nis2Regulated": "Sujeto directamente a NIS2",
+      "nis2RegulatedNote": "Este proveedor está a su vez dentro del ámbito de NIS2 y registrado ante el BSI. Según ENISA TIG §5.1.2 puede apoyarse en ello para buena parte de su evaluación de proveedores conforme al CIR 2024/2690.",
+      "servicesTitle": "Sistemas que este proveedor opera para usted",
+      "servicesIntro": "Estos datos se refieren únicamente a su relación. Otros clientes del mismo proveedor ven sus propios sistemas, no estos.",
+      "servicesEmpty": "Todavía no se ha registrado ningún sistema para usted.",
+      "nothingDeclared": "Aún no se han facilitado datos sobre este sistema.",
+      "incidentsTitle": "Incidentes que se le han comunicado",
+      "incidentsIntro": "Solo los incidentes que este proveedor le ha comunicado. Su seguimiento forma parte del artículo 21, apartado 2, letra d), NIS2.",
+      "incidentsEmpty": "Hasta ahora no se le ha comunicado ningún incidente.",
+      "discovered": "Detectado",
+      "resolved": "Resuelto",
+      "ongoing": "Aún no cerrado",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software en sus instalaciones",
+        "pro_services": "Servicios profesionales",
+        "managed": "Servicio gestionado"
+      },
+      "severity": {
+        "near_miss": "Cuasi incidente",
+        "incident": "Incidente",
+        "significant": "Incidente significativo"
+      }
+    },
     "fields": {
       "legalName": "Razón social",
       "registeredAddress": "Domicilio social",

--- a/messages/supplierPortal/fr.json
+++ b/messages/supplierPortal/fr.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Détails des services professionnels",
       "sectionManaged": "Détails des services gérés"
     },
+    "customerView": {
+      "securityProfile": "Profil de sécurité",
+      "sharedWith": "Partagé avec vous en tant que",
+      "revoke": "Mettre fin à l'accès",
+      "revokedTitle": "Accès terminé",
+      "revokedBody": "Vous ne recevrez plus de notifications de ce fournisseur.",
+      "nis2Regulated": "Directement soumis à NIS2",
+      "nis2RegulatedNote": "Ce fournisseur relève lui-même de NIS2 et est enregistré auprès du BSI. Selon ENISA TIG §5.1.2, vous pouvez vous appuyer sur ce fait pour une grande partie de votre évaluation fournisseur au titre du CIR 2024/2690.",
+      "servicesTitle": "Systèmes que ce fournisseur exploite pour vous",
+      "servicesIntro": "Ces informations ne concernent que votre relation. Les autres clients du même fournisseur voient leurs propres systèmes, pas ceux-ci.",
+      "servicesEmpty": "Aucun système n'a encore été enregistré pour vous.",
+      "nothingDeclared": "Aucune information n'a encore été fournie pour ce système.",
+      "incidentsTitle": "Incidents qui vous ont été signalés",
+      "incidentsIntro": "Uniquement les incidents que ce fournisseur vous a signalés. Leur suivi relève de l'article 21, paragraphe 2, point d), NIS2.",
+      "incidentsEmpty": "Aucun incident ne vous a été signalé à ce jour.",
+      "discovered": "Découvert",
+      "resolved": "Résolu",
+      "ongoing": "Pas encore clos",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Logiciel chez vous",
+        "pro_services": "Prestations de services",
+        "managed": "Service managé"
+      },
+      "severity": {
+        "near_miss": "Quasi-incident",
+        "incident": "Incident",
+        "significant": "Incident important"
+      }
+    },
     "fields": {
       "legalName": "Raison sociale",
       "registeredAddress": "Adresse du siège social",

--- a/messages/supplierPortal/it.json
+++ b/messages/supplierPortal/it.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Dettagli dei servizi professionali",
       "sectionManaged": "Dettagli del servizio gestito"
     },
+    "customerView": {
+      "securityProfile": "Profilo di sicurezza",
+      "sharedWith": "Condiviso con lei come",
+      "revoke": "Terminare l'accesso",
+      "revokedTitle": "Accesso terminato",
+      "revokedBody": "Non riceverà più notifiche da questo fornitore.",
+      "nis2Regulated": "Direttamente soggetto a NIS2",
+      "nis2RegulatedNote": "Questo fornitore rientra a sua volta nell'ambito NIS2 ed è registrato presso il BSI. Secondo ENISA TIG §5.1.2 può basarsi su questo fatto per gran parte della sua valutazione dei fornitori ai sensi del CIR 2024/2690.",
+      "servicesTitle": "Sistemi che questo fornitore gestisce per lei",
+      "servicesIntro": "Queste informazioni valgono solo per il vostro rapporto. Gli altri clienti dello stesso fornitore vedono i propri sistemi, non questi.",
+      "servicesEmpty": "Non è ancora stato registrato alcun sistema per lei.",
+      "nothingDeclared": "Per questo sistema non sono ancora state fornite informazioni.",
+      "incidentsTitle": "Incidenti che le sono stati segnalati",
+      "incidentsIntro": "Solo gli incidenti che questo fornitore le ha segnalato. Tenerne traccia rientra nell'articolo 21, paragrafo 2, lettera d), NIS2.",
+      "incidentsEmpty": "Finora non le è stato segnalato alcun incidente.",
+      "discovered": "Rilevato",
+      "resolved": "Risolto",
+      "ongoing": "Non ancora chiuso",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software presso di lei",
+        "pro_services": "Servizi professionali",
+        "managed": "Servizio gestito"
+      },
+      "severity": {
+        "near_miss": "Quasi incidente",
+        "incident": "Incidente",
+        "significant": "Incidente significativo"
+      }
+    },
     "fields": {
       "legalName": "Denominazione legale",
       "registeredAddress": "Indirizzo della sede legale",

--- a/messages/supplierPortal/nl.json
+++ b/messages/supplierPortal/nl.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Details professionele diensten",
       "sectionManaged": "Details beheerde diensten"
     },
+    "customerView": {
+      "securityProfile": "Beveiligingsprofiel",
+      "sharedWith": "Gedeeld met u als",
+      "revoke": "Toegang beëindigen",
+      "revokedTitle": "Toegang beëindigd",
+      "revokedBody": "U ontvangt geen meldingen meer van deze leverancier.",
+      "nis2Regulated": "Zelf onder NIS2",
+      "nis2RegulatedNote": "Deze leverancier valt zelf onder NIS2 en is geregistreerd bij het BSI. Volgens ENISA TIG §5.1.2 kunt u dat gebruiken voor een groot deel van uw leveranciersbeoordeling onder CIR 2024/2690.",
+      "servicesTitle": "Systemen die deze leverancier voor u beheert",
+      "servicesIntro": "Deze gegevens gelden alleen voor uw samenwerking. Andere klanten van dezelfde leverancier zien hun eigen systemen, niet deze.",
+      "servicesEmpty": "Er is nog geen systeem voor u vastgelegd.",
+      "nothingDeclared": "Over dit systeem zijn nog geen gegevens verstrekt.",
+      "incidentsTitle": "Incidenten die aan u zijn gemeld",
+      "incidentsIntro": "Alleen incidenten die deze leverancier aan u heeft gemeld. Dat bijhouden hoort bij artikel 21, lid 2, onder d, NIS2.",
+      "incidentsEmpty": "Er is tot nu toe geen incident aan u gemeld.",
+      "discovered": "Ontdekt",
+      "resolved": "Opgelost",
+      "ongoing": "Nog niet afgerond",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software bij u",
+        "pro_services": "Dienstverlening",
+        "managed": "Managed service"
+      },
+      "severity": {
+        "near_miss": "Bijna-incident",
+        "incident": "Incident",
+        "significant": "Significant incident"
+      }
+    },
     "fields": {
       "legalName": "Wettelijke naam",
       "registeredAddress": "Geregistreerd adres",

--- a/messages/supplierPortal/pl.json
+++ b/messages/supplierPortal/pl.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Szczegóły usług profesjonalnych",
       "sectionManaged": "Szczegóły usług zarządzanych"
     },
+    "customerView": {
+      "securityProfile": "Profil bezpieczeństwa",
+      "sharedWith": "Udostępniono Państwu jako",
+      "revoke": "Zakończ dostęp",
+      "revokedTitle": "Dostęp zakończony",
+      "revokedBody": "Nie będą Państwo już otrzymywać powiadomień od tego dostawcy.",
+      "nis2Regulated": "Sam podlega NIS2",
+      "nis2RegulatedNote": "Ten dostawca sam podlega NIS2 i jest zarejestrowany w BSI. Zgodnie z ENISA TIG §5.1.2 mogą Państwo oprzeć na tym znaczną część oceny dostawcy według CIR 2024/2690.",
+      "servicesTitle": "Systemy, które ten dostawca prowadzi dla Państwa",
+      "servicesIntro": "Te dane dotyczą wyłącznie Państwa współpracy. Inni klienci tego samego dostawcy widzą własne systemy, nie te.",
+      "servicesEmpty": "Nie zapisano jeszcze żadnego systemu dla Państwa.",
+      "nothingDeclared": "Do tego systemu nie podano jeszcze żadnych danych.",
+      "incidentsTitle": "Incydenty zgłoszone Państwu",
+      "incidentsIntro": "Tylko incydenty, które ten dostawca Państwu zgłosił. Ich śledzenie należy do artykułu 21 ust. 2 lit. d NIS2.",
+      "incidentsEmpty": "Dotychczas nie zgłoszono Państwu żadnego incydentu.",
+      "discovered": "Wykryto",
+      "resolved": "Rozwiązano",
+      "ongoing": "Jeszcze niezamknięty",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Oprogramowanie u Państwa",
+        "pro_services": "Usługi profesjonalne",
+        "managed": "Usługa zarządzana"
+      },
+      "severity": {
+        "near_miss": "Zdarzenie potencjalnie wypadkowe",
+        "incident": "Incydent",
+        "significant": "Poważny incydent"
+      }
+    },
     "fields": {
       "legalName": "Nazwa prawna",
       "registeredAddress": "Adres siedziby",

--- a/messages/supplierPortal/pt.json
+++ b/messages/supplierPortal/pt.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Detalhes de serviços profissionais",
       "sectionManaged": "Detalhes de serviço gerido"
     },
+    "customerView": {
+      "securityProfile": "Perfil de segurança",
+      "sharedWith": "Partilhado consigo como",
+      "revoke": "Terminar o acesso",
+      "revokedTitle": "Acesso terminado",
+      "revokedBody": "Deixará de receber notificações deste fornecedor.",
+      "nis2Regulated": "Diretamente sujeito à NIS2",
+      "nis2RegulatedNote": "Este fornecedor está ele próprio no âmbito da NIS2 e registado junto do BSI. Nos termos do ENISA TIG §5.1.2 pode apoiar-se nesse facto para grande parte da sua avaliação de fornecedores ao abrigo do CIR 2024/2690.",
+      "servicesTitle": "Sistemas que este fornecedor opera para si",
+      "servicesIntro": "Estes dados dizem respeito apenas à vossa relação. Outros clientes do mesmo fornecedor veem os seus próprios sistemas, não estes.",
+      "servicesEmpty": "Ainda não foi registado nenhum sistema para si.",
+      "nothingDeclared": "Ainda não foram fornecidos dados sobre este sistema.",
+      "incidentsTitle": "Incidentes que lhe foram comunicados",
+      "incidentsIntro": "Apenas os incidentes que este fornecedor lhe comunicou. Acompanhá-los faz parte do artigo 21.º, n.º 2, alínea d), da NIS2.",
+      "incidentsEmpty": "Até agora não lhe foi comunicado nenhum incidente.",
+      "discovered": "Detetado",
+      "resolved": "Resolvido",
+      "ongoing": "Ainda não encerrado",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software nas suas instalações",
+        "pro_services": "Serviços profissionais",
+        "managed": "Serviço gerido"
+      },
+      "severity": {
+        "near_miss": "Quase incidente",
+        "incident": "Incidente",
+        "significant": "Incidente significativo"
+      }
+    },
     "fields": {
       "legalName": "Designação legal",
       "registeredAddress": "Morada da sede",

--- a/messages/supplierPortal/ro.json
+++ b/messages/supplierPortal/ro.json
@@ -91,6 +91,36 @@
       "sectionProServices": "Detalii servicii profesionale",
       "sectionManaged": "Detalii servicii gestionate"
     },
+    "customerView": {
+      "securityProfile": "Profil de securitate",
+      "sharedWith": "Partajat cu dumneavoastră ca",
+      "revoke": "Încheiați accesul",
+      "revokedTitle": "Acces încheiat",
+      "revokedBody": "Nu veți mai primi notificări de la acest furnizor.",
+      "nis2Regulated": "Direct sub incidența NIS2",
+      "nis2RegulatedNote": "Acest furnizor intră el însuși sub incidența NIS2 și este înregistrat la BSI. Conform ENISA TIG §5.1.2 vă puteți baza pe acest fapt pentru o mare parte din evaluarea furnizorului potrivit CIR 2024/2690.",
+      "servicesTitle": "Sisteme pe care acest furnizor le operează pentru dumneavoastră",
+      "servicesIntro": "Aceste date se referă numai la relația dumneavoastră. Alți clienți ai aceluiași furnizor își văd propriile sisteme, nu pe acestea.",
+      "servicesEmpty": "Încă nu a fost înregistrat niciun sistem pentru dumneavoastră.",
+      "nothingDeclared": "Pentru acest sistem nu au fost furnizate încă date.",
+      "incidentsTitle": "Incidente care v-au fost raportate",
+      "incidentsIntro": "Numai incidentele pe care acest furnizor vi le-a raportat. Urmărirea lor ține de articolul 21 alineatul (2) litera (d) NIS2.",
+      "incidentsEmpty": "Până acum nu v-a fost raportat niciun incident.",
+      "discovered": "Descoperit",
+      "resolved": "Rezolvat",
+      "ongoing": "Încă neînchis",
+      "serviceTypes": {
+        "saas": "SaaS",
+        "on_prem": "Software la sediul dumneavoastră",
+        "pro_services": "Servicii profesionale",
+        "managed": "Serviciu administrat"
+      },
+      "severity": {
+        "near_miss": "Cvasi-incident",
+        "incident": "Incident",
+        "significant": "Incident semnificativ"
+      }
+    },
     "fields": {
       "legalName": "Denumire legală",
       "registeredAddress": "Adresă înregistrată",


### PR DESCRIPTION
## The gap

`supplierPortal.public.getByToken` returns five things: `relationship`, `supplierCompany`, `managedAssets`, `recentEvents`, `certifications`. The customer page passed **one** of them on.

- `managedAssets` — destructured and never used
- `recentEvents` — no renderer anywhere in `app/` or `components/`
- `certifications` — the only one that reached the screen

So an invited customer opening their private link saw the supplier's company-wide questionnaire and nothing else: not the systems that supplier runs for *them*, not the incidents broadcast to *them*. Both were computed, scoped to their relationship, and whitelisted column by column on the server, then dropped on the floor.

The portal's own marketing page promises the opposite, in `supplierPortal.marketing`:

> step3Body: "Jeder Kunde bekommt einen eigenen, privaten Link. Er sieht Ihr Profil, **die Systeme, die Sie für ihn betreuen**, und Ihre Zertifikate."
> step4Body: "Ist ein System eines Kunden betroffen, melden Sie das aus dem Portal heraus. **Nur dieser eine Kunde sieht die Meldung.**"

Per-customer declarations and the incident feed are the reason the portal exists. Without them the customer view is a generic questionnaire any supplier could hand out once, which is the thing the product positions against.

## The fix

Two read-only server components render what the payload already carries. They take props, run no mutations and call no tRPC — the supplier edits the same data through `CustomerAssetsSection` / `CustomerIncidentsSection` on `/portal/supplier/customers/[id]/*`, and this is the customer's half of it.

**Labels are reused, not restated.** The offering fields already carry `supplierPortal.fields.*` plus `fieldDescriptions.*` in all ten locales, and the asset-level security fields carry `assets.fields.*`. So the only new strings are 24 section-level keys, added to all ten locales and verified key-identical across them. Declarations the supplier left blank render as nothing rather than as fifteen rows of "not specified".

**Chrome moves into the same namespace.** "Shared with you as", "Revoke access", "Security profile" and the ENISA §5.1.2 note were hardcoded English on a page whose form is already German. The customer view is now coherent in one language instead of two.

**The revoke button gains a testid.** Translating its label broke an accessible-name regex in the e2e suite — which is what that regex was always going to do on the next locale.

## Verification

`bun run typecheck` clean. Full suite on this branch: **97 passed**.

The five supplier-portal specs pass against it, including one DOM check that was previously worthless: "customer B's service is absent from A's page" could not fail while no services rendered at all. It can now.

The e2e spec updates land in a separate PR, so this one is the product change on its own.