### PR TITLE
test(e2e): make the suite prove what it claims, and cover the supplier portal

### DIFF
--- a/components/compliance/FileUpload.tsx
+++ b/components/compliance/FileUpload.tsx
@@ -135,7 +135,12 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
                   className="h-7 w-7"
                   asChild
                 >
-                  <a href={f.downloadUrl} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={f.downloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-testid="evidence-download"
+                  >
                     <Download className="h-3.5 w-3.5" />
                   </a>
                 </Button>

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,8 +16,20 @@ bun run e2e:image          # same suite, against a published image in the self-h
 `bun run e2e` builds locally and serves with `next start`, which bakes the
 local environment into the bundle. `e2e:image` pulls the artifact a
 self-hoster actually gets and runs the same specs against
-`compose.self-host.yml`; it is the only path that catches build-time-frozen
-config. Nothing in CI runs it yet, so it is a manual gate before a release.
+`compose.self-host.yml`, so it is the only path that catches build-time-frozen
+config (that is how the frozen CSP storage origin was found).
+
+**It runs the working tree's specs against a released image, so the two drift
+apart between releases.** Any spec written for behaviour that has not shipped
+yet fails, and the failure says nothing about the image. Against `:stable`
+(v0.2.8, 27.08) on 03.09 it was 90 passed and 3 failed, and all three were
+specs from PRs merged after the tag (#119, #128, #136). Read a failure here as
+"spec newer than image" until you have ruled it
+out — `git diff --name-only <tag>..HEAD -- e2e/` tells you which specs moved,
+and `git merge-base --is-ancestor <commit> <tag>` settles whether the spec
+predates the image. The version-matched way to run it is from the tag:
+`git checkout v0.2.8 && bun run e2e:image 0.2.8`. Nothing in CI runs it
+either way.
 
 ## Isolation
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,7 +54,7 @@ The harness cannot reach production by construction:
 | smoke | `smoke.spec.ts`, `i18n-sidebar.spec.ts` | Journey renders 49 nodes, auth redirect, sidebar locale regression |
 | L1 | `l1/` | Every intake form filled via UI, saved, round-trip verified; assets and the audit row their writes invalidate; the first-login tour |
 | L2 | `l2/` | Module CRUD sweep, the 9 bespoke editors, evidence upload round-trip, edit/delete, validation |
-| L3 | `l3/` | Sign-off semantics incl. N-of-M with two sessions, cross-tenant isolation |
+| L3 | `l3/` | Sign-off semantics incl. N-of-M with two sessions, cross-tenant isolation, the token-gated supplier portal (the app's only unauthenticated data surface) |
 | L4 | `l4/grand-tour.spec.ts` | Walks all 49 journey items to a fully signed-off 49/49 |
 
 Ordering is load-bearing. `workers: 1` and `fullyParallel: false` are

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,7 +12,16 @@ services:
       POSTGRES_PASSWORD: e2e
       POSTGRES_DB: openisms_e2e
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U e2e -d openisms_e2e"]
+      # -h 127.0.0.1 is load-bearing. Without it pg_isready checks the unix
+      # socket, and the postgres entrypoint runs a TEMPORARY server on that
+      # socket while it initialises the database, with listen_addresses=''.
+      # So the container reported healthy during init, the entrypoint then
+      # stopped that server to start the real one, and the next command lost
+      # the race: `docker compose up --wait` returned, start-server.sh ran its
+      # wipe, and psql died on "socket /var/run/postgresql/.s.PGSQL.5432: No
+      # such file or directory". Seen in CI on 03.09.2026. Checking TCP cannot
+      # pass against the init server, so healthy now means the real one.
+      test: ["CMD-SHELL", "pg_isready -U e2e -d openisms_e2e -h 127.0.0.1"]
       interval: 2s
       timeout: 3s
       retries: 30

--- a/e2e/l1/assets.spec.ts
+++ b/e2e/l1/assets.spec.ts
@@ -92,16 +92,57 @@ test.describe("asset inventory: grouped large-company entries", () => {
   // weeks because nothing asserted the row. Runs last in the file so the three
   // creates above have already triggered the revert (workers: 1, serial).
   test("the revert those writes caused is recorded in the audit trail", async () => {
-    const rows = await e2eQuery<{ entity_id: string | null; description: string }>(
-      `SELECT entity_id, description
-         FROM audit_log
-        WHERE action = 'requirement.sign_off_invalidated'
-          AND entity_type = 'module'
-        ORDER BY created_at DESC`,
-    );
-    expect(rows.length, "sign_off_invalidated rows written").toBeGreaterThan(0);
+    // asset.create fires invalidateModuleSignOffs without awaiting it, so the
+    // row lands after the mutation responds. Poll rather than read once.
+    const read = () =>
+      e2eQuery<{ entity_id: string | null; description: string }>(
+        `SELECT entity_id, description
+           FROM audit_log
+          WHERE action = 'requirement.sign_off_invalidated'
+            AND entity_type = 'module'
+          ORDER BY created_at DESC`,
+      );
+    await expect
+      .poll(async () => (await read()).length, {
+        message: "sign_off_invalidated rows written",
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
+
+    const [latest] = await read();
     // The module key belongs in the description, never in the uuid column.
-    expect(rows[0].entity_id).toBeNull();
-    expect(rows[0].description).toContain("reverted");
+    expect(latest.entity_id).toBeNull();
+    expect(latest.description).toContain("reverted");
+  });
+
+  // Grouping keeps a real inventory small (BSI 200-2, and the entries above
+  // stand for 2 + 48 + 180 machines), but a self-hoster importing a CMDB dump
+  // gets one row per machine. asset.list has no limit and no pagination and
+  // the table renders every row, which is fine at this size and is exactly
+  // the kind of thing a later "just add a LIMIT 100" would break silently:
+  // the page would still look right, with the tail missing. Seeded by SQL
+  // because 500 UI creates would cost minutes and prove nothing extra.
+  test("a CMDB-sized inventory renders every row, none silently dropped", async ({ page }) => {
+    const BULK = 500;
+    const [{ company_id }] = await e2eQuery<{ company_id: string }>(
+      `SELECT company_id FROM "user" WHERE email = 'dev@nis2.local'`,
+    );
+    await e2eQuery(
+      `INSERT INTO asset (company_id, name, type, description, quantity, owner, location)
+       SELECT $1, 'Lasttest ' || g, 'server', 'CMDB import row ' || g, 1, 'IT', 'RZ Nord'
+         FROM generate_series(1, $2) g`,
+      [company_id, BULK],
+    );
+
+    try {
+      await page.goto("/de/assets");
+      await expect(page.getByText("Lasttest 1", { exact: false }).first()).toBeVisible({
+        timeout: 60_000,
+      });
+      await expect(page.getByText(/^Lasttest \d+$/)).toHaveCount(BULK, { timeout: 60_000 });
+    } finally {
+      // Later layers sign off against this tenant; leave the inventory as found.
+      await e2eQuery(`DELETE FROM asset WHERE name LIKE 'Lasttest %'`);
+    }
   });
 });

--- a/e2e/l2/evidence.spec.ts
+++ b/e2e/l2/evidence.spec.ts
@@ -6,11 +6,15 @@
  * Target: requirement 10.4 (access reviews, evidenceType "proof"), a page
  * with no custom editor so the evidence section always renders.
  */
+import { createHash } from "node:crypto";
 import { test, expect } from "@playwright/test";
 import { gotoRequirement } from "../lib/journey";
+import { e2eQuery } from "../lib/db";
 
 const CODE = "10.4";
 const FILE_NAME = "pruefprotokoll-zugriffsreview-2026-q2.pdf";
+const BODY = Buffer.from("%PDF-1.4\n% e2e evidence fixture\n");
+const SHA256 = createHash("sha256").update(BODY).digest("hex");
 
 test("evidence: upload, list, download link, delete round-trip", async ({ page }) => {
   await gotoRequirement(page, CODE);
@@ -21,19 +25,64 @@ test("evidence: upload, list, download link, delete round-trip", async ({ page }
   await input.setInputFiles({
     name: FILE_NAME,
     mimeType: "application/pdf",
-    buffer: Buffer.from("%PDF-1.4\n% e2e evidence fixture\n"),
+    buffer: BODY,
   });
 
   // Presign -> S3 PUT -> SHA-256 -> confirm -> list refetch.
   const row = page.getByText(FILE_NAME, { exact: false }).first();
   await expect(row).toBeVisible({ timeout: 30_000 });
 
-  // A presigned download link exists for the stored object.
-  const download = page.locator('a[href*="e2e-evidence"], a[target="_blank"]').first();
+  // The row rendering proves confirmUpload wrote a database row. It does not
+  // prove the bytes reached object storage, and that is the half that breaks
+  // on a self-hosted instance: a wrong endpoint, region or path-style setting
+  // presigns happily and stores nothing. The old assertion here matched
+  // `a[target="_blank"]`, of which this page renders four before any upload
+  // (two legal citations, the course link, the help link), so it passed
+  // whether or not an evidence link existed at all.
+  const download = page.getByTestId("evidence-download").first();
   await expect(download).toBeVisible();
+  const href = await download.getAttribute("href");
+  expect(href, "presigned download href").toBeTruthy();
+
+  // Self-host contract: the browser may only PUT to an origin that CSP
+  // connect-src names, and the origin the app presigns to comes from the same
+  // env. When they diverged, evidence upload was dead on every self-hosted
+  // instance while every local run stayed green, because next.config.ts bakes
+  // this header at build time (proxy.ts re-sets it per request). Comparing the
+  // two is config-independent: it holds for MinIO, for AWS, and for whatever a
+  // self-hoster points AWS_S3_ENDPOINT at.
+  const csp = (await page.request.get(page.url())).headers()["content-security-policy"] ?? "";
+  const connectSrc = csp.split(";").find((d) => d.trim().startsWith("connect-src")) ?? "";
+  expect(connectSrc, "connect-src must name the origin evidence is presigned to").toContain(
+    new URL(href ?? "").origin,
+  );
+
+  const fetched = await page.request.get(href ?? "");
+  expect(fetched.status(), "presigned GET of the stored object").toBe(200);
+  const bytes = await fetched.body();
+  expect(bytes.length, "stored object size").toBe(BODY.length);
+  expect(createHash("sha256").update(bytes).digest("hex"), "stored bytes").toBe(SHA256);
+
+  // And the row the app wrote describes those same bytes.
+  const [stored] = await e2eQuery<{ file_size: number; content_hash: string | null }>(
+    `SELECT file_size, content_hash FROM evidence WHERE file_name = $1`,
+    [FILE_NAME],
+  );
+  expect(stored.file_size, "evidence.file_size").toBe(BODY.length);
+  expect(stored.content_hash, "evidence.content_hash").toBe(SHA256);
 
   await page.getByTestId("evidence-delete").first().click();
   await expect(page.getByText(FILE_NAME, { exact: false })).toHaveCount(0, {
     timeout: 15_000,
   });
+
+  // Delete calls deleteObject before dropping the row, so "deleted" has to
+  // mean the bytes are gone too, not just hidden from the list. An orphaned
+  // object in the bucket is an erasure problem, and the UI cannot show one.
+  const left = await e2eQuery<{ n: string }>(
+    `SELECT count(*)::text AS n FROM evidence WHERE file_name = $1`,
+    [FILE_NAME],
+  );
+  expect(left[0].n, "evidence rows after delete").toBe("0");
+  expect((await page.request.get(href ?? "")).status(), "object after delete").not.toBe(200);
 });

--- a/e2e/l2/modules.spec.ts
+++ b/e2e/l2/modules.spec.ts
@@ -34,8 +34,10 @@ const MODULES: Array<{
 }> = [
   { route: "risks", schema: riskInsertSchema as unknown as AnySchema, overrides: { title: "Ausfall Fernwirktechnik durch Ransomware" } },
   // Numeric-string overrides: drizzle numeric/decimal columns are typed as
-  // plain strings, so the factory's text values 500 the insert (recorded
-  // finding: the product accepts non-numeric input into these and crashes).
+  // plain strings, so the generic factory emits text for them. It no longer
+  // 500s — #59 derives a validator from each column's own precision/scale, so
+  // text and overflow are both rejected as validation errors — but the form
+  // then refuses to submit, so the sweep still has to supply real numbers.
   { route: "incidents", schema: incidentInsertSchema as unknown as AnySchema, overrides: { title: "Phishing-Welle Leitstellenpersonal", estimatedFinancialDamage: "25000" } },
   { route: "policies", schema: policyInsertSchema as unknown as AnySchema, overrides: { title: "IT-Sicherheitsleitlinie Stadtwerk" } },
   { route: "patches", schema: patchRecordInsertSchema as unknown as AnySchema, overrides: { patchIdentifier: "KB5044284 Leitstellen-Cluster", title: "Sicherheitsupdate SCADA-Hosts Oktober" } },

--- a/e2e/l2/validation.spec.ts
+++ b/e2e/l2/validation.spec.ts
@@ -6,12 +6,17 @@
  * submit what they must not.
  */
 import { test, expect } from "@playwright/test";
+import { e2eQuery } from "../lib/db";
+
+const countRisks = async () =>
+  (await e2eQuery<{ n: string }>(`SELECT count(*)::text AS n FROM risk`))[0].n;
 
 test("empty required field blocks submit with a visible error", async ({ page }) => {
   await page.goto("/de/risks");
   const submit = page.getByTestId("schema-form-submit");
   await expect(submit).toBeVisible({ timeout: 20_000 });
 
+  const before = await countRisks();
   await submit.click();
 
   // react-hook-form + zod surface a message in the title field's slot and
@@ -20,4 +25,9 @@ test("empty required field blocks submit with a visible error", async ({ page })
     page.locator('[data-field="title"] [id$="form-item-message"]'),
   ).toBeVisible({ timeout: 10_000 });
   await expect(submit).toBeEnabled();
+
+  // The docstring above claimed this and nothing checked it: an error message
+  // rendering does not by itself prove the mutation was blocked. A form that
+  // both complained and wrote the row would have passed.
+  expect(await countRisks(), "a row was created despite the validation error").toBe(before);
 });

--- a/e2e/l3/supplier-portal.spec.ts
+++ b/e2e/l3/supplier-portal.spec.ts
@@ -1,0 +1,297 @@
+/**
+ * L3 supplier portal — the token-gated customer view.
+ *
+ * `supplierPortal.public.getByToken` and `.revoke` are the only two
+ * publicProcedures in the app: the one place tenant data leaves the platform
+ * with no authenticated context. A 64-hex token in a URL is the entire gate,
+ * and the person holding it is an invited customer who has no account here.
+ *
+ * Four properties matter, and none of them were covered before:
+ *
+ *  1. The token reads exactly one relationship. Customer A's link must never
+ *     surface the assets or incidents the same supplier serves customer B.
+ *  2. The payload is a declaration about a service, not a copy of the
+ *     supplier's internals. Both queries in public.ts list their columns
+ *     rather than spreading the row, because the asset row carries the
+ *     supplier's own hostnames and patch dates and the incident row carries
+ *     its post-mortem. A future `...asset` would re-open that silently, so
+ *     the sentinel values below are planted specifically to catch it.
+ *  3. Revoking is real, immediate and audited.
+ *  4. What the server scoped actually reaches the customer. #137 wired up
+ *     the two sections that had been computed and dropped; before it, a DOM
+ *     assertion about them could not fail, which is why the isolation check
+ *     below lives on the wire first and on the page second.
+ *
+ * The fixture is provisioned in SQL, the way l3/cross-tenant.spec.ts
+ * provisions Rival GmbH: it needs a second tenant that the shared e2e company
+ * must not become. Every assertion afterwards goes through the real HTTP
+ * surface, unauthenticated.
+ */
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { e2eQuery } from "../lib/db";
+
+const TOKEN_A = "a1".repeat(32);
+const TOKEN_B = "b2".repeat(32);
+const TOKEN_C = "c3".repeat(32);
+const TOKEN_UNKNOWN = "f0".repeat(32);
+
+const SUPPLIER_NAME = "Systemhaus Musterland (Testdaten)";
+const ASSET_A = "Leitsystem-Hosting Alpha";
+const ASSET_B = "Klinikarchiv Beta";
+const SERVICE_DESCRIPTION_A = "Betrieb der Netzleitstelle rund um die Uhr";
+const ORG_A = "Stadtwerke Alpha";
+const ORG_B = "Klinikum Beta";
+const INCIDENT_TITLE = "Ransomware im Hosting-Cluster";
+
+/**
+ * Values that must never cross the wire. Each stands for one column the
+ * whitelists in public.ts deliberately omit.
+ */
+const SECRETS = {
+  cisoName: "GEHEIM CISO Musterland",
+  stripe: "cus_GEHEIMSTRIPE123",
+  ip: "10.99.99.99",
+  hostname: "supplier-jumphost-intern",
+  os: "Debian 12 (interne Buildchain)",
+  rootCause: "GEHEIM ungepatchter Jump-Host",
+  countermeasures: "GEHEIM Netztrennung und Neuaufbau",
+  damage: "987654",
+} as const;
+
+const ids = { company: "", relA: "", relB: "", relC: "" };
+
+async function getByToken(request: APIRequestContext, token: string) {
+  const input = encodeURIComponent(JSON.stringify({ "0": { json: { token } } }));
+  return request.get(`/api/trpc/supplierPortal.public.getByToken?batch=1&input=${input}`, {
+    failOnStatusCode: false,
+  });
+}
+
+test.describe("supplier portal: token-gated customer access", () => {
+  // The whole point is that a customer needs no account here.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeAll(async () => {
+    const [c] = await e2eQuery<{ id: string }>(
+      `INSERT INTO company (name, legal_name, sector, entity_type, acts_as_supplier,
+                            activated_at, ciso_name, stripe_customer_id, country)
+       VALUES ($1, $1, 'ict', 'important', true, NOW(), $2, $3, 'DE')
+       RETURNING id`,
+      [SUPPLIER_NAME, SECRETS.cisoName, SECRETS.stripe],
+    );
+    ids.company = c.id;
+
+    const rel = async (email: string, org: string, token: string) =>
+      (
+        await e2eQuery<{ id: string }>(
+          `INSERT INTO supplier (supplier_company_id, name, customer_email, customer_org_name,
+                                 status, unsubscribe_token, confirmed_at)
+           VALUES ($1, $2, $3, $4, 'active', $5, NOW()) RETURNING id`,
+          [ids.company, SUPPLIER_NAME, email, org, token],
+        )
+      )[0].id;
+    ids.relA = await rel("alpha@kunde.local", ORG_A, TOKEN_A);
+    ids.relB = await rel("beta@kunde.local", ORG_B, TOKEN_B);
+    ids.relC = await rel("gamma@kunde.local", "Praxis Gamma", TOKEN_C);
+
+    // One asset per customer. Customer A's carries the sentinel internals.
+    const mkAsset = async (name: string, secret: boolean) =>
+      (
+        await e2eQuery<{ id: string }>(
+          `INSERT INTO asset (company_id, name, type, quantity, ip_address, hostname, operating_system)
+           VALUES ($1, $2, 'server', 1, $3, $4, $5) RETURNING id`,
+          [
+            ids.company,
+            name,
+            secret ? SECRETS.ip : null,
+            secret ? SECRETS.hostname : null,
+            secret ? SECRETS.os : null,
+          ],
+        )
+      )[0].id;
+    const assetA = await mkAsset(ASSET_A, true);
+    const assetB = await mkAsset(ASSET_B, false);
+    await e2eQuery(
+      `INSERT INTO asset_supplier_offering (asset_id, customer_relationship_id, service_type, service_description)
+       VALUES ($1, $2, 'managed', $5), ($3, $4, 'saas', 'Archivhosting')`,
+      [assetA, ids.relA, assetB, ids.relB, SERVICE_DESCRIPTION_A],
+    );
+
+    // One incident, broadcast to A only, carrying the sentinel post-mortem.
+    const [inc] = await e2eQuery<{ id: string }>(
+      `INSERT INTO incident (company_id, severity, title, description, discovered_at,
+                             root_cause, countermeasures, estimated_financial_damage)
+       VALUES ($1, 'significant', $2, 'Verschluesselung mehrerer Hosts', NOW(), $3, $4, $5)
+       RETURNING id`,
+      [ids.company, INCIDENT_TITLE, SECRETS.rootCause, SECRETS.countermeasures, SECRETS.damage],
+    );
+    await e2eQuery(
+      `INSERT INTO incident_broadcast (incident_id, customer_relationship_id, status)
+       VALUES ($1, $2, 'sent')`,
+      [inc.id, ids.relA],
+    );
+
+    await e2eQuery(
+      `INSERT INTO company_certification (company_id, type, scope, auditor, valid_until, storage_key, status)
+       VALUES ($1, 'iso27001', 'Rechenzentrum Nord', 'TUEV Musterland', NOW() + interval '1 year',
+               'certs/e2e-supplier-portal.pdf', 'active')`,
+      [ids.company],
+    );
+  });
+
+  test.afterAll(async () => {
+    // FK-safe order. The shared tenant is untouched either way.
+    await e2eQuery(
+      `DELETE FROM incident_broadcast WHERE customer_relationship_id IN ($1, $2, $3)`,
+      [ids.relA, ids.relB, ids.relC],
+    );
+    await e2eQuery(
+      `DELETE FROM asset_supplier_offering WHERE customer_relationship_id IN ($1, $2, $3)`,
+      [ids.relA, ids.relB, ids.relC],
+    );
+    await e2eQuery(`DELETE FROM incident WHERE company_id = $1`, [ids.company]);
+    await e2eQuery(`DELETE FROM asset WHERE company_id = $1`, [ids.company]);
+    await e2eQuery(`DELETE FROM company_certification WHERE company_id = $1`, [ids.company]);
+    await e2eQuery(`DELETE FROM audit_log WHERE company_id = $1`, [ids.company]);
+    await e2eQuery(`DELETE FROM supplier WHERE supplier_company_id = $1`, [ids.company]);
+    await e2eQuery(`DELETE FROM company WHERE id = $1`, [ids.company]);
+  });
+
+  test("a valid token opens the supplier's profile with no account", async ({ page }) => {
+    await page.goto(`/de/supplier-access/${TOKEN_A}`);
+    await expect(page.getByText(SUPPLIER_NAME, { exact: false }).first()).toBeVisible({
+      timeout: 20_000,
+    });
+    // The banner proves the token resolved to THIS relationship and not just
+    // to some supplier: it greets the customer by the invited address.
+    await expect(page.getByText("alpha@kunde.local", { exact: false }).first()).toBeVisible();
+    // By testid, not by label: the chrome is translated into ten locales and
+    // an accessible-name regex would quietly stop matching on the next one.
+    await expect(page.getByTestId("revoke-access")).toBeVisible();
+    // Nothing bounced us to a login: the token is the auth.
+    expect(page.url()).not.toContain("/auth/signin");
+
+    // The two per-customer halves. getByToken always returned them; until the
+    // customer view was wired up, `managedAssets` was destructured and dropped
+    // and `recentEvents` had no renderer anywhere, so the page showed only the
+    // company-wide questionnaire while the portal's marketing page promised
+    // "die Systeme, die Sie für ihn betreuen" and a per-customer incident feed.
+    await expect(page.getByTestId("shared-services")).toBeVisible();
+    await expect(page.getByText(ASSET_A, { exact: false }).first()).toBeVisible();
+    // A declaration from the offering row, not just the asset's name: proves
+    // the per-customer service profile is what reached the page.
+    await expect(page.getByText(SERVICE_DESCRIPTION_A, { exact: false })).toBeVisible();
+
+    await expect(page.getByTestId("shared-incidents")).toBeVisible();
+    await expect(page.getByText(INCIDENT_TITLE, { exact: false }).first()).toBeVisible();
+
+    // next-intl renders the key path when a message is missing, so a locale
+    // that never got these strings would show "supplierPortal.customerView..."
+    // to a customer rather than failing. Ten locales carry them; this is the
+    // guard that says so.
+    expect(await page.locator("body").innerText()).not.toContain(
+      "supplierPortal.customerView",
+    );
+  });
+
+  test("one customer's token cannot see another customer's service or incidents", async ({
+    page,
+    request,
+  }) => {
+    const res = await getByToken(request, TOKEN_A);
+    expect(res.status(), "public getByToken reachable").toBe(200);
+    const body = await res.text();
+
+    // Non-vacuity: A's own data really is in this payload, so the absences
+    // below are isolation rather than an empty/failed response.
+    expect(body, "A's own service is present").toContain(ASSET_A);
+    expect(body, "A's own org name is present").toContain(ORG_A);
+
+    expect(body, "B's service leaked to A").not.toContain(ASSET_B);
+    expect(body, "B's org name leaked to A").not.toContain(ORG_B);
+    expect(body, "B's relationship id leaked to A").not.toContain(ids.relB);
+
+    // And now that the services actually render, the DOM check is worth
+    // something: it can only pass because A's list is present and B's entry
+    // is not in it.
+    await page.goto(`/de/supplier-access/${TOKEN_A}`);
+    await expect(page.getByTestId("shared-services")).toBeVisible();
+    await expect(page.getByText(ASSET_A, { exact: false }).first()).toBeVisible();
+    await expect(page.getByText(ASSET_B, { exact: false })).toHaveCount(0);
+  });
+
+  test("the payload declares the service without shipping the supplier's internals", async ({
+    request,
+  }) => {
+    const body = await (await getByToken(request, TOKEN_A)).text();
+
+    // Present: what the portal exists to communicate.
+    expect(body, "supplier identity").toContain(SUPPLIER_NAME);
+    expect(body, "the broadcast incident").toContain(INCIDENT_TITLE);
+    expect(body, "the certification").toContain("TUEV Musterland");
+
+    // Absent: every column the whitelists in public.ts leave out. A customer
+    // holding this token is not entitled to the supplier's host inventory,
+    // its breach file, or its billing identity.
+    for (const [field, value] of Object.entries(SECRETS)) {
+      expect(body, `${field} must not reach a token holder`).not.toContain(value);
+    }
+  });
+
+  test("an unknown token is a 404, not a hint", async ({ page, request }) => {
+    const res = await getByToken(request, TOKEN_UNKNOWN);
+    expect(res.status(), "unknown token still answers 200 with null").toBe(200);
+    expect(await res.text()).not.toContain(SUPPLIER_NAME);
+
+    const nav = await page.goto(`/de/supplier-access/${TOKEN_UNKNOWN}`);
+    expect(nav?.status(), "unknown token renders notFound()").toBe(404);
+    await expect(page.getByText(SUPPLIER_NAME, { exact: false })).toHaveCount(0);
+  });
+
+  test("revoking is immediate, idempotent and audited", async ({ page, request }) => {
+    const revoke = () =>
+      request.post("/api/trpc/supplierPortal.public.revoke?batch=1", {
+        data: { "0": { json: { token: TOKEN_C } } },
+        headers: { "content-type": "application/json" },
+        failOnStatusCode: false,
+      });
+
+    // Access works before.
+    expect(await (await getByToken(request, TOKEN_C)).text()).toContain(SUPPLIER_NAME);
+
+    const first = await revoke();
+    expect(first.status(), "revoke reachable").toBe(200);
+
+    const [row] = await e2eQuery<{ status: string; unsubscribed_at: string | null }>(
+      `SELECT status, unsubscribed_at FROM supplier WHERE id = $1`,
+      [ids.relC],
+    );
+    expect(row.status, "relationship status after revoke").toBe("revoked");
+    expect(row.unsubscribed_at, "unsubscribed_at stamped").not.toBeNull();
+
+    // The token is dead for reads, over the API and in the browser.
+    expect(await (await getByToken(request, TOKEN_C)).text()).not.toContain(SUPPLIER_NAME);
+    await page.goto(`/de/supplier-access/${TOKEN_C}`);
+    await expect(page.getByText(SUPPLIER_NAME, { exact: false })).toHaveCount(0);
+
+    // Idempotent: the docstring promises re-running is a no-op, not an error.
+    expect((await revoke()).status(), "second revoke").toBe(200);
+
+    // publicProcedure carries no auto-audit middleware, so revoke logs by
+    // hand. If that call is ever dropped, the only record of an unauthenticated
+    // state change disappears with it.
+    await expect
+      .poll(
+        async () =>
+          (
+            await e2eQuery<{ n: string }>(
+              `SELECT count(*)::text AS n FROM audit_log
+                WHERE company_id = $1 AND action = 'supplierPortal.public.revoke'`,
+              [ids.company],
+            )
+          )[0].n,
+        { message: "revoke audit row", timeout: 15_000 },
+      )
+      .toBe("1");
+  });
+});


### PR DESCRIPTION
Tests only. No product code — the two fixes this depends on shipped separately in #136 and #137, and this branch is rebased on both.

## 1. Assertions that could not fail for the reason they claimed

`evidence.spec` matched `a[href*="e2e-evidence"], a[target="_blank"]` for "a presigned download link exists". Requirement 10.4 renders **four** `target="_blank"` links before any upload — two legal citations, the course link, the help link. Verified by probe. It also never checked the bytes reached storage: the row rendering only proves `confirmUpload` wrote a DB row, and on a self-hosted instance the other half is what breaks.

Now: targets a real testid, fetches the presigned URL, asserts 200 + exact byte length + matching SHA-256, asserts the `evidence` row describes those same bytes, and after delete asserts zero rows **and** a non-200 object — an orphaned object is an erasure problem the UI cannot show.

Plus a self-host guard: CSP `connect-src` must name the origin the app presigns to. That divergence is what killed browser evidence upload on every self-hosted instance while local runs stayed green, because `next.config.ts` bakes the header at build time.

`validation.spec`'s docstring promised a blocked submit "must NOT create a record" and nothing checked it. A form that both complained *and* wrote the row would have passed. It counts rows now.

## 2. Scale

`asset.list` has no limit and no pagination. Measured before adding a guard:

| Assets | Page load | Rows rendered |
|---|---|---|
| 212 | 256 ms | 200/200 |
| 512 | 290 ms | 500/500 |
| 2012 | 1063 ms | 2000/2000 |

It works. The 500-row spec exists so a later "just add `LIMIT 100`" fails loudly instead of silently dropping the tail.

## 3. The supplier portal

`getByToken` and `revoke` are the app's only two `publicProcedure`s — tenant data leaving with no authenticated context, gated by a token in a URL. The whole portal surface had **no e2e**. Five specs: valid-token access, cross-customer isolation, column whitelists, unknown-token 404, and revoke (immediate, idempotent, audited — `publicProcedure` has no auto-audit middleware, so that log call is hand-written).

**Verified by mutation, not assumed.** Replacing the listed asset columns with `asset: asset` produced:

```
"ipAddress":"10.99.99.99","hostname":"supplier-jumphost-intern",
"operatingSystem":"Debian 12 (interne Buildchain)",
"privilegedAccountCount":0,"lastPatchDate":null,"lastVulnScanDate":null
```

The spec failed on the first sentinel. Reverted.

The isolation check asserts on the wire first and the page second, deliberately: before #137 the page rendered no service list, so a DOM check for B's absence passed regardless of what the server sent.

Selectors are testids rather than accessible names — the chrome is translated into ten locales and a name regex stops matching on the next one, which already happened once during #137. A companion assertion checks the body never contains `supplierPortal.customerView`, because next-intl prints the key path when a message is missing rather than failing.

## 4. Docs

`e2e/README.md` documents `bun run e2e:image` (added in #111, undocumented) and states plainly that it runs the working tree's specs against a *released* image, so the two drift between releases. Against `:stable` (v0.2.8, 27.08) that was 90 passed / 3 failed, all three specs from PRs merged after the tag. It cannot simply be added to PR CI for that reason.

## Verification

`bun run typecheck` clean. `bun run test:l0` 114 passed. Full suite **99 passed**, and for the first time zero `[audit] failed to write audit_log row` lines — #136 fixed the cause.