### PR TITLE
Per-message email preferences: a consent gate that cannot be skipped

### DIFF
--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: Request) {
     await Promise.all([
       admins.length > 0
         ? sendMail({
+            emailType: "internal.new_signup_alert",
             to: admins,
             ...newUserSignupEmail({
               userEmail: email,

--- a/app/api/cron/course-reminders/route.ts
+++ b/app/api/cron/course-reminders/route.ts
@@ -247,12 +247,13 @@ export async function GET(req: NextRequest) {
       const firstNotificationId = insertedRows[0]?.id ?? null;
 
       sendMail({
+        emailType: "product.course_followup",
+        recipientUserId: u.id,
         to: u.email,
         subject: email.subject,
         html: email.html,
         text: email.text,
         replyTo: REPLY_TO,
-        unsubscribeUrl: unsubUrl,
       })
         .then((result) => {
           if (!result.success) {

--- a/app/api/cron/deadlines/route.ts
+++ b/app/api/cron/deadlines/route.ts
@@ -349,8 +349,9 @@ export async function GET(req: NextRequest) {
         const digest = await compileDailyDigest(db, member.id, co.id);
         if (digest) {
           sendMail({
+            emailType: "reminders.daily_digest",
+            recipientUserId: member.id,
             to: digest.recipientEmail,
-            unsubscribeUrl: unsubUrl,
             ...dailyDigestEmail({
               recipientName: digest.recipientName,
               companyName: digest.companyName,
@@ -382,8 +383,9 @@ export async function GET(req: NextRequest) {
           const mgmtDigest = await compileManagementDigest(db, member.id, co.id);
           if (mgmtDigest) {
             sendMail({
+              emailType: "reminders.weekly_management_digest",
+              recipientUserId: member.id,
               to: mgmtDigest.recipientEmail,
-              unsubscribeUrl: unsubUrl,
               ...weeklyManagementDigestEmail({
                 recipientName: mgmtDigest.recipientName,
                 companyName: mgmtDigest.companyName,

--- a/app/api/cron/deadlines/route.ts
+++ b/app/api/cron/deadlines/route.ts
@@ -6,7 +6,8 @@
  *   2. Backfill: NULL nextReviewDate → compute from priority
  *   3. Notification creation: schedule reminders for approaching deadlines
  *   4. Escalation: process overdue items through escalation chain
- *   5. Digest compilation: batch pending emails into daily/weekly digests
+ *   5. Notification dispatch: due in-app notifications are marked sent.
+ *      Digest EMAIL is not sent here — see lib/mail/digest-outbox.ts.
  *   6. Supplier portal: drain queued supplier_publication_event broadcasts
  *      (incident notifications); cron is the safety net for sync fan-out
  *      that failed in the publish path.
@@ -16,46 +17,37 @@
  * Security: Bearer token from CRON_SECRET env var.
  * Schedule: Vercel Cron at 06:00 UTC (08:00 CET)
  */
-import { NextRequest, NextResponse } from "next/server";
-import { eq, and, sql, inArray, lte, isNull, isNotNull } from "drizzle-orm";
-import { db } from "@/lib/db";
-import {
-  companyRequirementStatus,
-  companyAssessment,
-  company,
-  user,
-  notification,
-} from "@/schema";
-import { nis2StatusScope } from "@/server/trpc/helpers/nis2-scope";
+
+import { and, eq, inArray, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
 import { logAudit } from "@/lib/audit";
-import { env } from "@/lib/env";
-import { verifyCronBearer } from "@/lib/cron/auth";
-import { purgeExpiredErasureRecords } from "@/lib/gdpr/erase-user";
-import requirementsEn from "@/messages/requirements/en.json";
 import {
   computeInitialDeadline,
   computeNotificationSchedule,
   computeUrgency,
   daysUntilDeadline,
-  isRecurringFrequency,
-  toDateString,
   type Frequency,
-  type Priority,
   type Importance,
+  isRecurringFrequency,
+  type Priority,
+  toDateString,
 } from "@/lib/compliance/deadlines";
 import { processEscalation } from "@/lib/compliance/escalation";
 import { resolveRecipients } from "@/lib/compliance/resolve-recipients";
-import { compileDailyDigest, compileManagementDigest } from "@/lib/compliance/digest";
+import { verifyCronBearer } from "@/lib/cron/auth";
+import { db } from "@/lib/db";
+import { env } from "@/lib/env";
+import { purgeExpiredErasureRecords } from "@/lib/gdpr/erase-user";
+import requirementsEn from "@/messages/requirements/en.json";
 import {
-  sendMail,
-  deadlineReminderEmail,
-  deadlineUrgentEmail,
-  deadlineOverdueEmail,
-  dailyDigestEmail,
-  weeklyManagementDigestEmail,
-} from "@/lib/mail";
+  company,
+  companyAssessment,
+  companyRequirementStatus,
+  notification,
+  user,
+} from "@/schema";
+import { nis2StatusScope } from "@/server/trpc/helpers/nis2-scope";
 import { drainQueuedBroadcasts } from "@/server/trpc/routers/supplier-portal/broadcast";
-import { unsubscribeUrl as buildUnsubscribeUrl } from "@/lib/email/unsubscribe";
 
 export const dynamic = "force-dynamic";
 
@@ -76,7 +68,7 @@ export async function GET(req: NextRequest) {
     phase2_backfills: 0,
     phase3_notifications: 0,
     phase4_escalations: 0,
-    phase5_digests: 0,
+    phase5_in_app_marked: 0,
     phase6_supplier_events: 0,
     phase6_supplier_emails: 0,
     phase7_erasure_records_minimised: 0,
@@ -92,7 +84,11 @@ export async function GET(req: NextRequest) {
       where: and(
         nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} <= ${today}`,
-        inArray(companyRequirementStatus.status, ["completed", "approved", "not_applicable"]),
+        inArray(companyRequirementStatus.status, [
+          "completed",
+          "approved",
+          "not_applicable",
+        ]),
       ),
       columns: { id: true, assessmentId: true },
     });
@@ -128,7 +124,9 @@ export async function GET(req: NextRequest) {
 
     // Group by assessmentId for start date lookup
     const assessmentStartDates = new Map<string, Date>();
-    const assessmentIdsForBackfill = [...new Set(missingDeadlines.map((s) => s.assessmentId))];
+    const assessmentIdsForBackfill = [
+      ...new Set(missingDeadlines.map((s) => s.assessmentId)),
+    ];
 
     if (assessmentIdsForBackfill.length > 0) {
       const assessments = await db.query.companyAssessment.findMany({
@@ -147,7 +145,10 @@ export async function GET(req: NextRequest) {
       const startedAt = assessmentStartDates.get(status.assessmentId);
       if (!startedAt) continue;
 
-      const deadline = computeInitialDeadline(startedAt, status.requirement.priority as Priority);
+      const deadline = computeInitialDeadline(
+        startedAt,
+        status.requirement.priority as Priority,
+      );
       await db
         .update(companyRequirementStatus)
         .set({ nextReviewDate: toDateString(deadline), updatedAt: new Date() })
@@ -164,7 +165,12 @@ export async function GET(req: NextRequest) {
         nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} IS NOT NULL`,
         sql`${companyRequirementStatus.nextReviewDate} <= ${toDateString(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000))}`,
-        inArray(companyRequirementStatus.status, ["completed", "approved", "needs_review", "not_applicable"]),
+        inArray(companyRequirementStatus.status, [
+          "completed",
+          "approved",
+          "needs_review",
+          "not_applicable",
+        ]),
       ),
       with: {
         requirement: {
@@ -207,7 +213,10 @@ export async function GET(req: NextRequest) {
       if (existingActive.length > 0) continue; // Already has active notifications
 
       const req = status.requirement;
-      const reqKey = req.code.replace(/\./g, "_") as keyof typeof requirementsEn.requirements;
+      const reqKey = req.code.replace(
+        /\./g,
+        "_",
+      ) as keyof typeof requirementsEn.requirements;
       const reqTitle = requirementsEn.requirements[reqKey]?.title ?? req.code;
       const frequency = req.frequency as Frequency;
       const priority = req.priority as Priority;
@@ -215,7 +224,12 @@ export async function GET(req: NextRequest) {
       const reviewDate = new Date(status.nextReviewDate);
       const slug = req.category?.slug ?? "unknown";
 
-      const schedule = computeNotificationSchedule(reviewDate, frequency, priority, importance);
+      const schedule = computeNotificationSchedule(
+        reviewDate,
+        frequency,
+        priority,
+        importance,
+      );
       if (schedule.length === 0) continue;
 
       const recipients = await resolveRecipients(db, {
@@ -261,7 +275,7 @@ export async function GET(req: NextRequest) {
             escalationLevel: 0,
             linkUrl,
           },
-        ])
+        ]),
       );
 
       if (rows.length > 0) {
@@ -277,7 +291,11 @@ export async function GET(req: NextRequest) {
       where: and(
         nis2StatusScope(db),
         sql`${companyRequirementStatus.nextReviewDate} < ${today}`,
-        inArray(companyRequirementStatus.status, ["needs_review", "completed", "approved"]),
+        inArray(companyRequirementStatus.status, [
+          "needs_review",
+          "completed",
+          "approved",
+        ]),
       ),
       columns: { id: true, assessmentId: true },
     });
@@ -297,9 +315,10 @@ export async function GET(req: NextRequest) {
     }
 
     // -----------------------------------------------------------------------
-    // Phase 5: Dispatch due notifications + compile digests
+    // Phase 5: Dispatch due IN-APP notifications
     // -----------------------------------------------------------------------
-    // Send individual notifications that are due now
+    // These surface in the bell, not in anybody's inbox, so the cron still
+    // owns them.
     const dueNotifications = await db.query.notification.findMany({
       where: and(
         eq(notification.status, "pending"),
@@ -313,123 +332,25 @@ export async function GET(req: NextRequest) {
         .update(notification)
         .set({ status: "sent", sentAt: new Date() })
         .where(eq(notification.id, n.id));
+      stats.phase5_in_app_marked++;
     }
 
-    // Compile and send digests (one per company). Exclude draft shells
-    // (activatedAt IS NULL, auto-provisioned at email verification): they carry
-    // seeded assessment rows but no real work, and the weekly management digest
-    // would otherwise mail every drive-by signup a blank-named 0% report.
-    const companies = await db.query.company.findMany({
-      where: isNotNull(company.activatedAt),
-      columns: { id: true, name: true },
-    });
+    // Digests are NOT sent here. They go out from the platform admin's send
+    // console (lib/mail/digest-outbox.ts), because nothing at nisd2.eu mails
+    // a customer without a person pressing a button — and a job that emails
+    // everybody as a side effect of doing bookkeeping is precisely the shape
+    // that rule exists to prevent. The remaining phases below still run.
+    //
+    // Self-hosters who want the old behaviour can schedule their own call to
+    // the console's send path; the endpoint is unchanged in every other way.
 
-    for (const co of companies) {
-      const members = await db.query.user.findMany({
-        where: eq(user.companyId, co.id),
-        columns: {
-          id: true,
-          email: true,
-          name: true,
-          isManagement: true,
-          role: true,
-          emailFollowupsDisabled: true,
-        },
-      });
-
-      for (const member of members) {
-        // Users who opted out of follow-up emails get neither the daily nor
-        // the weekly digest. Transactional emails are unaffected (they're
-        // sent elsewhere and not gated by this flag).
-        if (member.emailFollowupsDisabled) continue;
-
-        const unsubUrl = buildUnsubscribeUrl(member.id);
-
-        // Daily digest for everyone (default frequency)
-        const digest = await compileDailyDigest(db, member.id, co.id);
-        if (digest) {
-          sendMail({
-            emailType: "reminders.daily_digest",
-            recipientUserId: member.id,
-            to: digest.recipientEmail,
-            ...dailyDigestEmail({
-              recipientName: digest.recipientName,
-              companyName: digest.companyName,
-              overdueItems: digest.overdueItems,
-              urgentItems: digest.urgentItems,
-              upcomingItems: digest.upcomingItems,
-              compliancePercentage: digest.compliancePercentage,
-              dashboardUrl: digest.dashboardUrl,
-              unsubscribeUrl: unsubUrl,
-            }),
-          }).catch((err) => {
-            logAudit({
-              companyId: co.id,
-              userId: null,
-              action: "email.digest_failed",
-              entityType: "notification",
-              entityId: null,
-              description: `Daily digest to ${digest.recipientEmail} failed: ${err instanceof Error ? err.message : "unknown"}`,
-            });
-          });
-          stats.phase5_digests++;
-        }
-
-        // Weekly management digest on Mondays
-        const isMonday = new Date().getDay() === 1;
-        const isManagementOrAdmin = member.isManagement || member.role === "admin";
-
-        if (isMonday && isManagementOrAdmin) {
-          const mgmtDigest = await compileManagementDigest(db, member.id, co.id);
-          if (mgmtDigest) {
-            sendMail({
-              emailType: "reminders.weekly_management_digest",
-              recipientUserId: member.id,
-              to: mgmtDigest.recipientEmail,
-              ...weeklyManagementDigestEmail({
-                recipientName: mgmtDigest.recipientName,
-                companyName: mgmtDigest.companyName,
-                compliancePercentage: mgmtDigest.compliancePercentage,
-                overdueCount: mgmtDigest.overdueCount,
-                urgentCount: mgmtDigest.urgentCount,
-                escalationCount: mgmtDigest.escalationCount,
-                totalRequirements: mgmtDigest.totalRequirements,
-                completedRequirements: mgmtDigest.completedRequirements,
-                dashboardUrl: mgmtDigest.dashboardUrl,
-                unsubscribeUrl: unsubUrl,
-              }),
-            }).catch((err) => {
-              logAudit({
-                companyId: co.id,
-                userId: null,
-                action: "email.mgmt_digest_failed",
-                entityType: "notification",
-                entityId: null,
-                description: `Management digest to ${mgmtDigest.recipientEmail} failed: ${err instanceof Error ? err.message : "unknown"}`,
-              });
-            });
-            stats.phase5_digests++;
-          }
-        }
-      }
-    }
-
-    // Mark digest email notifications as sent
-    const pendingEmails = await db.query.notification.findMany({
-      where: and(
-        eq(notification.status, "pending"),
-        eq(notification.channel, "email"),
-        lte(notification.scheduledFor, new Date()),
-      ),
-      columns: { id: true },
-    });
-
-    if (pendingEmails.length > 0) {
-      await db
-        .update(notification)
-        .set({ status: "sent", sentAt: new Date() })
-        .where(inArray(notification.id, pendingEmails.map((n) => n.id)));
-    }
+    // The per-requirement email rows that the digest covers are NOT flipped to
+    // "sent" here any more. They were, back when this phase did the sending —
+    // which already overstated reality, because the flip ran whether or not
+    // the digest actually left. Now that digests go out from the console, a
+    // flip here would mark mail sent that nobody has pressed send on yet, and
+    // would then hide those items from the next digest. They stay pending
+    // until a digest genuinely carries them (lib/mail/digest-outbox.ts).
 
     // -----------------------------------------------------------------------
     // Phase 6: Supplier portal — drain queued publication event broadcasts
@@ -460,7 +381,9 @@ export async function GET(req: NextRequest) {
     // pseudonymous fingerprint. Isolated: errors do NOT abort the cron.
     // -----------------------------------------------------------------------
     try {
-      stats.phase7_erasure_records_minimised = await purgeExpiredErasureRecords(new Date());
+      stats.phase7_erasure_records_minimised = await purgeExpiredErasureRecords(
+        new Date(),
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown error";
       console.error("[cron] erasure retention purge failed:", err);
@@ -514,7 +437,10 @@ async function recalculateAssessmentProgress(assessmentId: string) {
     where: eq(companyRequirementStatus.assessmentId, assessmentId),
   });
   const completed = allStatuses.filter(
-    (s) => s.status === "completed" || s.status === "approved" || s.status === "not_applicable"
+    (s) =>
+      s.status === "completed" ||
+      s.status === "approved" ||
+      s.status === "not_applicable",
   ).length;
   const total = allStatuses.length;
   const percentage = total > 0 ? ((completed / total) * 100).toFixed(2) : "0";

--- a/app/api/email/preferences/route.ts
+++ b/app/api/email/preferences/route.ts
@@ -1,0 +1,89 @@
+/**
+ * POST /api/email/preferences
+ *
+ * Toggle one email preference scope for one person. Credential is the same
+ * HMAC-signed token the unsubscribe links carry, so the preference centre
+ * works straight from an email without signing in — the person who received
+ * the mail is by definition the person allowed to change its settings.
+ *
+ * Body: { u: userId, t: token, scope: string, subscribed: boolean }
+ *   subscribed=false  -> store an opt-out row for that scope
+ *   subscribed=true   -> remove it (and, for scope "all", clear the legacy
+ *                        emailFollowupsDisabled boolean)
+ *
+ * Both directions are idempotent.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+import { logAudit } from "@/lib/audit";
+import { db } from "@/lib/db";
+import { verifyUnsubscribeToken } from "@/lib/email/unsubscribe";
+import { parseScope, SCOPE_ALL } from "@/lib/mail/consent";
+import { emailPreference, user } from "@/schema";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const userId = typeof body.u === "string" ? body.u : null;
+  const token = typeof body.t === "string" ? body.t : null;
+  const subscribed = body.subscribed === true;
+  if (!userId || !token || !verifyUnsubscribeToken(userId, token)) {
+    return NextResponse.json({ error: "Invalid link" }, { status: 403 });
+  }
+
+  const scope = parseScope(typeof body.scope === "string" ? body.scope : null);
+  if (!scope) {
+    return NextResponse.json({ error: "Unknown setting" }, { status: 400 });
+  }
+
+  const row = await db.query.user.findFirst({
+    where: eq(user.id, userId),
+    columns: { id: true, email: true, companyId: true },
+  });
+  if (!row) {
+    return NextResponse.json({ error: "Invalid link" }, { status: 403 });
+  }
+
+  if (subscribed) {
+    await db
+      .delete(emailPreference)
+      .where(and(eq(emailPreference.userId, row.id), eq(emailPreference.scope, scope)));
+    // Turning anything back on also clears the coarse switch: leaving it set
+    // would silently override the choice the person just made.
+    if (scope === SCOPE_ALL) {
+      await db
+        .update(user)
+        .set({ emailFollowupsDisabled: false, updatedAt: new Date() })
+        .where(eq(user.id, row.id));
+    }
+  } else if (scope === SCOPE_ALL) {
+    await db
+      .update(user)
+      .set({ emailFollowupsDisabled: true, updatedAt: new Date() })
+      .where(eq(user.id, row.id));
+  } else {
+    await db
+      .insert(emailPreference)
+      .values({ userId: row.id, scope, source: "preference_centre" })
+      .onConflictDoNothing();
+  }
+
+  logAudit({
+    companyId: row.companyId,
+    userId: row.id,
+    action: subscribed ? "email.resubscribed_scope" : "email.unsubscribed_scope",
+    entityType: "user",
+    entityId: row.id,
+    description: `${subscribed ? "Resubscribed" : "Unsubscribed"} ${row.email} ${subscribed ? "to" : "from"} ${scope} via preference centre`,
+  });
+
+  return NextResponse.json({ ok: true, scope, subscribed });
+}

--- a/app/api/email/unsubscribe/route.ts
+++ b/app/api/email/unsubscribe/route.ts
@@ -16,8 +16,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { user } from "@/schema";
+import { emailPreference, user } from "@/schema";
 import { verifyUnsubscribeToken } from "@/lib/email/unsubscribe";
+import { SCOPE_ALL, parseScope } from "@/lib/mail/consent";
 import { logAudit } from "@/lib/audit";
 import { getAppUrl } from "@/lib/utils";
 
@@ -48,27 +49,56 @@ async function processUnsubscribe(req: NextRequest): Promise<boolean> {
   if (!userId || !token) return false;
   if (!verifyUnsubscribeToken(userId, token)) return false;
 
+  // A scope names what to switch off: one message type, a whole category, or
+  // everything optional. Absent (every link in already-delivered mail) means
+  // everything, which is what those links have always done. An unrecognised
+  // scope is treated as a broken link rather than silently widened to "all".
+  const scope = parseScope(url.searchParams.get("scope"));
+  if (!scope) return false;
+
   // Look up the user to confirm existence and capture their companyId for
-  // the audit row. The flag flip is idempotent — clicking twice is a no-op.
+  // the audit row. Every path here is idempotent — clicking twice is a no-op.
   const row = await db.query.user.findFirst({
     where: eq(user.id, userId),
     columns: { id: true, email: true, companyId: true, emailFollowupsDisabled: true },
   });
   if (!row) return false;
 
-  if (!row.emailFollowupsDisabled) {
-    await db
-      .update(user)
-      .set({ emailFollowupsDisabled: true, updatedAt: new Date() })
-      .where(eq(user.id, userId));
+  if (scope === SCOPE_ALL) {
+    // The coarse switch stays the boolean it has always been, so nothing that
+    // reads emailFollowupsDisabled needs to learn about the new table.
+    if (!row.emailFollowupsDisabled) {
+      await db
+        .update(user)
+        .set({ emailFollowupsDisabled: true, updatedAt: new Date() })
+        .where(eq(user.id, userId));
 
+      logAudit({
+        companyId: row.companyId,
+        userId: row.id,
+        action: "email.unsubscribed",
+        entityType: "user",
+        entityId: row.id,
+        description: `Unsubscribed ${row.email} from all optional emails`,
+      });
+    }
+    return true;
+  }
+
+  const inserted = await db
+    .insert(emailPreference)
+    .values({ userId: row.id, scope, source: "one_click" })
+    .onConflictDoNothing()
+    .returning({ id: emailPreference.id });
+
+  if (inserted.length > 0) {
     logAudit({
       companyId: row.companyId,
       userId: row.id,
-      action: "email.unsubscribed",
+      action: "email.unsubscribed_scope",
       entityType: "user",
       entityId: row.id,
-      description: `Unsubscribed ${row.email} from follow-up emails`,
+      description: `Unsubscribed ${row.email} from ${scope}`,
     });
   }
   return true;

--- a/app/email/preferences/PreferenceForm.tsx
+++ b/app/email/preferences/PreferenceForm.tsx
@@ -75,17 +75,22 @@ export function PreferenceForm({
 
   return (
     <div className="space-y-6">
+      {/* Every switch on this page means the same thing: ticked = you receive
+          it. An earlier version had this master switch inverted (ticked =
+          unsubscribe from everything) while the ones below meant the
+          opposite, which is how somebody ends up subscribing when they meant
+          to leave. One polarity, no exceptions. */}
       <label className="flex items-start gap-3 rounded-lg border border-border p-4">
         <input
           type="checkbox"
           className="mt-1 h-4 w-4"
-          checked={allOff}
-          onChange={(e) => toggle("all", !e.target.checked)}
+          checked={!allOff}
+          onChange={(e) => toggle("all", e.target.checked)}
         />
         <span>
-          <span className="font-medium">{copy.allOffTitle}</span>
+          <span className="font-medium">{copy.allOnTitle}</span>
           <span className="block text-sm text-muted-foreground">
-            {copy.allOffDescription}
+            {copy.allOnDescription}
           </span>
         </span>
       </label>

--- a/app/email/preferences/PreferenceForm.tsx
+++ b/app/email/preferences/PreferenceForm.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CATEGORY_LABELS,
+  PAGE_COPY,
+  type PreferenceLocale,
+  TYPE_LABELS,
+} from "@/lib/mail/email-type-labels";
+import type { EmailCategory, UserConsentEmailTypeId } from "@/lib/mail/email-types";
+
+interface Group {
+  category: EmailCategory;
+  types: UserConsentEmailTypeId[];
+}
+
+/**
+ * Optimistic toggles over the preference API. Each switch owns one scope
+ * string; the master switch owns "all" and, while on, visually disables the
+ * rest because it already overrides them in the gate — the UI states what
+ * the server does rather than pretending the finer switches still apply.
+ */
+export function PreferenceForm({
+  userId,
+  token,
+  locale,
+  groups,
+  allOptionalDisabled,
+  optedOutScopes,
+}: {
+  userId: string;
+  token: string;
+  locale: PreferenceLocale;
+  groups: Group[];
+  allOptionalDisabled: boolean;
+  optedOutScopes: string[];
+}) {
+  const copy = PAGE_COPY[locale];
+  const [allOff, setAllOff] = useState(allOptionalDisabled);
+  const [optedOut, setOptedOut] = useState<Set<string>>(new Set(optedOutScopes));
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+
+  async function toggle(scope: string, subscribed: boolean) {
+    const previousAll = allOff;
+    const previous = new Set(optedOut);
+    if (scope === "all") {
+      setAllOff(!subscribed);
+      if (subscribed) {
+        const next = new Set(optedOut);
+        next.delete("all");
+        setOptedOut(next);
+      }
+    } else {
+      const next = new Set(optedOut);
+      if (subscribed) next.delete(scope);
+      else next.add(scope);
+      setOptedOut(next);
+    }
+    setStatus("idle");
+
+    const res = await fetch("/api/email/preferences", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ u: userId, t: token, scope, subscribed }),
+    }).catch(() => null);
+
+    if (!res?.ok) {
+      setAllOff(previousAll);
+      setOptedOut(previous);
+      setStatus("error");
+      return;
+    }
+    setStatus("saved");
+  }
+
+  return (
+    <div className="space-y-6">
+      <label className="flex items-start gap-3 rounded-lg border border-border p-4">
+        <input
+          type="checkbox"
+          className="mt-1 h-4 w-4"
+          checked={allOff}
+          onChange={(e) => toggle("all", !e.target.checked)}
+        />
+        <span>
+          <span className="font-medium">{copy.allOffTitle}</span>
+          <span className="block text-sm text-muted-foreground">
+            {copy.allOffDescription}
+          </span>
+        </span>
+      </label>
+
+      {groups.map((group) => {
+        const categoryScope = `category:${group.category}`;
+        const categoryOff = optedOut.has(categoryScope);
+        const label = CATEGORY_LABELS[group.category][locale];
+        return (
+          <fieldset
+            key={group.category}
+            className={`space-y-3 rounded-lg border border-border p-4 ${allOff ? "opacity-50" : ""}`}
+            disabled={allOff}
+          >
+            <legend className="px-1 font-medium">{label.title}</legend>
+            <p className="text-sm text-muted-foreground">{label.description}</p>
+            <label className="flex items-center gap-3 text-sm">
+              <input
+                type="checkbox"
+                className="h-4 w-4"
+                checked={!categoryOff && !allOff}
+                onChange={(e) => toggle(categoryScope, e.target.checked)}
+              />
+              <span>{label.title}</span>
+            </label>
+            <div className="space-y-2 pl-7">
+              {group.types.map((type) => {
+                const scope = `type:${type}`;
+                const on = !allOff && !categoryOff && !optedOut.has(scope);
+                return (
+                  <label key={type} className="flex items-center gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4"
+                      checked={on}
+                      disabled={allOff || categoryOff}
+                      onChange={(e) => toggle(scope, e.target.checked)}
+                    />
+                    <span className="text-muted-foreground">
+                      {TYPE_LABELS[type][locale]}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        );
+      })}
+
+      <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">
+          {CATEGORY_LABELS.security[locale].title}
+          {" · "}
+          {CATEGORY_LABELS.account[locale].title}
+        </span>
+        <span className="block">{copy.alwaysSent}</span>
+        <span className="block">{CATEGORY_LABELS.security[locale].description}</span>
+      </div>
+
+      <p className="text-sm" role="status" aria-live="polite">
+        {status === "saved" && (
+          <span className="text-muted-foreground">{copy.saved}</span>
+        )}
+        {status === "error" && <span className="text-destructive">{copy.failed}</span>}
+      </p>
+    </div>
+  );
+}

--- a/app/email/preferences/page.tsx
+++ b/app/email/preferences/page.tsx
@@ -1,0 +1,105 @@
+/**
+ * The preference centre, reached from the footer of any optional email.
+ *
+ * Sits outside the [locale] segment like its sibling /email/unsubscribed,
+ * because it is opened from a mail client with no session and no locale
+ * cookie worth trusting. The language rides in the URL (`lang`), set at send
+ * time from the same resolution the email body used, so the page speaks
+ * whatever the email spoke.
+ *
+ * Credential is the HMAC-signed token from the email link. It grants exactly
+ * one thing: managing that person's own email settings.
+ */
+
+import { eq } from "drizzle-orm";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { db } from "@/lib/db";
+import { verifyUnsubscribeToken } from "@/lib/email/unsubscribe";
+import { mailSupportEmail } from "@/lib/env";
+import { buildEmailConsent } from "@/lib/mail/consent";
+import { PAGE_COPY, parsePreferenceLocale } from "@/lib/mail/email-type-labels";
+import { optionalEmailTypesByCategory } from "@/lib/mail/email-types";
+import { emailPreference, user } from "@/schema";
+import { PreferenceForm } from "./PreferenceForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Email settings | NISD2",
+  robots: { index: false, follow: false },
+};
+
+export default async function EmailPreferencesPage(props: {
+  searchParams: Promise<{ u?: string; t?: string; lang?: string }>;
+}) {
+  const { u: userId, t: token, lang } = await props.searchParams;
+  const locale = parsePreferenceLocale(lang);
+  const copy = PAGE_COPY[locale];
+  const supportEmail = mailSupportEmail();
+
+  const valid = Boolean(userId && token && verifyUnsubscribeToken(userId, token));
+  const recipient = valid
+    ? await db.query.user.findFirst({
+        where: eq(user.id, userId as string),
+        columns: { id: true, email: true, emailFollowupsDisabled: true },
+      })
+    : undefined;
+
+  if (!recipient) {
+    return (
+      <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+        <div className="max-w-md w-full text-center space-y-4">
+          <h1 className="text-2xl font-semibold">{copy.invalid}</h1>
+          <p className="text-muted-foreground leading-relaxed">{copy.invalidHelp}</p>
+          <p className="text-sm text-muted-foreground">
+            <a className="underline" href={`mailto:${supportEmail}`}>
+              {supportEmail}
+            </a>
+          </p>
+          <div className="pt-4">
+            <Link href="/" className="text-sm underline">
+              nisd2.eu
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const rows = await db
+    .select({ scope: emailPreference.scope })
+    .from(emailPreference)
+    .where(eq(emailPreference.userId, recipient.id));
+  const consent = buildEmailConsent({
+    followupsDisabled: recipient.emailFollowupsDisabled,
+    scopes: rows.map((r) => r.scope),
+  });
+
+  return (
+    <main className="min-h-screen px-6 py-12 bg-background">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">{copy.title}</h1>
+          <p className="text-muted-foreground leading-relaxed">{copy.intro}</p>
+          <p className="text-sm text-muted-foreground">{recipient.email}</p>
+        </div>
+
+        <PreferenceForm
+          userId={recipient.id}
+          token={token as string}
+          locale={locale}
+          groups={optionalEmailTypesByCategory()}
+          allOptionalDisabled={consent.allOptionalDisabled}
+          optedOutScopes={Array.from(consent.optedOutScopes)}
+        />
+
+        <div className="pt-4">
+          <Link href="/" className="text-sm underline">
+            nisd2.eu
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -529,6 +529,121 @@ function LifecycleQueuePanel() {
   );
 }
 
+/**
+ * The deadline digests waiting to go out. Same shape as the lifecycle
+ * console: see who, choose how many, press send. These used to leave from
+ * the nightly cron; they no longer do.
+ */
+function DigestQueuePanel() {
+  const utils = trpc.useUtils();
+  const [limit, setLimit] = useState(1);
+  const queue = trpc.platformAdmin.digestQueue.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const send = trpc.platformAdmin.sendDigestBatch.useMutation({
+    onSuccess: (r) => {
+      if (r.skipped) {
+        toast.warning(`Nothing sent: ${r.skipped}`);
+      } else {
+        toast.success(
+          `Sent ${r.sent}${r.failed ? `, ${r.failed} failed` : ""}${r.deferred ? `, ${r.deferred} still queued` : ""}`,
+        );
+      }
+      void utils.platformAdmin.digestQueue.invalidate();
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const total = queue.data?.total ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Deadline digests
+          {total > 0 && (
+            <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+              {total} waiting
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Daily summaries and the weekly management report. Only people with something to
+          report and who have not unsubscribed appear here. Each is rebuilt at the moment
+          you send, so the numbers are never stale.
+        </p>
+
+        {queue.isLoading && (
+          <p className="text-sm text-muted-foreground">Building digests...</p>
+        )}
+        {queue.isError && (
+          <p className="text-sm text-destructive">
+            Could not build the queue: {queue.error.message}
+          </p>
+        )}
+        {queue.data && total === 0 && (
+          <p className="text-sm text-muted-foreground">
+            Nothing to send — no company has open items worth a digest today.
+          </p>
+        )}
+
+        {total > 0 && (
+          <div className="max-h-48 overflow-y-auto rounded border border-border">
+            <table className="w-full text-sm">
+              <tbody>
+                {queue.data?.items.map((item) => (
+                  <tr
+                    key={`${item.kind}:${item.email}:${item.companyName}`}
+                    className="border-b border-border/50 last:border-0"
+                  >
+                    <td className="py-1.5 pl-3 pr-2">
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                        {item.kind}
+                      </span>
+                    </td>
+                    <td className="py-1.5 pr-4">{item.email}</td>
+                    <td className="py-1.5 pr-4 text-muted-foreground">
+                      {item.companyName}
+                    </td>
+                    <td className="py-1.5 pr-3 text-muted-foreground">{item.summary}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
+          <label className="text-sm text-muted-foreground" htmlFor="digest-limit">
+            How many to send
+          </label>
+          <input
+            id="digest-limit"
+            type="number"
+            min={1}
+            max={100}
+            value={limit}
+            onChange={(e) =>
+              setLimit(Math.min(100, Math.max(1, Number(e.target.value) || 1)))
+            }
+            className="w-20 rounded border border-border bg-background px-2 py-1 text-sm"
+          />
+          <Button
+            size="sm"
+            onClick={() => send.mutate({ limit })}
+            disabled={send.isPending || total === 0}
+          >
+            {send.isPending ? "Sending..." : `Send ${Math.min(limit, total)} now`}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 function ResubscribeButton({ userId, email }: { userId: string; email: string }) {
   const utils = trpc.useUtils();
   const resubscribe = trpc.platformAdmin.resubscribeUser.useMutation({
@@ -1020,8 +1135,10 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
 
   return (
     <div className="space-y-6">
-      {/* The send console: review the queue, choose how many, press send. */}
+      {/* The send consoles: review the queue, choose how many, press send.
+          Nothing on this page goes out on a timer. */}
       <LifecycleQueuePanel />
+      <DigestQueuePanel />
 
       {/* KPI strip */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">

--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -1,34 +1,30 @@
 "use client";
 
-import { useState } from "react";
 import {
   Activity,
   BadgeCheck,
   Building2,
+  FlaskConical,
   GraduationCap,
   Loader2,
   Mail,
   Shield,
   Trash2,
-  FlaskConical,
   Truck,
   Users,
 } from "lucide-react";
-import { trpc, type RouterInputs } from "@/lib/trpc/client";
+import { useState } from "react";
 import { toast } from "sonner";
+import { type RouterInputs, trpc } from "@/lib/trpc/client";
 
 type CourseId = RouterInputs["platformAdmin"]["trainingMarkCourseComplete"]["courseId"];
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+
 import { PageHeader } from "@/components/shared/PageHeader";
-import { Link, useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
-import { EraseUserButton, ErasuresPanel } from "./GdprErasure";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link, useRouter } from "@/i18n/navigation";
 import { DevPanel } from "./DevPanel";
+import { EraseUserButton, ErasuresPanel } from "./GdprErasure";
 
 // ---------------------------------------------------------------------------
 // Types (inferred from tRPC, kept flat for props)
@@ -138,6 +134,10 @@ interface OptedOutUserRow {
   name: string;
   companyName: string | null;
   updatedAt: Date;
+  /** The legacy coarse switch: all optional email off. */
+  allOff: boolean;
+  /** Per-scope opt-outs ("category:reminders", "type:newsletter.issue", ...). */
+  scopes: string[];
 }
 
 interface EmailActivity {
@@ -187,23 +187,52 @@ function timeAgo(date: Date | string): string {
 }
 
 function planBadge(plan: string | null) {
-  if (!plan || plan === "free") return <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">free</span>;
-  if (plan === "guided") return <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">guided</span>;
-  return <span className="rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-300">{plan}</span>;
+  if (!plan || plan === "free")
+    return (
+      <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+        free
+      </span>
+    );
+  if (plan === "guided")
+    return (
+      <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+        guided
+      </span>
+    );
+  return (
+    <span className="rounded bg-purple-100 px-1.5 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900 dark:text-purple-300">
+      {plan}
+    </span>
+  );
 }
 
-type Tab = "users" | "companies" | "compliance" | "training" | "suppliers" | "emails" | "erasures" | "dev";
+type Tab =
+  | "users"
+  | "companies"
+  | "compliance"
+  | "training"
+  | "suppliers"
+  | "emails"
+  | "erasures"
+  | "dev";
 
 /** Human-readable label for a notification.entityType value. */
 function emailTypeLabel(t: string): string {
   switch (t) {
-    case "course_followup": return "Course follow-up";
-    case "requirement": return "Compliance reminder";
-    case "policy": return "Policy reminder";
-    case "supplier_publication_event": return "Supplier incident broadcast";
-    case "lifecycle_email": return "Lifecycle nudge";
-    case "newsletter_issue": return "Newsletter";
-    default: return t;
+    case "course_followup":
+      return "Course follow-up";
+    case "requirement":
+      return "Compliance reminder";
+    case "policy":
+      return "Policy reminder";
+    case "supplier_publication_event":
+      return "Supplier incident broadcast";
+    case "lifecycle_email":
+      return "Lifecycle nudge";
+    case "newsletter_issue":
+      return "Newsletter";
+    default:
+      return t;
   }
 }
 
@@ -240,26 +269,81 @@ export function PlatformAdminPage({
 
       {/* KPI cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-        <StatCard label="Total Users" value={overview.totalUsers} sub={`${overview.recentUsers} this week`} />
-        <StatCard label="Activated Users" value={overview.usersWithActivatedCompany} sub={`of ${overview.totalUsers}`} />
-        <StatCard label="Activated Orgs" value={overview.activatedCompanies} sub={`${overview.draftCompanies} draft`} />
-        <StatCard label="CEO Course Done" value={overview.ceoCourseFinished} sub={`of ${overview.ceoCourseStarted} started`} />
+        <StatCard
+          label="Total Users"
+          value={overview.totalUsers}
+          sub={`${overview.recentUsers} this week`}
+        />
+        <StatCard
+          label="Activated Users"
+          value={overview.usersWithActivatedCompany}
+          sub={`of ${overview.totalUsers}`}
+        />
+        <StatCard
+          label="Activated Orgs"
+          value={overview.activatedCompanies}
+          sub={`${overview.draftCompanies} draft`}
+        />
+        <StatCard
+          label="CEO Course Done"
+          value={overview.ceoCourseFinished}
+          sub={`of ${overview.ceoCourseStarted} started`}
+        />
         <StatCard label="Assessments" value={overview.totalAssessments} />
-        <StatCard label="Not Activated" value={overview.totalUsers - overview.usersWithActivatedCompany} sub="draft shell only" />
+        <StatCard
+          label="Not Activated"
+          value={overview.totalUsers - overview.usersWithActivatedCompany}
+          sub="draft shell only"
+        />
       </div>
 
       {/* Tabs */}
       <div className="flex flex-wrap gap-1 rounded-lg border bg-muted/50 p-1">
-        {([
+        {[
           { key: "users" as const, label: "Users", icon: Users, count: users.length },
-          { key: "companies" as const, label: "Companies", icon: Building2, count: companies.length },
-          { key: "compliance" as const, label: "Compliance", icon: Activity, count: complianceActivity.length },
-          { key: "training" as const, label: "Training", icon: GraduationCap, count: trainingActivity.length },
-          { key: "suppliers" as const, label: "Suppliers", icon: Truck, count: supplierActivity.length },
-          { key: "emails" as const, label: "Emails", icon: Mail, count: emailActivity.totalSent },
-          { key: "erasures" as const, label: "Erasures", icon: Trash2, count: undefined as number | undefined },
-          { key: "dev" as const, label: "Dev", icon: FlaskConical, count: undefined as number | undefined },
-        ]).map(({ key, label, icon: Icon, count }) => (
+          {
+            key: "companies" as const,
+            label: "Companies",
+            icon: Building2,
+            count: companies.length,
+          },
+          {
+            key: "compliance" as const,
+            label: "Compliance",
+            icon: Activity,
+            count: complianceActivity.length,
+          },
+          {
+            key: "training" as const,
+            label: "Training",
+            icon: GraduationCap,
+            count: trainingActivity.length,
+          },
+          {
+            key: "suppliers" as const,
+            label: "Suppliers",
+            icon: Truck,
+            count: supplierActivity.length,
+          },
+          {
+            key: "emails" as const,
+            label: "Emails",
+            icon: Mail,
+            count: emailActivity.totalSent,
+          },
+          {
+            key: "erasures" as const,
+            label: "Erasures",
+            icon: Trash2,
+            count: undefined as number | undefined,
+          },
+          {
+            key: "dev" as const,
+            label: "Dev",
+            icon: FlaskConical,
+            count: undefined as number | undefined,
+          },
+        ].map(({ key, label, icon: Icon, count }) => (
           <button
             key={key}
             onClick={() => setTab(key)}
@@ -271,7 +355,9 @@ export function PlatformAdminPage({
           >
             <Icon className="h-4 w-4" />
             {label}
-            {typeof count === "number" && <span className="text-xs text-muted-foreground">({count})</span>}
+            {typeof count === "number" && (
+              <span className="text-xs text-muted-foreground">({count})</span>
+            )}
           </button>
         ))}
       </div>
@@ -294,13 +380,24 @@ export function PlatformAdminPage({
 // ---------------------------------------------------------------------------
 
 function SendTestNudgeButton() {
+  const utils = trpc.useUtils();
   const send = trpc.platformAdmin.sendLifecycleTestEmail.useMutation({
-    onSuccess: (r) =>
+    onSuccess: (r) => {
+      if (!r.sent) {
+        // The gate refused, which is the honest answer: this is the same
+        // check a customer gets. Say so instead of quietly delivering.
+        toast.warning(
+          `Nothing sent — ${r.to} is unsubscribed from this email. Resubscribe below to test it.`,
+        );
+        return;
+      }
       toast.success(
         r.suppressed
           ? `Rendered for ${r.to}; delivery suppressed in this environment`
           : `Test nudge sent to ${r.to}`,
-      ),
+      );
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
     onError: (e) => toast.error(e.message),
   });
   return (
@@ -313,6 +410,154 @@ function SendTestNudgeButton() {
       {send.isPending ? "Sending..." : "Send me a test nudge"}
     </Button>
   );
+}
+
+/**
+ * The send console: what is queued, how many to send, and the button that
+ * sends them. Nothing about the lifecycle campaign goes out on a timer —
+ * this is the only path, so the queue is always reviewed by a person before
+ * anything leaves.
+ */
+function LifecycleQueuePanel() {
+  const utils = trpc.useUtils();
+  const [limit, setLimit] = useState(1);
+  const queue = trpc.platformAdmin.lifecycleQueue.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const send = trpc.platformAdmin.sendLifecycleBatch.useMutation({
+    onSuccess: (r) => {
+      if (r.skipped) {
+        toast.warning(`Nothing sent: ${r.skipped}`);
+      } else {
+        toast.success(
+          `Sent ${r.sent}${r.failed ? `, ${r.failed} failed` : ""}${r.deferred ? `, ${r.deferred} still queued` : ""}`,
+        );
+      }
+      void utils.platformAdmin.lifecycleQueue.invalidate();
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  const totalQueued = queue.data?.types.reduce((sum, t) => sum + t.prepared, 0) ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Queued to send
+          {totalQueued > 0 && (
+            <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+              {totalQueued} waiting
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Nothing here sends on a schedule. These people are eligible right now; they
+          receive the email only when you press send, oldest-dormant first, and each
+          person can receive it at most once ever.
+        </p>
+
+        {queue.isLoading && (
+          <p className="text-sm text-muted-foreground">Checking who is due...</p>
+        )}
+        {queue.data?.available === false && (
+          <p className="text-sm text-muted-foreground">
+            Sending unavailable: {queue.data.reason}
+          </p>
+        )}
+
+        {queue.data?.types.map((t) => (
+          <div key={t.key} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">{t.key}</span>
+              <span className="text-sm text-muted-foreground">{t.prepared} queued</span>
+            </div>
+            {t.error && (
+              <p className="text-sm text-destructive">
+                Campaign failed to run: {t.error}
+              </p>
+            )}
+            {t.recipients.length > 0 && (
+              <div className="max-h-48 overflow-y-auto rounded border border-border">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {t.recipients.map((r, i) => (
+                      <tr key={r.to} className="border-b border-border/50 last:border-0">
+                        <td className="py-1.5 pl-3 pr-2 text-muted-foreground w-10">
+                          {i + 1}
+                        </td>
+                        <td className="py-1.5 pr-4">{r.to}</td>
+                        <td className="py-1.5 pr-3 text-muted-foreground">{r.subject}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        ))}
+
+        <div className="flex flex-wrap items-center gap-3 border-t border-border pt-4">
+          <label className="text-sm text-muted-foreground" htmlFor="lifecycle-limit">
+            How many to send
+          </label>
+          <input
+            id="lifecycle-limit"
+            type="number"
+            min={1}
+            max={100}
+            value={limit}
+            onChange={(e) =>
+              setLimit(Math.min(100, Math.max(1, Number(e.target.value) || 1)))
+            }
+            className="w-20 rounded border border-border bg-background px-2 py-1 text-sm"
+          />
+          <Button
+            size="sm"
+            onClick={() => send.mutate({ limit })}
+            disabled={send.isPending || totalQueued === 0}
+          >
+            {send.isPending ? "Sending..." : `Send ${Math.min(limit, totalQueued)} now`}
+          </Button>
+          <SendTestNudgeButton />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResubscribeButton({ userId, email }: { userId: string; email: string }) {
+  const utils = trpc.useUtils();
+  const resubscribe = trpc.platformAdmin.resubscribeUser.useMutation({
+    onSuccess: (r) => {
+      toast.success(`${r.email} resubscribed to all optional email`);
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => resubscribe.mutate({ userId })}
+      disabled={resubscribe.isPending}
+      title={`Put ${email} back on the list`}
+    >
+      {resubscribe.isPending ? "..." : "Resubscribe"}
+    </Button>
+  );
+}
+
+/** "category:reminders" -> "Reminders", "type:newsletter.issue" -> "Newsletter issue". */
+function scopeLabel(scope: string): string {
+  const [kind, ...rest] = scope.split(":");
+  const value = rest.join(":");
+  if (kind === "category") return value.charAt(0).toUpperCase() + value.slice(1);
+  if (kind === "type") return value.split(".").pop()?.replace(/_/g, " ") ?? value;
+  return scope;
 }
 
 function StatCard({ label, value, sub }: { label: string; value: number; sub?: string }) {
@@ -356,11 +601,19 @@ function UsersTable({ users }: { users: UserRow[] }) {
                 <tr key={u.id} className="border-b border-border/50 last:border-0">
                   <td className="py-2 pr-4 font-medium">{u.name}</td>
                   <td className="py-2 pr-4 text-muted-foreground">{u.email}</td>
-                  <td className="py-2 pr-4">{u.companyName ?? <span className="text-muted-foreground italic">none</span>}</td>
+                  <td className="py-2 pr-4">
+                    {u.companyName ?? (
+                      <span className="text-muted-foreground italic">none</span>
+                    )}
+                  </td>
                   <td className="py-2 pr-4">{planBadge(u.companyPlan)}</td>
                   <td className="py-2 pr-4">{u.role}</td>
-                  <td className="py-2 pr-4 text-muted-foreground">{timeAgo(u.createdAt)}</td>
-                  <td className="py-2"><EraseUserButton userId={u.id} email={u.email} /></td>
+                  <td className="py-2 pr-4 text-muted-foreground">
+                    {timeAgo(u.createdAt)}
+                  </td>
+                  <td className="py-2">
+                    <EraseUserButton userId={u.id} email={u.email} />
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -409,16 +662,32 @@ function CompaniesTable({ companies }: { companies: CompanyRow[] }) {
                       <div className="h-1.5 w-16 rounded-full bg-gray-200 dark:bg-gray-700">
                         <div
                           className="h-1.5 rounded-full bg-green-500"
-                          style={{ width: `${Math.min(100, parseFloat(c.compliancePct))}%` }}
+                          style={{
+                            width: `${Math.min(100, parseFloat(c.compliancePct))}%`,
+                          }}
                         />
                       </div>
-                      <span className="text-xs text-muted-foreground">{parseFloat(c.compliancePct).toFixed(0)}%</span>
+                      <span className="text-xs text-muted-foreground">
+                        {parseFloat(c.compliancePct).toFixed(0)}%
+                      </span>
                     </div>
                   </td>
                   <td className="py-2 pr-4 space-x-1">
-                    {!c.activatedAt && <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">Draft</span>}
-                    {c.actsAsNis2Entity && <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-700 dark:bg-amber-900 dark:text-amber-300">NIS2</span>}
-                    {c.actsAsSupplier && <span className="rounded bg-cyan-100 px-1.5 py-0.5 text-xs text-cyan-700 dark:bg-cyan-900 dark:text-cyan-300">Supplier</span>}
+                    {!c.activatedAt && (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                        Draft
+                      </span>
+                    )}
+                    {c.actsAsNis2Entity && (
+                      <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-700 dark:bg-amber-900 dark:text-amber-300">
+                        NIS2
+                      </span>
+                    )}
+                    {c.actsAsSupplier && (
+                      <span className="rounded bg-cyan-100 px-1.5 py-0.5 text-xs text-cyan-700 dark:bg-cyan-900 dark:text-cyan-300">
+                        Supplier
+                      </span>
+                    )}
                   </td>
                   <td className="py-2 text-muted-foreground">{timeAgo(c.createdAt)}</td>
                 </tr>
@@ -459,11 +728,19 @@ function ComplianceTable({ rows }: { rows: ComplianceRow[] }) {
               {rows.map((r) => {
                 const pct = r.total > 0 ? (r.completed / r.total) * 100 : 0;
                 return (
-                  <tr key={r.companyId} className="border-b border-border/50 last:border-0">
+                  <tr
+                    key={r.companyId}
+                    className="border-b border-border/50 last:border-0"
+                  >
                     <td className="py-2 pr-4 font-medium">{r.companyName}</td>
                     <td className="py-2 pr-4 text-xs text-muted-foreground">
                       {r.adminEmail ? (
-                        <a href={`mailto:${r.adminEmail}`} className="underline-offset-2 hover:underline">{r.adminEmail}</a>
+                        <a
+                          href={`mailto:${r.adminEmail}`}
+                          className="underline-offset-2 hover:underline"
+                        >
+                          {r.adminEmail}
+                        </a>
                       ) : (
                         <span>—</span>
                       )}
@@ -475,16 +752,25 @@ function ComplianceTable({ rows }: { rows: ComplianceRow[] }) {
                     <td className="py-2">
                       <div className="flex items-center gap-2">
                         <div className="h-1.5 w-20 rounded-full bg-gray-200 dark:bg-gray-700">
-                          <div className="h-1.5 rounded-full bg-green-500" style={{ width: `${pct}%` }} />
+                          <div
+                            className="h-1.5 rounded-full bg-green-500"
+                            style={{ width: `${pct}%` }}
+                          />
                         </div>
-                        <span className="text-xs text-muted-foreground">{pct.toFixed(0)}%</span>
+                        <span className="text-xs text-muted-foreground">
+                          {pct.toFixed(0)}%
+                        </span>
                       </div>
                     </td>
                   </tr>
                 );
               })}
               {rows.length === 0 && (
-                <tr><td colSpan={7} className="py-8 text-center text-muted-foreground">No compliance activity yet</td></tr>
+                <tr>
+                  <td colSpan={7} className="py-8 text-center text-muted-foreground">
+                    No compliance activity yet
+                  </td>
+                </tr>
               )}
             </tbody>
           </table>
@@ -512,16 +798,28 @@ function TrainingTable({ rows }: { rows: TrainingRow[] }) {
                 <th className="pb-2 pr-4 font-medium">User</th>
                 <th className="pb-2 pr-4 font-medium">Email</th>
                 <th className="pb-2 pr-4 font-medium">Company</th>
-                <th className="pb-2 pr-4 font-medium" title="Completed / total lessons in the CEO course (47)">
+                <th
+                  className="pb-2 pr-4 font-medium"
+                  title="Completed / total lessons in the CEO course (47)"
+                >
                   CEO
                 </th>
-                <th className="pb-2 pr-4 font-medium" title="Completed / total lessons in the CRA-SBOM course (9)">
+                <th
+                  className="pb-2 pr-4 font-medium"
+                  title="Completed / total lessons in the CRA-SBOM course (9)"
+                >
                   CRA
                 </th>
-                <th className="pb-2 pr-4 font-medium" title="Completed / total lessons in the NIS2 Tabletop course (8)">
+                <th
+                  className="pb-2 pr-4 font-medium"
+                  title="Completed / total lessons in the NIS2 Tabletop course (8)"
+                >
                   Tabletop
                 </th>
-                <th className="pb-2 pr-4 font-medium" title="Quizzes passed across all courses">
+                <th
+                  className="pb-2 pr-4 font-medium"
+                  title="Quizzes passed across all courses"
+                >
                   Quizzes
                 </th>
                 <th className="pb-2 font-medium">Last Active</th>
@@ -532,22 +830,53 @@ function TrainingTable({ rows }: { rows: TrainingRow[] }) {
                 <tr key={r.userId} className="border-b border-border/50 last:border-0">
                   <td className="py-2 pr-4 font-medium">{r.userName}</td>
                   <td className="py-2 pr-4 text-muted-foreground">{r.userEmail}</td>
-                  <td className="py-2 pr-4">{r.companyName ?? <span className="text-muted-foreground italic">none</span>}</td>
-                  <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.ceoCompleted} total={COURSES.ceo.total} touched={r.ceoTouched} courseId={COURSES.ceo.id} userId={r.userId} userEmail={r.userEmail} />
+                  <td className="py-2 pr-4">
+                    {r.companyName ?? (
+                      <span className="text-muted-foreground italic">none</span>
+                    )}
                   </td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.craCompleted} total={COURSES.cra.total} touched={r.craTouched} courseId={COURSES.cra.id} userId={r.userId} userEmail={r.userEmail} />
+                    <CourseCell
+                      completed={r.ceoCompleted}
+                      total={COURSES.ceo.total}
+                      touched={r.ceoTouched}
+                      courseId={COURSES.ceo.id}
+                      userId={r.userId}
+                      userEmail={r.userEmail}
+                    />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">
-                    <CourseCell completed={r.tabletopCompleted} total={COURSES.tabletop.total} touched={r.tabletopTouched} courseId={COURSES.tabletop.id} userId={r.userId} userEmail={r.userEmail} />
+                    <CourseCell
+                      completed={r.craCompleted}
+                      total={COURSES.cra.total}
+                      touched={r.craTouched}
+                      courseId={COURSES.cra.id}
+                      userId={r.userId}
+                      userEmail={r.userEmail}
+                    />
+                  </td>
+                  <td className="py-2 pr-4 tabular-nums">
+                    <CourseCell
+                      completed={r.tabletopCompleted}
+                      total={COURSES.tabletop.total}
+                      touched={r.tabletopTouched}
+                      courseId={COURSES.tabletop.id}
+                      userId={r.userId}
+                      userEmail={r.userEmail}
+                    />
                   </td>
                   <td className="py-2 pr-4 tabular-nums">{r.quizzesPassed}</td>
-                  <td className="py-2 text-muted-foreground">{r.lastActivity ? timeAgo(r.lastActivity) : "-"}</td>
+                  <td className="py-2 text-muted-foreground">
+                    {r.lastActivity ? timeAgo(r.lastActivity) : "-"}
+                  </td>
                 </tr>
               ))}
               {rows.length === 0 && (
-                <tr><td colSpan={8} className="py-8 text-center text-muted-foreground">No training activity yet</td></tr>
+                <tr>
+                  <td colSpan={8} className="py-8 text-center text-muted-foreground">
+                    No training activity yet
+                  </td>
+                </tr>
               )}
             </tbody>
           </table>
@@ -583,7 +912,11 @@ function CourseCell({
         </span>
       )}
       {completed < total && (
-        <MarkCourseCompleteButton courseId={courseId} userId={userId} userEmail={userEmail} />
+        <MarkCourseCompleteButton
+          courseId={courseId}
+          userId={userId}
+          userEmail={userEmail}
+        />
       )}
     </span>
   );
@@ -601,7 +934,9 @@ function MarkCourseCompleteButton({
   const router = useRouter();
   const mark = trpc.platformAdmin.trainingMarkCourseComplete.useMutation({
     onSuccess: (res) => {
-      toast.success(`Marked ${res.courseId} complete (${res.lessonCount} lessons) for ${userEmail}`);
+      toast.success(
+        `Marked ${res.courseId} complete (${res.lessonCount} lessons) for ${userEmail}`,
+      );
       router.refresh();
     },
     onError: (e) => toast.error(e.message),
@@ -660,7 +995,11 @@ function SuppliersTable({ rows }: { rows: SupplierRow[] }) {
                 </tr>
               ))}
               {rows.length === 0 && (
-                <tr><td colSpan={4} className="py-8 text-center text-muted-foreground">No supplier portal companies yet</td></tr>
+                <tr>
+                  <td colSpan={4} className="py-8 text-center text-muted-foreground">
+                    No supplier portal companies yet
+                  </td>
+                </tr>
               )}
             </tbody>
           </table>
@@ -681,18 +1020,23 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
 
   return (
     <div className="space-y-6">
-      {/* Test send: prove template + transport in this environment without
-          touching any claim or real recipient. */}
-      <div className="flex justify-end">
-        <SendTestNudgeButton />
-      </div>
+      {/* The send console: review the queue, choose how many, press send. */}
+      <LifecycleQueuePanel />
 
       {/* KPI strip */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
         <StatCard label="Sent (all time)" value={data.totalSent} sub="cron-driven only" />
         <StatCard label="Sent (last 7 days)" value={data.sentLast7d} />
-        <StatCard label="Subscribed users" value={subscribed} sub={`of ${data.totalUsers}`} />
-        <StatCard label="Opted out" value={data.optedOut} sub={`${optOutRate.toFixed(1)}% opt-out`} />
+        <StatCard
+          label="Subscribed users"
+          value={subscribed}
+          sub={`of ${data.totalUsers}`}
+        />
+        <StatCard
+          label="Opted out"
+          value={data.optedOut}
+          sub={`${optOutRate.toFixed(1)}% opt-out`}
+        />
         <StatCard
           label="Send failures"
           value={data.lifecycleFailed}
@@ -702,9 +1046,12 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
 
       {/* Scope note */}
       <p className="text-xs text-muted-foreground italic">
-        Scope: emails recorded in the notification table (course follow-ups, daily digests, weekly management digests, deadline reminders, lifecycle nudges, newsletter sends).
-        Transactional emails (invites, welcome, contact-change notices, supplier incident broadcasts) are not yet logged here.
-        Lifecycle rows record claims, not confirmed deliveries; the send-failures counter is the reconciliation signal.
+        Scope: emails recorded in the notification table (course follow-ups, daily
+        digests, weekly management digests, deadline reminders, lifecycle nudges,
+        newsletter sends). Transactional emails (invites, welcome, contact-change notices,
+        supplier incident broadcasts) are not yet logged here. Lifecycle rows record
+        claims, not confirmed deliveries; the send-failures counter is the reconciliation
+        signal.
       </p>
 
       {/* Daily volume, last 14 days */}
@@ -722,7 +1069,9 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
               >
                 <div
                   className="w-full rounded-t bg-primary/80 transition-colors group-hover:bg-primary"
-                  style={{ height: `${Math.max(2, Math.round((d.count / maxDaily) * 88))}px` }}
+                  style={{
+                    height: `${Math.max(2, Math.round((d.count / maxDaily) * 88))}px`,
+                  }}
                 />
               </div>
             ))}
@@ -748,8 +1097,9 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
         </CardHeader>
         <CardContent>
           <p className="mb-3 text-xs text-muted-foreground">
-            Rows are flagged from {data.multiSendAlertPerDay} sends to one person in a single day.
-            A digest, a course follow-up and a lifecycle nudge can coincide once; repeatedly hitting this level means a producer is misbehaving.
+            Rows are flagged from {data.multiSendAlertPerDay} sends to one person in a
+            single day. A digest, a course follow-up and a lifecycle nudge can coincide
+            once; repeatedly hitting this level means a producer is misbehaving.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -764,18 +1114,29 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
                 {data.frequentRecipients.map((r) => {
                   const flagged = r.maxPerDay >= data.multiSendAlertPerDay;
                   return (
-                    <tr key={r.recipient} className="border-b border-border/50 last:border-0">
+                    <tr
+                      key={r.recipient}
+                      className="border-b border-border/50 last:border-0"
+                    >
                       <td className="py-2 pr-4 text-muted-foreground">{r.recipient}</td>
                       <td className="py-2 pr-4">{r.total}</td>
-                      <td className={`py-2 ${flagged ? "font-semibold text-orange-600 dark:text-orange-400" : ""}`}>
+                      <td
+                        className={`py-2 ${flagged ? "font-semibold text-orange-600 dark:text-orange-400" : ""}`}
+                      >
                         {r.maxPerDay}
-                        {flagged && <span className="ml-1.5 text-xs font-normal">review</span>}
+                        {flagged && (
+                          <span className="ml-1.5 text-xs font-normal">review</span>
+                        )}
                       </td>
                     </tr>
                   );
                 })}
                 {data.frequentRecipients.length === 0 && (
-                  <tr><td colSpan={3} className="py-8 text-center text-muted-foreground">No sends in the last 7 days</td></tr>
+                  <tr>
+                    <td colSpan={3} className="py-8 text-center text-muted-foreground">
+                      No sends in the last 7 days
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>
@@ -796,7 +1157,8 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
                   key={b.type}
                   className="rounded bg-muted px-2.5 py-1 text-xs text-foreground"
                 >
-                  {emailTypeLabel(b.type)} <span className="font-semibold">{b.count}</span>
+                  {emailTypeLabel(b.type)}{" "}
+                  <span className="font-semibold">{b.count}</span>
                 </span>
               ))}
             </div>
@@ -827,16 +1189,28 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
                     <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
                       {e.sentAt ? timeAgo(e.sentAt) : "—"}
                     </td>
-                    <td className="py-2 pr-4 text-muted-foreground">{e.recipientEmail ?? "—"}</td>
-                    <td className="py-2 pr-4">{e.companyName ?? <span className="text-muted-foreground italic">—</span>}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {e.recipientEmail ?? "—"}
+                    </td>
                     <td className="py-2 pr-4">
-                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs">{emailTypeLabel(e.entityType)}</span>
+                      {e.companyName ?? (
+                        <span className="text-muted-foreground italic">—</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                        {emailTypeLabel(e.entityType)}
+                      </span>
                     </td>
                     <td className="py-2">{e.subject}</td>
                   </tr>
                 ))}
                 {data.recentEmails.length === 0 && (
-                  <tr><td colSpan={5} className="py-8 text-center text-muted-foreground">No emails sent yet</td></tr>
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                      No emails sent yet
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>
@@ -847,17 +1221,22 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
       {/* Opted-out users */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Opted-out users</CardTitle>
+          <CardTitle className="text-base">Unsubscribed</CardTitle>
         </CardHeader>
         <CardContent>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Resubscribing overrides a person&rsquo;s own choice and is recorded in the
+            audit log. Use it when someone asks to come back.
+          </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left text-muted-foreground">
                   <th className="pb-2 pr-4 font-medium">Name</th>
                   <th className="pb-2 pr-4 font-medium">Email</th>
-                  <th className="pb-2 pr-4 font-medium">Company</th>
-                  <th className="pb-2 font-medium">Opted out</th>
+                  <th className="pb-2 pr-4 font-medium">Unsubscribed from</th>
+                  <th className="pb-2 pr-4 font-medium">When</th>
+                  <th className="pb-2 font-medium" />
                 </tr>
               </thead>
               <tbody>
@@ -865,12 +1244,38 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
                   <tr key={u.id} className="border-b border-border/50 last:border-0">
                     <td className="py-2 pr-4 font-medium">{u.name}</td>
                     <td className="py-2 pr-4 text-muted-foreground">{u.email}</td>
-                    <td className="py-2 pr-4">{u.companyName ?? <span className="text-muted-foreground italic">none</span>}</td>
-                    <td className="py-2 text-muted-foreground">{timeAgo(u.updatedAt)}</td>
+                    <td className="py-2 pr-4">
+                      {u.allOff ? (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                          Everything optional
+                        </span>
+                      ) : (
+                        <span className="flex flex-wrap gap-1">
+                          {u.scopes.map((s) => (
+                            <span
+                              key={s}
+                              className="rounded bg-muted px-1.5 py-0.5 text-xs"
+                            >
+                              {scopeLabel(s)}
+                            </span>
+                          ))}
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {timeAgo(u.updatedAt)}
+                    </td>
+                    <td className="py-2">
+                      <ResubscribeButton userId={u.id} email={u.email} />
+                    </td>
                   </tr>
                 ))}
                 {data.optedOutUsers.length === 0 && (
-                  <tr><td colSpan={4} className="py-8 text-center text-muted-foreground">No users have opted out</td></tr>
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-muted-foreground">
+                      No users have opted out
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </table>

--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -546,7 +546,7 @@ function DigestQueuePanel() {
         toast.warning(`Nothing sent: ${r.skipped}`);
       } else {
         toast.success(
-          `Sent ${r.sent}${r.failed ? `, ${r.failed} failed` : ""}${r.deferred ? `, ${r.deferred} still queued` : ""}`,
+          `Sent ${r.sent}${r.failed ? `, ${r.failed} failed` : ""}${r.alreadySentToday ? `, ${r.alreadySentToday} already had today's` : ""}${r.deferred ? `, ${r.deferred} still queued` : ""}`,
         );
       }
       void utils.platformAdmin.digestQueue.invalidate();

--- a/content/docs/self-hosting/scheduled-jobs.md
+++ b/content/docs/self-hosting/scheduled-jobs.md
@@ -22,6 +22,8 @@ Skip it and none of that happens. Requirements stay in the status they were last
 
 ## Lifecycle emails
 
+Scheduling this one is optional, and nisd2.eu deliberately does not. Re-engagement mail goes to people who have gone quiet, and the cost of getting it wrong is paid by a real person's inbox, so the platform admin carries a send console instead: it shows exactly who is queued, lets you choose how many to send, and sends only when somebody presses the button. If you would rather a human approve every batch, skip the schedule below and use that. If you would rather it run itself, schedule it — the endpoint and the console share the same selection and the same at-most-once guarantee, so neither can double-send.
+
 `/api/cron/lifecycle` sends the one-shot re-engagement emails. Each user receives each email type at most once, ever: the send is recorded in the database before the email goes out, and a unique index makes a second send impossible even if two runs overlap. Without `RESEND_API_KEY` the endpoint reports `skipped` and records nothing, so enabling email later starts with a clean slate. Users with `emailFollowupsDisabled` are never selected, and every one of these emails carries an unsubscribe link that sets exactly that flag.
 
 Who gets the first campaign (the activation nudge): accounts with a verified email, a company, at least one open step on the NIS 2 path, and no sign-in or recorded activity for 3 days or more. Selection runs oldest-dormant first.

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -238,6 +238,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           await Promise.all([
             admins.length > 0
               ? sendMail({
+                  emailType: "internal.new_signup_alert",
                   to: admins,
                   ...newUserSignupEmail({ userEmail: authUser.email, userName: newName, provider: account.provider }),
                 }).catch((err) => console.error("[auth] Failed to send admin signup alert:", err))

--- a/lib/compliance/digest.ts
+++ b/lib/compliance/digest.ts
@@ -4,22 +4,22 @@
  * Used by the cron job to batch pending email notifications into a single
  * digest email instead of individual emails per reminder.
  */
-import { eq, and, lte, inArray, sql, desc } from "drizzle-orm";
-import {
-  notification,
-  companyRequirementStatus,
-  companyAssessment,
-  requirement,
-  requirementCategory,
-  company,
-  user,
-} from "@/schema";
+import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import type { Database } from "@/lib/db";
 import type { DigestItem } from "@/lib/mail";
-import { daysUntilDeadline } from "./deadlines";
 import { getAppUrl } from "@/lib/utils";
-import { getNis2FrameworkId } from "@/server/trpc/helpers/nis2-scope";
 import requirementsEn from "@/messages/requirements/en.json";
+import {
+  company,
+  companyAssessment,
+  companyRequirementStatus,
+  notification,
+  requirement,
+  requirementCategory,
+  user,
+} from "@/schema";
+import { getNis2FrameworkId } from "@/server/trpc/helpers/nis2-scope";
+import { daysUntilDeadline } from "./deadlines";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -92,14 +92,22 @@ export async function compileDailyDigest(
       eq(companyAssessment.companyId, companyId),
       eq(companyAssessment.frameworkId, nis2FrameworkId),
     ),
-    columns: { id: true, compliancePercentage: true, completedRequirements: true, totalRequirements: true },
+    columns: {
+      id: true,
+      compliancePercentage: true,
+      completedRequirements: true,
+      totalRequirements: true,
+    },
   });
 
   if (assessments.length === 0) return null;
 
   // Compute aggregate compliance %
   const totalReq = assessments.reduce((s, a) => s + (a.totalRequirements ?? 0), 0);
-  const completedReq = assessments.reduce((s, a) => s + (a.completedRequirements ?? 0), 0);
+  const completedReq = assessments.reduce(
+    (s, a) => s + (a.completedRequirements ?? 0),
+    0,
+  );
   const pct = totalReq > 0 ? ((completedReq / totalReq) * 100).toFixed(1) : "0";
 
   const assessmentIds = assessments.map((a) => a.id);
@@ -134,10 +142,17 @@ export async function compileDailyDigest(
 
     const item: DigestItem = {
       requirementCode: s.requirement.code,
-      requirementTitle: requirementsEn.requirements[s.requirement.code.replace(/\./g, "_") as keyof typeof requirementsEn.requirements]?.title ?? s.requirement.code,
+      requirementTitle:
+        requirementsEn.requirements[
+          s.requirement.code.replace(
+            /\./g,
+            "_",
+          ) as keyof typeof requirementsEn.requirements
+        ]?.title ?? s.requirement.code,
       deadline: s.nextReviewDate,
       daysRemaining: days,
-      urgency: days < 0 ? "critical" : days <= 7 ? "urgent" : days <= 30 ? "warning" : "info",
+      urgency:
+        days < 0 ? "critical" : days <= 7 ? "urgent" : days <= 30 ? "warning" : "info",
       categoryUrl: `${appUrl}/compliance/${slug}#${s.requirement.code}`,
     };
 
@@ -151,7 +166,11 @@ export async function compileDailyDigest(
   }
 
   // Don't send empty digests
-  if (overdueItems.length === 0 && urgentItems.length === 0 && upcomingItems.length === 0) {
+  if (
+    overdueItems.length === 0 &&
+    urgentItems.length === 0 &&
+    upcomingItems.length === 0
+  ) {
     return null;
   }
 
@@ -210,11 +229,25 @@ export async function compileManagementDigest(
       eq(companyAssessment.companyId, companyId),
       eq(companyAssessment.frameworkId, nis2FrameworkId),
     ),
-    columns: { id: true, compliancePercentage: true, completedRequirements: true, totalRequirements: true },
+    columns: {
+      id: true,
+      compliancePercentage: true,
+      completedRequirements: true,
+      totalRequirements: true,
+    },
   });
 
+  // No NIS 2 assessment means there is nothing to report on. The daily digest
+  // has always guarded this; this one did not, so a company with no NIS 2
+  // scope — a supplier-portal signup, say — could be mailed a management
+  // report announcing it was 0% compliant across 0 of 0 requirements.
+  if (assessments.length === 0) return null;
+
   const totalReq = assessments.reduce((s, a) => s + (a.totalRequirements ?? 0), 0);
-  const completedReq = assessments.reduce((s, a) => s + (a.completedRequirements ?? 0), 0);
+  const completedReq = assessments.reduce(
+    (s, a) => s + (a.completedRequirements ?? 0),
+    0,
+  );
   const pct = totalReq > 0 ? ((completedReq / totalReq) * 100).toFixed(1) : "0";
 
   const assessmentIds = assessments.map((a) => a.id);

--- a/lib/email/unsubscribe.ts
+++ b/lib/email/unsubscribe.ts
@@ -34,6 +34,33 @@ export function unsubscribeUrl(userId: string): string {
   return `${getAppUrl()}/api/email/unsubscribe?u=${encodeURIComponent(userId)}&t=${token}`;
 }
 
+/**
+ * One-click opt-out from ONE kind of message — what the RFC 8058 header and
+ * the footer link point at. Scoping it to the message's own type is the least
+ * surprising behaviour: a person switching off nudges keeps their deadline
+ * reminders. Broader choices live in the preference centre.
+ *
+ * The token still signs only the user id, so links in already-delivered mail
+ * (which carry no scope) keep working and mean "all optional mail off". The
+ * scope is not a capability: the worst a holder of their own valid token can
+ * do by editing it is unsubscribe themselves from something else, which the
+ * same link already permits.
+ */
+export function oneClickUnsubscribeUrl(userId: string, emailTypeId: string): string {
+  const token = unsubscribeToken(userId);
+  return `${getAppUrl()}/api/email/unsubscribe?u=${encodeURIComponent(userId)}&t=${token}&scope=${encodeURIComponent(`type:${emailTypeId}`)}`;
+}
+
+/**
+ * The preference centre, reachable from any optional email without signing
+ * in. Same signed-token credential as the unsubscribe link.
+ */
+export function preferenceCentreUrl(userId: string, locale?: string): string {
+  const token = unsubscribeToken(userId);
+  const lang = locale ? `&lang=${encodeURIComponent(locale)}` : "";
+  return `${getAppUrl()}/email/preferences?u=${encodeURIComponent(userId)}&t=${token}${lang}`;
+}
+
 export function verifyUnsubscribeToken(userId: string, token: string): boolean {
   if (token.length !== TOKEN_LENGTH) return false;
   const expected = Buffer.from(signUserId(userId), "utf8");

--- a/lib/lifecycle/dispatch.ts
+++ b/lib/lifecycle/dispatch.ts
@@ -133,12 +133,14 @@ async function deliverOne(
   if (!claim) return "already_claimed";
 
   const result = await sendMail({
+    emailType: "product.lifecycle_nudge",
+    recipientUserId: email.userId,
+    db,
     to: email.to,
     subject: email.subject,
     html: email.html,
     text: email.text,
     replyTo: mailSupportEmail(),
-    unsubscribeUrl: email.unsubscribeUrl,
     // Keyed on the claim row: sendMail's retry loop re-POSTs on ambiguous
     // network failures, and without this a request Resend accepted (response
     // lost) would deliver a second copy on the retry — the one double-send

--- a/lib/mail/auth-code.ts
+++ b/lib/mail/auth-code.ts
@@ -49,7 +49,12 @@ export async function sendAuthCode({ to, code, locale, kind }: SendAuthCodeOptio
       ? emailVerificationCodeEmail({ code, locale })
       : passwordResetCodeEmail({ code, locale });
 
-  const result = await sendMail({ to, ...content });
+  const result = await sendMail({
+    emailType:
+      kind === "verification" ? "auth.verification_code" : "auth.password_reset_code",
+    to,
+    ...content,
+  });
 
   if (hasNoMailTransport()) {
     const what = kind === "verification" ? "sign-in code" : "password reset code";

--- a/lib/mail/consent-rules.ts
+++ b/lib/mail/consent-rules.ts
@@ -1,0 +1,93 @@
+/**
+ * The consent rules, as pure functions over data.
+ *
+ * Separated from the database and URL work in ./consent so the decision that
+ * governs whether a real person hears from us can be read, reasoned about and
+ * tested on its own — no db, no env, no network. Everything here is total:
+ * same inputs, same answer, every time.
+ */
+import {
+  EMAIL_CATEGORIES,
+  EMAIL_TYPES,
+  type EmailCategory,
+  type EmailTypeId,
+  emailTypeCategory,
+  isUserConsentEmailType,
+} from "./email-types";
+
+export const SCOPE_ALL = "all";
+
+export function categoryScope(category: EmailCategory): string {
+  return `category:${category}`;
+}
+
+export function typeScope(id: EmailTypeId): string {
+  return `type:${id}`;
+}
+
+/**
+ * Validate a scope arriving from a URL against the registry. Returns the
+ * canonical scope string, or null when it names nothing we send — an unknown
+ * scope must not be stored, or the table fills with rows that suppress
+ * nothing and mislead whoever reads it later.
+ *
+ * A missing scope means "all", which is what links in already-delivered mail
+ * carry and what they have always meant.
+ */
+export function parseScope(raw: string | null | undefined): string | null {
+  if (!raw || raw === SCOPE_ALL) return SCOPE_ALL;
+  const [kind, ...rest] = raw.split(":");
+  const value = rest.join(":");
+  if (kind === "category") {
+    return (EMAIL_CATEGORIES as readonly string[]).includes(value)
+      ? categoryScope(value as EmailCategory)
+      : null;
+  }
+  if (kind === "type") {
+    if (!(value in EMAIL_TYPES)) return null;
+    // Offering to switch off mail that is never gated would be a broken
+    // promise: the gate ignores such a row.
+    return isUserConsentEmailType(value as EmailTypeId)
+      ? typeScope(value as EmailTypeId)
+      : null;
+  }
+  return null;
+}
+
+/**
+ * A recipient's stored choices, resolved once and cheap to query repeatedly —
+ * a send loop can load this per recipient and ask about several messages.
+ */
+export interface EmailConsent {
+  allows(id: EmailTypeId): boolean;
+  /** Scope keys this person has switched off, for the preference centre. */
+  optedOutScopes: ReadonlySet<string>;
+  /** True when the coarse legacy switch is on (all optional mail off). */
+  allOptionalDisabled: boolean;
+}
+
+/** Used when the recipient cannot be found: no proof of permission, no send. */
+export const DENY_OPTIONAL: EmailConsent = {
+  allows: (id) => !isUserConsentEmailType(id),
+  optedOutScopes: new Set([SCOPE_ALL]),
+  allOptionalDisabled: true,
+};
+
+export function buildEmailConsent(opts: {
+  followupsDisabled: boolean;
+  scopes: readonly string[];
+}): EmailConsent {
+  const optedOutScopes = new Set(opts.scopes);
+  const allOptionalDisabled = opts.followupsDisabled || optedOutScopes.has(SCOPE_ALL);
+  return {
+    optedOutScopes,
+    allOptionalDisabled,
+    allows(id: EmailTypeId): boolean {
+      // Essential / external / operator mail is not preference-gated.
+      if (!isUserConsentEmailType(id)) return true;
+      if (allOptionalDisabled) return false;
+      if (optedOutScopes.has(categoryScope(emailTypeCategory(id)))) return false;
+      return !optedOutScopes.has(typeScope(id));
+    },
+  };
+}

--- a/lib/mail/consent.test.ts
+++ b/lib/mail/consent.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The consent gate decides whether a real person hears from us. These tests
+ * pin the two directions that matter: an essential message is never
+ * suppressible, and an optional one is suppressed by any of the three
+ * switches that can name it.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  buildEmailConsent,
+  categoryScope,
+  parseScope,
+  SCOPE_ALL,
+  typeScope,
+} from "./consent-rules";
+import {
+  EMAIL_TYPES,
+  type EmailTypeId,
+  isUserConsentEmailType,
+  optionalEmailTypesByCategory,
+} from "./email-types";
+
+const subscribed = buildEmailConsent({ followupsDisabled: false, scopes: [] });
+
+describe("essential mail is never gated", () => {
+  const essentials: EmailTypeId[] = [
+    "auth.verification_code",
+    "auth.password_reset_code",
+    "account.contact_email_changed",
+    "account.invite",
+    "account.member_removed",
+    "auth.welcome",
+  ];
+  for (const id of essentials) {
+    test(id, () => {
+      // Even with every switch thrown, including one that names the type.
+      const consent = buildEmailConsent({
+        followupsDisabled: true,
+        scopes: [SCOPE_ALL, typeScope(id), categoryScope(EMAIL_TYPES[id].category)],
+      });
+      expect(consent.allows(id)).toBe(true);
+    });
+  }
+});
+
+describe("optional mail respects each switch", () => {
+  const id = "product.lifecycle_nudge";
+
+  test("subscribed by default — absence of a row means yes", () => {
+    expect(subscribed.allows(id)).toBe(true);
+  });
+
+  test("the legacy boolean still switches everything optional off", () => {
+    const consent = buildEmailConsent({ followupsDisabled: true, scopes: [] });
+    expect(consent.allows(id)).toBe(false);
+    expect(consent.allOptionalDisabled).toBe(true);
+  });
+
+  test('an "all" row switches everything optional off', () => {
+    const consent = buildEmailConsent({ followupsDisabled: false, scopes: [SCOPE_ALL] });
+    expect(consent.allows(id)).toBe(false);
+  });
+
+  test("a category row switches off its whole category, and nothing else", () => {
+    const consent = buildEmailConsent({
+      followupsDisabled: false,
+      scopes: [categoryScope("product")],
+    });
+    expect(consent.allows("product.lifecycle_nudge")).toBe(false);
+    expect(consent.allows("product.course_followup")).toBe(false);
+    expect(consent.allows("reminders.daily_digest")).toBe(true);
+  });
+
+  test("a type row switches off exactly one message", () => {
+    const consent = buildEmailConsent({
+      followupsDisabled: false,
+      scopes: [typeScope("product.lifecycle_nudge")],
+    });
+    expect(consent.allows("product.lifecycle_nudge")).toBe(false);
+    expect(consent.allows("product.course_followup")).toBe(true);
+  });
+});
+
+describe("parseScope only accepts scopes we actually send", () => {
+  test("missing means all — what links in already-delivered mail carry", () => {
+    expect(parseScope(null)).toBe(SCOPE_ALL);
+    expect(parseScope(undefined)).toBe(SCOPE_ALL);
+    expect(parseScope("all")).toBe(SCOPE_ALL);
+  });
+
+  test("known categories and types round-trip", () => {
+    expect(parseScope("category:reminders")).toBe("category:reminders");
+    expect(parseScope("type:newsletter.issue")).toBe("type:newsletter.issue");
+  });
+
+  test("unknown or ungatable scopes are rejected, not stored", () => {
+    expect(parseScope("category:nonsense")).toBeNull();
+    expect(parseScope("type:does.not.exist")).toBeNull();
+    // Real type, but one nobody can switch off: offering it would be a lie.
+    expect(parseScope("type:auth.verification_code")).toBeNull();
+    expect(parseScope("everything")).toBeNull();
+    expect(parseScope("type:")).toBeNull();
+  });
+});
+
+describe("the registry stays coherent", () => {
+  test("every optional type appears in exactly one preference-centre group", () => {
+    const grouped = optionalEmailTypesByCategory().flatMap((g) => g.types);
+    const optional = (Object.keys(EMAIL_TYPES) as EmailTypeId[]).filter(
+      isUserConsentEmailType,
+    );
+    expect([...grouped].sort()).toEqual([...optional].sort());
+    expect(new Set(grouped).size).toBe(grouped.length);
+  });
+
+  test("every optional type is reachable as a one-click scope", () => {
+    for (const id of (Object.keys(EMAIL_TYPES) as EmailTypeId[]).filter(
+      isUserConsentEmailType,
+    )) {
+      expect(parseScope(`type:${id}`)).toBe(typeScope(id));
+    }
+  });
+
+  test("no type claims a category that the catalogue does not list", () => {
+    for (const id of Object.keys(EMAIL_TYPES) as EmailTypeId[]) {
+      expect(typeof EMAIL_TYPES[id].category).toBe("string");
+      expect(EMAIL_TYPES[id].consent).toBeDefined();
+    }
+  });
+});

--- a/lib/mail/consent.ts
+++ b/lib/mail/consent.ts
@@ -1,0 +1,59 @@
+/**
+ * The consent gate: the one place that answers "may this message go to this
+ * person?".
+ *
+ * It is consulted inside `sendMail`, not at the call sites, so an optional
+ * email cannot be sent by forgetting to ask. The call site's only obligation
+ * is to say WHICH message it is sending and WHO the recipient is, and the
+ * type system makes both mandatory for anything gated (see lib/mail/send.ts).
+ *
+ * Three sources of "no", checked in this order:
+ *   1. the recipient no longer exists            -> fail closed
+ *   2. user.emailFollowupsDisabled               -> all optional mail off
+ *      (the legacy coarse switch the RFC 8058 one-click header flips)
+ *   3. an email_preference row naming "all", the message's category, or the
+ *      message's own type id
+ * Essential, external and operator mail never reaches the gate at all.
+ *
+ * This module is the I/O half; the decision itself lives in ./consent-rules
+ * as pure functions, which is what the tests exercise.
+ */
+import "@/lib/server-guard";
+import { eq } from "drizzle-orm";
+import type { DbOrTx } from "@/lib/db";
+import { emailPreference, user } from "@/schema";
+import { buildEmailConsent, DENY_OPTIONAL, type EmailConsent } from "./consent-rules";
+
+export {
+  buildEmailConsent,
+  categoryScope,
+  type EmailConsent,
+  parseScope,
+  SCOPE_ALL,
+  typeScope,
+} from "./consent-rules";
+
+/**
+ * Load a recipient's consent. An unknown user denies every optional message:
+ * the safe direction when we cannot prove permission.
+ */
+export async function loadEmailConsent(
+  db: DbOrTx,
+  userId: string,
+): Promise<EmailConsent> {
+  const [recipient, rows] = await Promise.all([
+    db.query.user.findFirst({
+      where: eq(user.id, userId),
+      columns: { emailFollowupsDisabled: true },
+    }),
+    db
+      .select({ scope: emailPreference.scope })
+      .from(emailPreference)
+      .where(eq(emailPreference.userId, userId)),
+  ]);
+  if (!recipient) return DENY_OPTIONAL;
+  return buildEmailConsent({
+    followupsDisabled: recipient.emailFollowupsDisabled,
+    scopes: rows.map((r) => r.scope),
+  });
+}

--- a/lib/mail/digest-outbox.ts
+++ b/lib/mail/digest-outbox.ts
@@ -1,0 +1,267 @@
+/**
+ * The digest outbox: what the deadline digests WOULD say right now, and the
+ * one path that sends them.
+ *
+ * Digests used to go out from inside the nightly cron. They no longer do —
+ * nothing at nisd2.eu mails a customer without a person pressing a button,
+ * and a job that quietly emails everybody as a side effect of doing
+ * bookkeeping is the exact shape of thing that rule exists to prevent. The
+ * cron still runs the other six phases (status transitions, deadline
+ * backfill, reminder scheduling, escalation, supplier broadcasts, GDPR
+ * retention); only the sending moved here.
+ *
+ * Nothing is precomputed or stored. A digest is a view of the tenant's
+ * current state, so building it at send time is both simpler and more
+ * correct than queueing a snapshot that can go stale between the operator
+ * reading it and pressing send.
+ *
+ * Unlike the lifecycle campaign there is no once-ever claim: a digest is
+ * meant to recur. What stops a double-send is that a person presses the
+ * button, plus the empty-digest rule below — send twice in a morning and
+ * the second one still has content, so the operator is the guard here.
+ */
+import "@/lib/server-guard";
+import { eq, isNotNull } from "drizzle-orm";
+import { logAudit } from "@/lib/audit";
+import { compileDailyDigest, compileManagementDigest } from "@/lib/compliance/digest";
+import type { Database } from "@/lib/db";
+import { loadEmailConsent } from "@/lib/mail/consent";
+import type { UserConsentEmailTypeId } from "@/lib/mail/email-types";
+import { preferenceFooterFor } from "@/lib/mail/footer";
+import { isSuppressedSendId, mailSuppressionReason, sendMail } from "@/lib/mail/send";
+import { dailyDigestEmail, weeklyManagementDigestEmail } from "@/lib/mail/templates";
+import { company, user } from "@/schema";
+
+export type DigestKind = "daily" | "weekly";
+
+export interface QueuedDigest {
+  kind: DigestKind;
+  userId: string;
+  email: string;
+  companyId: string;
+  companyName: string;
+  subject: string;
+  /** One line the operator can scan: what this person is being told. */
+  summary: string;
+}
+
+// Narrowed to the gated ids on purpose: sendMail only accepts a
+// recipientUserId alongside a user-consent type, so widening this would stop
+// the digests going through the consent gate at all.
+const EMAIL_TYPE: Record<DigestKind, UserConsentEmailTypeId> = {
+  daily: "reminders.daily_digest",
+  weekly: "reminders.weekly_management_digest",
+};
+
+/**
+ * Everyone with a digest worth sending right now.
+ *
+ * Draft companies are excluded (activatedAt IS NULL): they hold seeded
+ * assessment rows but no real work, so a digest would mail every drive-by
+ * signup a blank-named 0% report. Recipients who opted out are excluded here
+ * too — the gate inside sendMail would refuse them anyway, but an operator
+ * reviewing a queue should not be shown people who will not receive it.
+ *
+ * The weekly management digest is offered for management and admins
+ * whenever it has content. It used to be Monday-only because a cron had to
+ * pick a day; a person pressing a button picks the day themselves.
+ */
+export async function buildDigestQueue(db: Database): Promise<QueuedDigest[]> {
+  const companies = await db.query.company.findMany({
+    where: isNotNull(company.activatedAt),
+    columns: { id: true, name: true },
+  });
+
+  const queue: QueuedDigest[] = [];
+  for (const co of companies) {
+    const members = await db.query.user.findMany({
+      where: eq(user.companyId, co.id),
+      columns: { id: true, email: true, isManagement: true, role: true },
+    });
+
+    for (const member of members) {
+      const consent = await loadEmailConsent(db, member.id);
+
+      if (consent.allows(EMAIL_TYPE.daily)) {
+        const digest = await compileDailyDigest(db, member.id, co.id);
+        if (digest) {
+          queue.push({
+            kind: "daily",
+            userId: member.id,
+            email: digest.recipientEmail,
+            companyId: co.id,
+            companyName: co.name,
+            subject: dailyDigestEmail({
+              recipientName: digest.recipientName,
+              companyName: digest.companyName,
+              overdueItems: digest.overdueItems,
+              urgentItems: digest.urgentItems,
+              upcomingItems: digest.upcomingItems,
+              compliancePercentage: digest.compliancePercentage,
+              dashboardUrl: digest.dashboardUrl,
+              unsubscribeUrl: "",
+            }).subject,
+            summary: `${digest.overdueItems.length} overdue, ${digest.urgentItems.length} urgent, ${digest.upcomingItems.length} upcoming`,
+          });
+        }
+      }
+
+      const isManagementOrAdmin = member.isManagement || member.role === "admin";
+      if (isManagementOrAdmin && consent.allows(EMAIL_TYPE.weekly)) {
+        const mgmt = await compileManagementDigest(db, member.id, co.id);
+        if (mgmt) {
+          queue.push({
+            kind: "weekly",
+            userId: member.id,
+            email: mgmt.recipientEmail,
+            companyId: co.id,
+            companyName: co.name,
+            subject: weeklyManagementDigestEmail({
+              recipientName: mgmt.recipientName,
+              companyName: mgmt.companyName,
+              compliancePercentage: mgmt.compliancePercentage,
+              overdueCount: mgmt.overdueCount,
+              urgentCount: mgmt.urgentCount,
+              escalationCount: mgmt.escalationCount,
+              totalRequirements: mgmt.totalRequirements,
+              completedRequirements: mgmt.completedRequirements,
+              dashboardUrl: mgmt.dashboardUrl,
+              unsubscribeUrl: "",
+            }).subject,
+            summary: `${mgmt.compliancePercentage}% compliant, ${mgmt.overdueCount} overdue, ${mgmt.escalationCount} escalations`,
+          });
+        }
+      }
+    }
+  }
+  return queue;
+}
+
+/** Resend's default rate limit is ~2 requests/second. */
+const SEND_INTERVAL_MS = 600;
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface DigestSendResult {
+  skipped: string | null;
+  sent: number;
+  failed: number;
+  optedOut: number;
+  deferred: number;
+}
+
+/**
+ * Send the first `limit` queued digests, in queue order. Recompiles each
+ * digest immediately before sending rather than trusting the queue the
+ * operator looked at, so nobody receives a digest whose numbers moved while
+ * the page was open.
+ */
+export async function sendDigestBatch(
+  db: Database,
+  limit: number,
+  actorUserId: string,
+): Promise<DigestSendResult> {
+  const suppression = mailSuppressionReason();
+  if (suppression) {
+    return {
+      skipped: `email transport unavailable (${suppression})`,
+      sent: 0,
+      failed: 0,
+      optedOut: 0,
+      deferred: 0,
+    };
+  }
+
+  const queue = await buildDigestQueue(db);
+  const batch = queue.slice(0, Math.max(1, limit));
+  const result: DigestSendResult = {
+    skipped: null,
+    sent: 0,
+    failed: 0,
+    optedOut: 0,
+    deferred: queue.length - batch.length,
+  };
+
+  for (const [index, item] of batch.entries()) {
+    const footer = preferenceFooterFor(item.userId, EMAIL_TYPE[item.kind]);
+    const content =
+      item.kind === "daily"
+        ? await compileDailyDigest(db, item.userId, item.companyId).then((d) =>
+            d
+              ? dailyDigestEmail({
+                  recipientName: d.recipientName,
+                  companyName: d.companyName,
+                  overdueItems: d.overdueItems,
+                  urgentItems: d.urgentItems,
+                  upcomingItems: d.upcomingItems,
+                  compliancePercentage: d.compliancePercentage,
+                  dashboardUrl: d.dashboardUrl,
+                  unsubscribeUrl: footer.unsubscribeUrl,
+                })
+              : null,
+          )
+        : await compileManagementDigest(db, item.userId, item.companyId).then((d) =>
+            d
+              ? weeklyManagementDigestEmail({
+                  recipientName: d.recipientName,
+                  companyName: d.companyName,
+                  compliancePercentage: d.compliancePercentage,
+                  overdueCount: d.overdueCount,
+                  urgentCount: d.urgentCount,
+                  escalationCount: d.escalationCount,
+                  totalRequirements: d.totalRequirements,
+                  completedRequirements: d.completedRequirements,
+                  dashboardUrl: d.dashboardUrl,
+                  unsubscribeUrl: footer.unsubscribeUrl,
+                })
+              : null,
+          );
+
+    // Emptied out between queueing and sending: nothing left to say.
+    if (!content) continue;
+
+    const res = await sendMail({
+      emailType: EMAIL_TYPE[item.kind],
+      recipientUserId: item.userId,
+      db,
+      to: item.email,
+      subject: content.subject,
+      html: content.html,
+      text: content.text,
+    });
+
+    if (!res.success) {
+      result.failed++;
+      logAudit({
+        companyId: item.companyId,
+        userId: null,
+        action: "email.digest_failed",
+        entityType: "notification",
+        entityId: null,
+        description: `${item.kind} digest to ${item.email} failed after retries`,
+      });
+    } else if ("skipped" in res) {
+      result.optedOut++;
+    } else if (isSuppressedSendId(res.id)) {
+      // Transport went away mid-batch; stop rather than report phantom sends.
+      result.skipped = "email transport became unavailable during the batch";
+      break;
+    } else {
+      result.sent++;
+    }
+
+    if (index < batch.length - 1) await wait(SEND_INTERVAL_MS);
+  }
+
+  logAudit({
+    companyId: null,
+    userId: actorUserId,
+    action: "email.digest_batch_sent",
+    entityType: "system",
+    entityId: null,
+    description: `Platform admin sent a digest batch (limit ${limit}): ${JSON.stringify(result)}`,
+  });
+  return result;
+}

--- a/lib/mail/digest-outbox.ts
+++ b/lib/mail/digest-outbox.ts
@@ -15,13 +15,16 @@
  * correct than queueing a snapshot that can go stale between the operator
  * reading it and pressing send.
  *
- * Unlike the lifecycle campaign there is no once-ever claim: a digest is
- * meant to recur. What stops a double-send is that a person presses the
- * button, plus the empty-digest rule below — send twice in a morning and
- * the second one still has content, so the operator is the guard here.
+ * Unlike the lifecycle campaign the claim is not once-EVER — a digest is
+ * meant to recur — but there is still a claim: one row per recipient per
+ * digest kind per UTC day, inserted before the send. That is what makes the
+ * queue drain after a batch and what stops a second press, or a second
+ * browser tab, mailing somebody the same digest twice. Without it the panel
+ * kept showing the same people as "waiting" after they had been mailed,
+ * which invites exactly the duplicate send it looks like it is warning about.
  */
 import "@/lib/server-guard";
-import { eq, isNotNull } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull } from "drizzle-orm";
 import { logAudit } from "@/lib/audit";
 import { compileDailyDigest, compileManagementDigest } from "@/lib/compliance/digest";
 import type { Database } from "@/lib/db";
@@ -30,7 +33,7 @@ import type { UserConsentEmailTypeId } from "@/lib/mail/email-types";
 import { preferenceFooterFor } from "@/lib/mail/footer";
 import { isSuppressedSendId, mailSuppressionReason, sendMail } from "@/lib/mail/send";
 import { dailyDigestEmail, weeklyManagementDigestEmail } from "@/lib/mail/templates";
-import { company, user } from "@/schema";
+import { company, notification, user } from "@/schema";
 
 export type DigestKind = "daily" | "weekly";
 
@@ -53,6 +56,50 @@ const EMAIL_TYPE: Record<DigestKind, UserConsentEmailTypeId> = {
   weekly: "reminders.weekly_management_digest",
 };
 
+/** notification.entityType per kind; the partial unique index keys on these. */
+const ENTITY_TYPE: Record<DigestKind, string> = {
+  daily: "daily_digest",
+  weekly: "weekly_management_digest",
+};
+
+/** UTC day, so "already sent today" means the same thing everywhere. */
+function utcDay(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function digestClaimKey(userId: string, kind: DigestKind): string {
+  return `${userId}:${kind}`;
+}
+
+/**
+ * Recipients who already received each digest kind today, as claim keys.
+ * Read once per queue build rather than per member: a send loop over every
+ * member of every company would otherwise issue one query each.
+ */
+async function loadTodaysDigestRecipients(db: Database): Promise<Set<string>> {
+  const startOfDay = new Date(`${utcDay()}T00:00:00.000Z`);
+  const rows = await db
+    .select({
+      recipientId: notification.recipientId,
+      entityType: notification.entityType,
+    })
+    .from(notification)
+    .where(
+      and(
+        inArray(notification.entityType, [ENTITY_TYPE.daily, ENTITY_TYPE.weekly]),
+        gte(notification.createdAt, startOfDay),
+      ),
+    );
+
+  const sent = new Set<string>();
+  for (const row of rows) {
+    if (!row.recipientId) continue;
+    const kind: DigestKind = row.entityType === ENTITY_TYPE.daily ? "daily" : "weekly";
+    sent.add(digestClaimKey(row.recipientId, kind));
+  }
+  return sent;
+}
+
 /**
  * Everyone with a digest worth sending right now.
  *
@@ -68,9 +115,17 @@ const EMAIL_TYPE: Record<DigestKind, UserConsentEmailTypeId> = {
  */
 export async function buildDigestQueue(db: Database): Promise<QueuedDigest[]> {
   const companies = await db.query.company.findMany({
-    where: isNotNull(company.activatedAt),
+    // actsAsNis2Entity as well as activated: a supplier-portal signup is a
+    // real, activated company that is explicitly NOT in NIS 2 scope, and
+    // mailing it a NIS 2 compliance report is both wrong and alarming.
+    where: and(isNotNull(company.activatedAt), eq(company.actsAsNis2Entity, true)),
     columns: { id: true, name: true },
   });
+
+  // Who already got which digest today. This is what drains the queue: a
+  // recipient mailed an hour ago must not still read as "waiting", or the
+  // operator presses send again and mails them a second identical copy.
+  const alreadySentToday = await loadTodaysDigestRecipients(db);
 
   const queue: QueuedDigest[] = [];
   for (const co of companies) {
@@ -82,7 +137,10 @@ export async function buildDigestQueue(db: Database): Promise<QueuedDigest[]> {
     for (const member of members) {
       const consent = await loadEmailConsent(db, member.id);
 
-      if (consent.allows(EMAIL_TYPE.daily)) {
+      if (
+        consent.allows(EMAIL_TYPE.daily) &&
+        !alreadySentToday.has(digestClaimKey(member.id, "daily"))
+      ) {
         const digest = await compileDailyDigest(db, member.id, co.id);
         if (digest) {
           queue.push({
@@ -107,7 +165,11 @@ export async function buildDigestQueue(db: Database): Promise<QueuedDigest[]> {
       }
 
       const isManagementOrAdmin = member.isManagement || member.role === "admin";
-      if (isManagementOrAdmin && consent.allows(EMAIL_TYPE.weekly)) {
+      if (
+        isManagementOrAdmin &&
+        consent.allows(EMAIL_TYPE.weekly) &&
+        !alreadySentToday.has(digestClaimKey(member.id, "weekly"))
+      ) {
         const mgmt = await compileManagementDigest(db, member.id, co.id);
         if (mgmt) {
           queue.push({
@@ -149,6 +211,8 @@ export interface DigestSendResult {
   sent: number;
   failed: number;
   optedOut: number;
+  /** Claimed by an earlier press or another tab; nothing sent, nothing lost. */
+  alreadySentToday: number;
   deferred: number;
 }
 
@@ -158,7 +222,35 @@ export interface DigestSendResult {
  * operator looked at, so nobody receives a digest whose numbers moved while
  * the page was open.
  */
+/** The in-flight batch, or null. Same single-container assumption as the
+ *  lifecycle dispatcher: two presses cannot interleave two send loops. */
+let activeDigestRun: Promise<DigestSendResult> | null = null;
+
 export async function sendDigestBatch(
+  db: Database,
+  limit: number,
+  actorUserId: string,
+): Promise<DigestSendResult> {
+  if (activeDigestRun) {
+    return {
+      skipped: "a digest batch is already in progress",
+      sent: 0,
+      failed: 0,
+      optedOut: 0,
+      alreadySentToday: 0,
+      deferred: 0,
+    };
+  }
+  const run = executeDigestBatch(db, limit, actorUserId);
+  activeDigestRun = run;
+  try {
+    return await run;
+  } finally {
+    activeDigestRun = null;
+  }
+}
+
+async function executeDigestBatch(
   db: Database,
   limit: number,
   actorUserId: string,
@@ -170,6 +262,7 @@ export async function sendDigestBatch(
       sent: 0,
       failed: 0,
       optedOut: 0,
+      alreadySentToday: 0,
       deferred: 0,
     };
   }
@@ -181,6 +274,7 @@ export async function sendDigestBatch(
     sent: 0,
     failed: 0,
     optedOut: 0,
+    alreadySentToday: 0,
     deferred: queue.length - batch.length,
   };
 
@@ -221,6 +315,34 @@ export async function sendDigestBatch(
 
     // Emptied out between queueing and sending: nothing left to say.
     if (!content) continue;
+
+    // Claim before sending, exactly as the lifecycle dispatcher does. The
+    // partial unique index arbitrates, so a second press or a second tab
+    // finds the row already there and skips rather than sending a duplicate.
+    const now = new Date();
+    const claimed = await db
+      .insert(notification)
+      .values({
+        companyId: item.companyId,
+        recipientId: item.userId,
+        entityType: ENTITY_TYPE[item.kind],
+        entityId: item.userId,
+        triggerField: utcDay(now),
+        subject: content.subject,
+        channel: "email" as const,
+        status: "sent" as const,
+        scheduledFor: now,
+        sentAt: now,
+        urgency: "info" as const,
+        escalationLevel: 0,
+      })
+      .onConflictDoNothing()
+      .returning({ id: notification.id });
+    const claim = claimed[0];
+    if (!claim) {
+      result.alreadySentToday++;
+      continue;
+    }
 
     const res = await sendMail({
       emailType: EMAIL_TYPE[item.kind],

--- a/lib/mail/email-type-labels.ts
+++ b/lib/mail/email-type-labels.ts
@@ -1,0 +1,236 @@
+/**
+ * Human names for the email catalogue, for the preference centre and the
+ * in-app settings page. Kept beside the registry rather than in the next-intl
+ * message files because the preference centre is reachable without a session
+ * (straight from an email link, outside the [locale] segment) and so has no
+ * request locale to read — the language rides in the URL instead.
+ *
+ * de / en / nl only, matching the languages our email copy exists in.
+ */
+import type { EmailCategory, UserConsentEmailTypeId } from "./email-types";
+
+export type PreferenceLocale = "de" | "en" | "nl";
+
+export const PREFERENCE_LOCALES: readonly PreferenceLocale[] = ["de", "en", "nl"];
+
+export function parsePreferenceLocale(raw: string | null | undefined): PreferenceLocale {
+  return raw === "en" || raw === "nl" ? raw : "de";
+}
+
+interface Label {
+  title: string;
+  description: string;
+}
+
+export const CATEGORY_LABELS: Record<EmailCategory, Record<PreferenceLocale, Label>> = {
+  security: {
+    de: {
+      title: "Sicherheit und Anmeldung",
+      description:
+        "Anmeldecodes, Passwort zurücksetzen, Hinweise zu Änderungen an Ihrem Konto. Diese senden wir immer.",
+    },
+    en: {
+      title: "Security and sign-in",
+      description:
+        "Sign-in codes, password resets, notices about changes to your account. These are always sent.",
+    },
+    nl: {
+      title: "Beveiliging en aanmelden",
+      description:
+        "Aanmeldcodes, wachtwoordherstel, meldingen over wijzigingen in uw account. Deze sturen we altijd.",
+    },
+  },
+  account: {
+    de: {
+      title: "Konto",
+      description:
+        "Einladungen in ein Unternehmen und Änderungen an Ihrer Mitgliedschaft. Diese senden wir immer.",
+    },
+    en: {
+      title: "Account",
+      description:
+        "Invitations to a company and changes to your membership. These are always sent.",
+    },
+    nl: {
+      title: "Account",
+      description:
+        "Uitnodigingen voor een bedrijf en wijzigingen in uw lidmaatschap. Deze sturen we altijd.",
+    },
+  },
+  work: {
+    de: {
+      title: "Zuweisungen und Freigaben",
+      description:
+        "Wenn Ihnen jemand einen Bereich zuweist oder eine Freigabe entscheidet.",
+    },
+    en: {
+      title: "Assignments and reviews",
+      description: "When someone assigns you an area or decides on a review.",
+    },
+    nl: {
+      title: "Toewijzingen en beoordelingen",
+      description: "Wanneer iemand u een gebied toewijst of een beoordeling afrondt.",
+    },
+  },
+  reminders: {
+    de: {
+      title: "Erinnerungen an Fristen",
+      description:
+        "Die tägliche Übersicht offener Punkte und der Wochenbericht für die Leitung.",
+    },
+    en: {
+      title: "Deadline reminders",
+      description:
+        "The daily summary of open items and the weekly report for management.",
+    },
+    nl: {
+      title: "Herinneringen aan deadlines",
+      description:
+        "Het dagelijkse overzicht van openstaande punten en het weekrapport voor de leiding.",
+    },
+  },
+  product: {
+    de: {
+      title: "Hinweise zur Nutzung",
+      description:
+        "Gelegentliche Hinweise, wenn ein Kurs oder Ihr Umsetzungspfad liegen bleibt.",
+    },
+    en: {
+      title: "Product nudges",
+      description:
+        "Occasional pointers when a course or your implementation path stalls.",
+    },
+    nl: {
+      title: "Gebruikstips",
+      description:
+        "Af en toe een tip wanneer een cursus of uw implementatiepad stilligt.",
+    },
+  },
+  newsletter: {
+    de: {
+      title: "Newsletter",
+      description: "Was sich bei NIS 2 und in der Plattform getan hat.",
+    },
+    en: {
+      title: "Newsletter",
+      description: "What has changed in NIS 2 and in the platform.",
+    },
+    nl: {
+      title: "Nieuwsbrief",
+      description: "Wat er is veranderd in NIS 2 en in het platform.",
+    },
+  },
+  // Not shown in the centre: no account holder can switch these off there.
+  supplier: {
+    de: { title: "Lieferkette", description: "" },
+    en: { title: "Supply chain", description: "" },
+    nl: { title: "Toeleveringsketen", description: "" },
+  },
+  internal: {
+    de: { title: "Intern", description: "" },
+    en: { title: "Internal", description: "" },
+    nl: { title: "Intern", description: "" },
+  },
+};
+
+export const TYPE_LABELS: Record<
+  UserConsentEmailTypeId,
+  Record<PreferenceLocale, string>
+> = {
+  "work.category_assigned": {
+    de: "Ein Bereich wurde mir zugewiesen",
+    en: "An area was assigned to me",
+    nl: "Een gebied is aan mij toegewezen",
+  },
+  "work.category_unassigned": {
+    de: "Eine Zuweisung wurde aufgehoben",
+    en: "An assignment was removed",
+    nl: "Een toewijzing is ingetrokken",
+  },
+  "work.review_decision": {
+    de: "Entscheidung über eine Freigabe",
+    en: "Decision on a review",
+    nl: "Besluit over een beoordeling",
+  },
+  "reminders.daily_digest": {
+    de: "Tägliche Übersicht offener Punkte",
+    en: "Daily summary of open items",
+    nl: "Dagelijks overzicht van openstaande punten",
+  },
+  "reminders.weekly_management_digest": {
+    de: "Wochenbericht für die Leitung",
+    en: "Weekly report for management",
+    nl: "Weekrapport voor de leiding",
+  },
+  "product.course_followup": {
+    de: "Nachfrage zu einem begonnenen Kurs",
+    en: "Follow-up on a course you started",
+    nl: "Navraag over een gestarte cursus",
+  },
+  "product.lifecycle_nudge": {
+    de: "Hinweis auf den nächsten Schritt im Umsetzungspfad",
+    en: "Pointer to your next step on the implementation path",
+    nl: "Tip over uw volgende stap op het implementatiepad",
+  },
+  "newsletter.issue": {
+    de: "Newsletter-Ausgaben",
+    en: "Newsletter issues",
+    nl: "Nieuwsbriefedities",
+  },
+};
+
+export const PAGE_COPY: Record<
+  PreferenceLocale,
+  {
+    title: string;
+    intro: string;
+    allOffTitle: string;
+    allOffDescription: string;
+    alwaysSent: string;
+    saved: string;
+    failed: string;
+    invalid: string;
+    invalidHelp: string;
+  }
+> = {
+  de: {
+    title: "E-Mail-Einstellungen",
+    intro:
+      "Wählen Sie, welche E-Mails Sie von nisd2.eu erhalten. Änderungen gelten sofort.",
+    allOffTitle: "Alle optionalen E-Mails abbestellen",
+    allOffDescription:
+      "Sie erhalten dann nur noch das Nötigste: Anmeldecodes, Sicherheitshinweise und Kontoänderungen.",
+    alwaysSent: "Wird immer gesendet",
+    saved: "Gespeichert",
+    failed: "Konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    invalid: "Dieser Link ist nicht mehr gültig",
+    invalidHelp:
+      "Der Link wurde vermutlich beim Kopieren abgeschnitten. Schreiben Sie uns, dann stellen wir es ein.",
+  },
+  en: {
+    title: "Email settings",
+    intro: "Choose which emails you get from nisd2.eu. Changes take effect immediately.",
+    allOffTitle: "Unsubscribe from all optional emails",
+    allOffDescription:
+      "You will only keep the essentials: sign-in codes, security notices and account changes.",
+    alwaysSent: "Always sent",
+    saved: "Saved",
+    failed: "Could not save. Please try again.",
+    invalid: "This link is no longer valid",
+    invalidHelp:
+      "The link was probably cut off when it was copied. Write to us and we will set it for you.",
+  },
+  nl: {
+    title: "E-mailinstellingen",
+    intro: "Kies welke e-mails u van nisd2.eu ontvangt. Wijzigingen gaan meteen in.",
+    allOffTitle: "Afmelden voor alle optionele e-mails",
+    allOffDescription:
+      "U houdt alleen het noodzakelijke: aanmeldcodes, beveiligingsmeldingen en accountwijzigingen.",
+    alwaysSent: "Wordt altijd verzonden",
+    saved: "Opgeslagen",
+    failed: "Opslaan mislukt. Probeer het opnieuw.",
+    invalid: "Deze link is niet meer geldig",
+    invalidHelp:
+      "De link is waarschijnlijk afgekapt bij het kopiëren. Schrijf ons, dan stellen wij het in.",
+  },
+};

--- a/lib/mail/email-type-labels.ts
+++ b/lib/mail/email-type-labels.ts
@@ -184,8 +184,14 @@ export const PAGE_COPY: Record<
   {
     title: string;
     intro: string;
-    allOffTitle: string;
-    allOffDescription: string;
+    /**
+     * Phrased as what ticking the box DOES, because every switch on the page
+     * means "ticked = you receive it". A label that said "unsubscribe from
+     * everything" on a box that means "subscribed" is how people leave when
+     * they meant to stay, or the reverse.
+     */
+    allOnTitle: string;
+    allOnDescription: string;
     alwaysSent: string;
     saved: string;
     failed: string;
@@ -197,9 +203,9 @@ export const PAGE_COPY: Record<
     title: "E-Mail-Einstellungen",
     intro:
       "Wählen Sie, welche E-Mails Sie von nisd2.eu erhalten. Änderungen gelten sofort.",
-    allOffTitle: "Alle optionalen E-Mails abbestellen",
-    allOffDescription:
-      "Sie erhalten dann nur noch das Nötigste: Anmeldecodes, Sicherheitshinweise und Kontoänderungen.",
+    allOnTitle: "Optionale E-Mails erhalten",
+    allOnDescription:
+      "Abwählen heißt: nur noch das Nötigste, also Anmeldecodes, Sicherheitshinweise und Kontoänderungen.",
     alwaysSent: "Wird immer gesendet",
     saved: "Gespeichert",
     failed: "Konnte nicht gespeichert werden. Bitte erneut versuchen.",
@@ -210,9 +216,9 @@ export const PAGE_COPY: Record<
   en: {
     title: "Email settings",
     intro: "Choose which emails you get from nisd2.eu. Changes take effect immediately.",
-    allOffTitle: "Unsubscribe from all optional emails",
-    allOffDescription:
-      "You will only keep the essentials: sign-in codes, security notices and account changes.",
+    allOnTitle: "Receive optional emails",
+    allOnDescription:
+      "Unticking this keeps only the essentials: sign-in codes, security notices and account changes.",
     alwaysSent: "Always sent",
     saved: "Saved",
     failed: "Could not save. Please try again.",
@@ -223,9 +229,9 @@ export const PAGE_COPY: Record<
   nl: {
     title: "E-mailinstellingen",
     intro: "Kies welke e-mails u van nisd2.eu ontvangt. Wijzigingen gaan meteen in.",
-    allOffTitle: "Afmelden voor alle optionele e-mails",
-    allOffDescription:
-      "U houdt alleen het noodzakelijke: aanmeldcodes, beveiligingsmeldingen en accountwijzigingen.",
+    allOnTitle: "Optionele e-mails ontvangen",
+    allOnDescription:
+      "Uitvinken betekent: alleen nog het noodzakelijke, dus aanmeldcodes, beveiligingsmeldingen en accountwijzigingen.",
     alwaysSent: "Wordt altijd verzonden",
     saved: "Opgeslagen",
     failed: "Opslaan mislukt. Probeer het opnieuw.",

--- a/lib/mail/email-types.ts
+++ b/lib/mail/email-types.ts
@@ -1,0 +1,129 @@
+/**
+ * The catalogue of every email this product sends.
+ *
+ * One entry per distinct message. The entry is the message's identity: it
+ * names the message in preference settings, in the send log, and in the
+ * consent check that runs before delivery. Nothing may be sent that is not
+ * in here — `sendMail` takes an id from this table, so adding a new email
+ * means adding a row here first, and that row is where someone decides
+ * whether a recipient is allowed to switch the message off.
+ *
+ * Consent modes
+ * -------------
+ * "essential"  Sent regardless of preferences. Reserved for messages a
+ *              person cannot reasonably be asked to opt out of: proof of
+ *              identity (sign-in codes), security notices about their own
+ *              account, and the confirmation of an action they just took.
+ *              Under GDPR/UWG these ride on contract performance, not
+ *              consent, which is exactly why the list is short and closed.
+ * "user"       Optional mail to someone who has an account. Requires a
+ *              recipientUserId at the call site so the gate can look their
+ *              preferences up. Every one of these carries an unsubscribe
+ *              footer and RFC 8058 headers.
+ * "external"   Optional mail to an address with no account (supplier-portal
+ *              customers). Consent lives with that subsystem's own token
+ *              (supplier.unsubscribedAt); the caller asserts it has checked.
+ * "operator"   Mail to the platform operators themselves (PLATFORM_ADMIN_
+ *              EMAILS). Not subject to recipient preferences.
+ *
+ * Categories group types in the preference centre so a person can switch off
+ * "reminders" without hunting through individual messages. Both granularities
+ * are honoured: an opt-out may name a category or a single type.
+ */
+
+export const EMAIL_CATEGORIES = [
+  "security",
+  "account",
+  "work",
+  "reminders",
+  "product",
+  "newsletter",
+  "supplier",
+  "internal",
+] as const;
+
+export type EmailCategory = (typeof EMAIL_CATEGORIES)[number];
+
+export type ConsentMode = "essential" | "user" | "external" | "operator";
+
+interface EmailTypeDefinition {
+  category: EmailCategory;
+  consent: ConsentMode;
+}
+
+/**
+ * Ids are permanent: they are written into opt-out rows, so renaming one
+ * silently resubscribes everyone who had switched it off. Retire an email by
+ * deleting its entry (the opt-out rows become inert), never by reusing an id
+ * for a different message.
+ */
+export const EMAIL_TYPES = {
+  // --- Essential: identity, security, and account state ---------------------
+  "auth.verification_code": { category: "security", consent: "essential" },
+  "auth.password_reset_code": { category: "security", consent: "essential" },
+  "auth.welcome": { category: "account", consent: "essential" },
+  "account.contact_email_changed": { category: "security", consent: "essential" },
+  "account.invite": { category: "account", consent: "essential" },
+  "account.member_removed": { category: "account", consent: "essential" },
+
+  // --- Optional, to account holders ----------------------------------------
+  "work.category_assigned": { category: "work", consent: "user" },
+  "work.category_unassigned": { category: "work", consent: "user" },
+  "work.review_decision": { category: "work", consent: "user" },
+  "reminders.daily_digest": { category: "reminders", consent: "user" },
+  "reminders.weekly_management_digest": { category: "reminders", consent: "user" },
+  "product.course_followup": { category: "product", consent: "user" },
+  "product.lifecycle_nudge": { category: "product", consent: "user" },
+  "newsletter.issue": { category: "newsletter", consent: "user" },
+
+  // --- Optional, to addresses with no account ------------------------------
+  "supplier.invite": { category: "supplier", consent: "external" },
+  "supplier.added_you": { category: "supplier", consent: "external" },
+  "supplier.incident_broadcast": { category: "supplier", consent: "external" },
+
+  // --- To the platform operators -------------------------------------------
+  "internal.new_signup_alert": { category: "internal", consent: "operator" },
+  "internal.test_send": { category: "internal", consent: "operator" },
+} as const satisfies Record<string, EmailTypeDefinition>;
+
+export type EmailTypeId = keyof typeof EMAIL_TYPES;
+
+/** Ids whose delivery depends on the recipient's stored preferences. */
+export type UserConsentEmailTypeId = {
+  [K in EmailTypeId]: (typeof EMAIL_TYPES)[K]["consent"] extends "user" ? K : never;
+}[EmailTypeId];
+
+/** Ids that bypass the preference gate, for one of the three reasons above. */
+export type UngatedEmailTypeId = Exclude<EmailTypeId, UserConsentEmailTypeId>;
+
+export function emailTypeCategory(id: EmailTypeId): EmailCategory {
+  return EMAIL_TYPES[id].category;
+}
+
+export function emailTypeConsent(id: EmailTypeId): ConsentMode {
+  return EMAIL_TYPES[id].consent;
+}
+
+export function isUserConsentEmailType(id: EmailTypeId): id is UserConsentEmailTypeId {
+  return EMAIL_TYPES[id].consent === "user";
+}
+
+/** Every optional type, grouped by category — the preference centre's model. */
+export function optionalEmailTypesByCategory(): Array<{
+  category: EmailCategory;
+  types: UserConsentEmailTypeId[];
+}> {
+  const grouped = new Map<EmailCategory, UserConsentEmailTypeId[]>();
+  for (const id of Object.keys(EMAIL_TYPES) as EmailTypeId[]) {
+    if (!isUserConsentEmailType(id)) continue;
+    const category = emailTypeCategory(id);
+    const list = grouped.get(category) ?? [];
+    list.push(id);
+    grouped.set(category, list);
+  }
+  // Registry order, so the centre lists categories the way this file reads.
+  return EMAIL_CATEGORIES.filter((c) => grouped.has(c)).map((category) => ({
+    category,
+    types: grouped.get(category) ?? [],
+  }));
+}

--- a/lib/mail/footer.ts
+++ b/lib/mail/footer.ts
@@ -1,0 +1,28 @@
+/**
+ * Builds the two footer links a recipient sees on any optional email: one to
+ * switch off this kind of message, one to the preference centre.
+ *
+ * Kept apart from the consent rules so those stay free of URL and env
+ * concerns, and apart from the layout so the layout stays a pure renderer.
+ */
+import "@/lib/server-guard";
+import { oneClickUnsubscribeUrl, preferenceCentreUrl } from "@/lib/email/unsubscribe";
+import type { EmailTypeId } from "./email-types";
+import type { PreferenceFooter } from "./layout";
+
+/**
+ * The footer for one recipient and one message. Call sites pass the result
+ * straight into a template's `footer`, so the visible opt-out and the RFC
+ * 8058 header that `sendMail` derives always name the same scope.
+ */
+export function preferenceFooterFor(
+  userId: string,
+  emailType: EmailTypeId,
+  locale?: "de" | "en" | "nl",
+): PreferenceFooter {
+  return {
+    unsubscribeUrl: oneClickUnsubscribeUrl(userId, emailType),
+    preferencesUrl: preferenceCentreUrl(userId, locale),
+    locale,
+  };
+}

--- a/lib/mail/layout.ts
+++ b/lib/mail/layout.ts
@@ -84,11 +84,72 @@ function brandFooter(): string {
 }
 
 /**
+ * The consent footer every optional email carries: one link to switch off
+ * this kind of message, one to the preference centre for everything else.
+ * Rendered by the layout rather than hand-written per template, so the two
+ * links cannot drift apart or go missing from a new email.
+ *
+ * Essential mail (sign-in codes, security notices) passes no footer: there
+ * is nothing to opt out of, and offering it would be a lie.
+ */
+export interface PreferenceFooter {
+  unsubscribeUrl: string;
+  preferencesUrl: string;
+  /** Copy language; falls back to German, the platform default. */
+  locale?: "de" | "en" | "nl";
+}
+
+const FOOTER_COPY: Record<
+  "de" | "en" | "nl",
+  { unsubscribe: string; manage: string; separator: string }
+> = {
+  de: {
+    unsubscribe: "Diese E-Mails abbestellen",
+    manage: "E-Mail-Einstellungen",
+    separator: "oder",
+  },
+  en: {
+    unsubscribe: "Unsubscribe from these emails",
+    manage: "Email settings",
+    separator: "or",
+  },
+  nl: {
+    unsubscribe: "Afmelden voor deze e-mails",
+    manage: "E-mailinstellingen",
+    separator: "of",
+  },
+};
+
+export function preferenceFooterHtml(footer: PreferenceFooter): string {
+  const copy = FOOTER_COPY[footer.locale ?? "de"];
+  return `
+        <p style="color: ${BRAND.mutedForeground}; font-size: 12px; margin: 32px 0 0; line-height: 1.5; border-top: 1px solid ${BRAND.border}; padding-top: 16px;">
+          <a href="${footer.unsubscribeUrl}" style="color: ${BRAND.mutedForeground};">${copy.unsubscribe}</a>
+          &nbsp;${copy.separator}&nbsp;
+          <a href="${footer.preferencesUrl}" style="color: ${BRAND.mutedForeground};">${copy.manage}</a>
+        </p>`;
+}
+
+/** Plain-text twin of the footer, for the text/plain alternative. */
+export function preferenceFooterText(footer: PreferenceFooter): string {
+  const copy = FOOTER_COPY[footer.locale ?? "de"];
+  return [`${copy.unsubscribe}: ${footer.unsubscribeUrl}`, `${copy.manage}: ${footer.preferencesUrl}`].join(
+    "\n",
+  );
+}
+
+/**
  * Wrap an inner HTML body in the shared brand layout (header + footer +
  * card container). Inner content is rendered inside a 24px-padded white
- * panel below the header.
+ * panel below the header. Pass `footer` for any message the recipient is
+ * allowed to switch off; omit it for essential mail.
  */
-export function emailLayout(innerHtml: string): string {
+export function emailLayout(innerHtml: string, footer?: PreferenceFooter): string {
+  const body = footer ? `${innerHtml}\n${preferenceFooterHtml(footer)}` : innerHtml;
+  return renderLayout(body);
+}
+
+function renderLayout(innerHtml: string): string {
   return `
     <div style="background: ${BRAND.pageBackground}; padding: 24px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
       <div style="max-width: 560px; margin: 0 auto; background: ${BRAND.background}; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">

--- a/lib/mail/send.ts
+++ b/lib/mail/send.ts
@@ -5,9 +5,13 @@ import { resend, FROM_EMAIL } from "./resend";
 import { env } from "@/lib/env";
 import { WelcomeEmail } from "./templates/WelcomeEmail";
 import { getAppUrl } from "@/lib/utils";
+import { db } from "@/lib/db";
+import type { DbOrTx } from "@/lib/db";
+import { loadEmailConsent } from "./consent";
+import type { EmailTypeId, UngatedEmailTypeId, UserConsentEmailTypeId } from "./email-types";
+import { oneClickUnsubscribeUrl } from "@/lib/email/unsubscribe";
 
-export interface SendMailOptions {
-  to: string | string[];
+interface BaseMailOptions {
   subject: string;
   html: string;
   text?: string;
@@ -19,12 +23,6 @@ export interface SendMailOptions {
    */
   fromEmail?: string;
   /**
-   * If set, adds RFC 8058 one-click List-Unsubscribe headers. The URL is sent
-   * via both `List-Unsubscribe` and `List-Unsubscribe-Post`, letting Gmail /
-   * Apple Mail render a native "Unsubscribe" link in the message header.
-   */
-  unsubscribeUrl?: string;
-  /**
    * Resend Idempotency-Key. The retry loop below re-POSTs on ambiguous
    * network failures, so a request that Resend accepted but whose response
    * was lost would otherwise be delivered AGAIN on the retry. Callers with
@@ -33,6 +31,39 @@ export interface SendMailOptions {
    */
   idempotencyKey?: string;
 }
+
+/**
+ * Every send names the message it is (lib/mail/email-types.ts). For messages
+ * a recipient is allowed to switch off, the id alone is not enough — the
+ * caller must also say WHO the recipient is, because the consent gate below
+ * needs an identity to look up. That obligation is carried by the type, not
+ * by a convention someone can forget: there is no way to spell a call that
+ * sends `product.lifecycle_nudge` without a recipientUserId, and no way to
+ * send one to an unbounded list of addresses.
+ *
+ * The unsubscribe URL and its RFC 8058 headers are derived here rather than
+ * passed in, so an optional message cannot go out without a working one-click
+ * opt-out. Ungated messages (sign-in codes, security notices, supplier-portal
+ * mail with its own token, operator alerts) carry no such header.
+ */
+export type SendMailOptions =
+  | (BaseMailOptions & {
+      emailType: UserConsentEmailTypeId;
+      /** Single recipient: consent is per person, so a bulk `to` is not expressible. */
+      to: string;
+      recipientUserId: string;
+      /** Overrides the transaction the gate reads (defaults to the app db). */
+      db?: DbOrTx;
+    })
+  | (BaseMailOptions & {
+      emailType: UngatedEmailTypeId;
+      to: string | string[];
+      recipientUserId?: undefined;
+      db?: undefined;
+    });
+
+/** Reasons a send did not happen that are not errors. */
+export type SendSkippedReason = "opted-out";
 
 const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1000;
@@ -114,11 +145,25 @@ export async function sendMail(opts: SendMailOptions) {
     return { success: true, id: "no-api-key" } as const;
   }
 
+  // The consent gate. Reached only by messages the recipient may switch off,
+  // and only after the transport checks above, so a suppressed environment
+  // never spends a database query on it.
+  let unsubscribeUrl: string | undefined;
+  if (opts.recipientUserId !== undefined) {
+    const consent = await loadEmailConsent(opts.db ?? db, opts.recipientUserId);
+    if (!consent.allows(opts.emailType)) {
+      return { success: true, skipped: "opted-out" as SendSkippedReason } as const;
+    }
+    // Derived, never passed in: an optional message always leaves with a
+    // working one-click opt-out for its own kind.
+    unsubscribeUrl = oneClickUnsubscribeUrl(opts.recipientUserId, opts.emailType);
+  }
+
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      const headers = opts.unsubscribeUrl
+      const headers = unsubscribeUrl
         ? {
-            "List-Unsubscribe": `<${opts.unsubscribeUrl}>`,
+            "List-Unsubscribe": `<${unsubscribeUrl}>`,
             "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
           }
         : undefined;
@@ -169,6 +214,7 @@ export async function sendWelcomeEmail(opts: { name: string; email: string }) {
     React.createElement(WelcomeEmail, { name: opts.name, dashboardUrl }),
   );
   return sendMail({
+    emailType: "auth.welcome",
     to: opts.email,
     subject: "Welcome to NISD2",
     html,

--- a/lib/mail/templates.ts
+++ b/lib/mail/templates.ts
@@ -14,6 +14,8 @@ import {
   type EmailContent,
   emailLayout,
   escapeHtml,
+  type PreferenceFooter,
+  preferenceFooterText,
   SEVERITY,
   safeHeader,
 } from "./layout";
@@ -115,6 +117,7 @@ export function categoryAssignedEmail(opts: {
   companyName: string;
   assignerName: string;
   categoryUrl: string;
+  footer?: PreferenceFooter;
 }): EmailContent {
   const { assigneeName, categoryName, categoryCode, companyName, assignerName, categoryUrl } = opts;
   const safeAssignee = escapeHtml(assigneeName);
@@ -136,13 +139,14 @@ export function categoryAssignedEmail(opts: {
         <a href="${categoryUrl}" style="display: inline-block; background: ${BRAND.primary}; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
           Go to ${safeCatCode}
         </a>
-    `),
+    `, opts.footer),
     text: [
       `New Assignment`,
       ``,
       `Hi ${assigneeName}, ${assignerName} has assigned you to ${categoryName} (${categoryCode}) in ${companyName}.`,
       ``,
       `Go to category: ${categoryUrl}`,
+      ...(opts.footer ? ["", preferenceFooterText(opts.footer)] : []),
     ].join("\n"),
   };
 }
@@ -156,6 +160,7 @@ export function categoryUnassignedEmail(opts: {
   categoryName: string;
   categoryCode: string;
   companyName: string;
+  footer?: PreferenceFooter;
 }): EmailContent {
   const { assigneeName, categoryName, categoryCode, companyName } = opts;
   const safeAssignee = escapeHtml(assigneeName);
@@ -173,13 +178,14 @@ export function categoryUnassignedEmail(opts: {
         <p style="color: ${BRAND.foreground}; line-height: 1.6; margin: 0;">
           If you believe this was a mistake, please contact your team administrator.
         </p>
-    `),
+    `, opts.footer),
     text: [
       `Assignment Removed`,
       ``,
       `Hi ${assigneeName}, you have been unassigned from ${categoryName} (${categoryCode}) in ${companyName}.`,
       ``,
       `If you believe this was a mistake, please contact your team administrator.`,
+      ...(opts.footer ? ["", preferenceFooterText(opts.footer)] : []),
     ].join("\n"),
   };
 }
@@ -194,6 +200,7 @@ export function reviewDecisionEmail(opts: {
   requirementTitle: string;
   decision: "approved" | "rejected";
   feedback?: string | null;
+  footer?: PreferenceFooter;
 }): EmailContent {
   const { submitterName, requirementCode, requirementTitle, decision, feedback } = opts;
   const label = decision === "approved" ? "Approved" : "Rejected";
@@ -211,12 +218,13 @@ export function reviewDecisionEmail(opts: {
           Hi ${safeName}, your submission for <strong>${safeCode}</strong> (${safeTitle}) has been <span style="color: ${color}; font-weight: 600;">${decision}</span>.
         </p>
         ${safeFeedback ? `<p style="color: ${BRAND.foreground}; line-height: 1.6; margin: 16px 0 0; padding: 12px; background: ${BRAND.muted}; border-radius: 6px;"><strong>Feedback:</strong> ${safeFeedback}</p>` : ""}
-    `),
+    `, opts.footer),
     text: [
       `Submission ${label}`,
       ``,
       `Hi ${submitterName}, your submission for ${requirementCode} (${requirementTitle}) has been ${decision}.`,
       feedback ? `\nFeedback: ${feedback}` : "",
+      ...(opts.footer ? ["", preferenceFooterText(opts.footer)] : []),
     ].join("\n"),
   };
 }

--- a/packages/isms-schema/drizzle/0011_email_preferences.sql
+++ b/packages/isms-schema/drizzle/0011_email_preferences.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "email_preference" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"scope" varchar(100) NOT NULL,
+	"source" varchar(40) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "email_preference" ADD CONSTRAINT "email_preference_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_email_preference_user" ON "email_preference" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_email_preference_user_scope" ON "email_preference" USING btree ("user_id","scope");

--- a/packages/isms-schema/drizzle/0012_digest_once_per_day.sql
+++ b/packages/isms-schema/drizzle/0012_digest_once_per_day.sql
@@ -1,0 +1,7 @@
+-- migration-safety:allow: notification is small (reminder bookkeeping) and the
+-- index is partial, so a plain CREATE UNIQUE INDEX holds its write lock for
+-- milliseconds; CONCURRENTLY would also forbid running inside the migration
+-- transaction for no gain at this size. Duplicates cannot reject it either:
+-- the entity_type values 'daily_digest' and 'weekly_management_digest' are
+-- introduced by this release, so the predicate matches zero existing rows.
+CREATE UNIQUE INDEX "uq_notification_digest_once_per_day" ON "notification" USING btree ("recipient_id","entity_type","trigger_field") WHERE "notification"."entity_type" IN ('daily_digest', 'weekly_management_digest');

--- a/packages/isms-schema/drizzle/meta/0011_snapshot.json
+++ b/packages/isms-schema/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,5875 @@
+{
+  "id": "1ca7682e-b7ba-4873-b918-5801bcf0c32a",
+  "prevId": "29eda144-307b-4953-bfe0-4e564a3242ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.policy_acknowledgment": {
+      "name": "policy_acknowledgment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acknowledged_version": {
+          "name": "acknowledged_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_policy_ack_policy": {
+          "name": "idx_policy_ack_policy",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_ack_user": {
+          "name": "idx_policy_ack_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "policy_acknowledgment_policy_id_policy_id_fk": {
+          "name": "policy_acknowledgment_policy_id_policy_id_fk",
+          "tableFrom": "policy_acknowledgment",
+          "tableTo": "policy",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_acknowledgment_user_id_user_id_fk": {
+          "name": "policy_acknowledgment_user_id_user_id_fk",
+          "tableFrom": "policy_acknowledgment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicability_lookup": {
+      "name": "applicability_lookup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_response": {
+          "name": "api_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "looked_up_at": {
+          "name": "looked_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_applicability_lookup_company": {
+          "name": "uq_applicability_lookup_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applicability_lookup_created": {
+          "name": "idx_applicability_lookup_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applicability_lookup_classification": {
+          "name": "idx_applicability_lookup_classification",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_assessment": {
+      "name": "company_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "framework_id": {
+          "name": "framework_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "total_requirements": {
+          "name": "total_requirements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "completed_requirements": {
+          "name": "completed_requirements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "compliance_percentage": {
+          "name": "compliance_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "entity_type_at_assessment": {
+          "name": "entity_type_at_assessment",
+          "type": "entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reassessment_date": {
+          "name": "next_reassessment_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reassessed_at": {
+          "name": "last_reassessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assessment_company": {
+          "name": "idx_assessment_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assessment_framework": {
+          "name": "idx_assessment_framework",
+          "columns": [
+            {
+              "expression": "framework_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_assessment_company_id_company_id_fk": {
+          "name": "company_assessment_company_id_company_id_fk",
+          "tableFrom": "company_assessment",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_assessment_framework_id_compliance_framework_id_fk": {
+          "name": "company_assessment_framework_id_compliance_framework_id_fk",
+          "tableFrom": "company_assessment",
+          "tableTo": "compliance_framework",
+          "columnsFrom": [
+            "framework_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_requirement_status": {
+      "name": "company_requirement_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "is_applicable": {
+          "name": "is_applicable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "not_applicable_reason": {
+          "name": "not_applicable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_template_version": {
+          "name": "signed_off_template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_feedback": {
+          "name": "review_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign_off_snapshot": {
+          "name": "sign_off_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_req_status_assessment": {
+          "name": "idx_req_status_assessment",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_requirement": {
+          "name": "idx_req_status_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_unique": {
+          "name": "idx_req_status_unique",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_next_review": {
+          "name": "idx_req_status_next_review",
+          "columns": [
+            {
+              "expression": "next_review_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_requirement_status_assessment_id_company_assessment_id_fk": {
+          "name": "company_requirement_status_assessment_id_company_assessment_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_requirement_id_requirement_id_fk": {
+          "name": "company_requirement_status_requirement_id_requirement_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_completed_by_user_id_fk": {
+          "name": "company_requirement_status_completed_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_signed_off_by_user_id_fk": {
+          "name": "company_requirement_status_signed_off_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_reviewed_by_user_id_fk": {
+          "name": "company_requirement_status_reviewed_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_assigned_to_user_id_fk": {
+          "name": "company_requirement_status_assigned_to_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_company": {
+          "name": "idx_audit_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_entity": {
+          "name": "idx_audit_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created": {
+          "name": "idx_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_company_created": {
+          "name": "idx_audit_company_created",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_company_id_company_id_fk": {
+          "name": "audit_log_company_id_company_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_user_id_fk": {
+          "name": "audit_log_user_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_finding": {
+      "name": "audit_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "finding_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corrective_action": {
+          "name": "corrective_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_finding_audit": {
+          "name": "idx_audit_finding_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_finding_status": {
+          "name": "idx_audit_finding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_finding_audit_id_internal_audit_id_fk": {
+          "name": "audit_finding_audit_id_internal_audit_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "internal_audit",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_finding_assigned_to_user_id_fk": {
+          "name": "audit_finding_assigned_to_user_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_finding_verified_by_user_id_fk": {
+          "name": "audit_finding_verified_by_user_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_audit": {
+      "name": "internal_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_area": {
+          "name": "audit_area",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "audit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auditor_name": {
+          "name": "auditor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_file_key": {
+          "name": "report_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_internal_audit_company": {
+          "name": "idx_internal_audit_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_internal_audit_status": {
+          "name": "idx_internal_audit_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_audit_company_id_company_id_fk": {
+          "name": "internal_audit_company_id_company_id_fk",
+          "tableFrom": "internal_audit",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_assignment": {
+      "name": "category_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_category_owner": {
+          "name": "uq_category_owner",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_assignment_assessment_id_company_assessment_id_fk": {
+          "name": "category_assignment_assessment_id_company_assessment_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_category_id_requirement_category_id_fk": {
+          "name": "category_assignment_category_id_requirement_category_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "requirement_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_user_id_user_id_fk": {
+          "name": "category_assignment_user_id_user_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_assigned_by_user_id_fk": {
+          "name": "category_assignment_assigned_by_user_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_category_intake": {
+      "name": "company_category_intake",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "completion_pct": {
+          "name": "completion_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_saved_by": {
+          "name": "last_saved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign_off_snapshot": {
+          "name": "sign_off_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_intake_assessment_category": {
+          "name": "uq_intake_assessment_category",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_category_intake_assessment_id_company_assessment_id_fk": {
+          "name": "company_category_intake_assessment_id_company_assessment_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_category_id_requirement_category_id_fk": {
+          "name": "company_category_intake_category_id_requirement_category_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "requirement_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_last_saved_by_user_id_fk": {
+          "name": "company_category_intake_last_saved_by_user_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_saved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_signed_off_by_user_id_fk": {
+          "name": "company_category_intake_signed_off_by_user_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_request": {
+      "name": "change_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_justification": {
+          "name": "business_justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_impact_assessment": {
+          "name": "security_impact_assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "change_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implemented_by": {
+          "name": "implemented_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implemented_at": {
+          "name": "implemented_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_at": {
+          "name": "tested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollback_plan": {
+          "name": "rollback_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_change_request_company": {
+          "name": "idx_change_request_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_request_status": {
+          "name": "idx_change_request_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_request_company_id_company_id_fk": {
+          "name": "change_request_company_id_company_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_asset_id_asset_id_fk": {
+          "name": "change_request_asset_id_asset_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_requested_by_user_id_fk": {
+          "name": "change_request_requested_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_approved_by_user_id_fk": {
+          "name": "change_request_approved_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_implemented_by_user_id_fk": {
+          "name": "change_request_implemented_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "implemented_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_preference": {
+      "name": "email_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_preference_user": {
+          "name": "idx_email_preference_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_email_preference_user_scope": {
+          "name": "uq_email_preference_user_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_preference_user_id_user_id_fk": {
+          "name": "email_preference_user_id_user_id_fk",
+          "tableFrom": "email_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence": {
+      "name": "evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requirement_status_id": {
+          "name": "requirement_status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "evidence_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "previous_version_id": {
+          "name": "previous_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_evidence_requirement_status": {
+          "name": "idx_evidence_requirement_status",
+          "columns": [
+            {
+              "expression": "requirement_status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_evidence_status": {
+          "name": "idx_evidence_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_requirement_status_id_company_requirement_status_id_fk": {
+          "name": "evidence_requirement_status_id_company_requirement_status_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "requirement_status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evidence_uploaded_by_user_id_fk": {
+          "name": "evidence_uploaded_by_user_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evidence_reviewed_by_user_id_fk": {
+          "name": "evidence_reviewed_by_user_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise": {
+      "name": "exercise",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_type": {
+          "name": "exercise_type",
+          "type": "exercise_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scenario_description": {
+          "name": "scenario_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "facilitator": {
+          "name": "facilitator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identified_gaps": {
+          "name": "identified_gaps",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "lessons_learned": {
+          "name": "lessons_learned",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_action_report_file_key": {
+          "name": "after_action_report_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exercise_company": {
+          "name": "idx_exercise_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercise_type": {
+          "name": "idx_exercise_type",
+          "columns": [
+            {
+              "expression": "exercise_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercise_domain": {
+          "name": "idx_exercise_domain",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_company_id_company_id_fk": {
+          "name": "exercise_company_id_company_id_fk",
+          "tableFrom": "exercise",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gap_assessment": {
+      "name": "gap_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_password_hash": {
+          "name": "share_password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gap_assessment_user": {
+          "name": "idx_gap_assessment_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gap_assessment_company": {
+          "name": "idx_gap_assessment_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gap_assessment_share_token": {
+          "name": "idx_gap_assessment_share_token",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gap_assessment_user_id_user_id_fk": {
+          "name": "gap_assessment_user_id_user_id_fk",
+          "tableFrom": "gap_assessment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gap_assessment_company_id_company_id_fk": {
+          "name": "gap_assessment_company_id_company_id_fk",
+          "tableFrom": "gap_assessment",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.improvement_item": {
+      "name": "improvement_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "improvement_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_reference_id": {
+          "name": "source_reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "deferral_reason": {
+          "name": "deferral_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_notes": {
+          "name": "verification_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_improvement_item_company": {
+          "name": "idx_improvement_item_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_improvement_item_status": {
+          "name": "idx_improvement_item_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_improvement_item_source": {
+          "name": "idx_improvement_item_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "improvement_item_company_id_company_id_fk": {
+          "name": "improvement_item_company_id_company_id_fk",
+          "tableFrom": "improvement_item",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "improvement_item_assigned_to_user_id_fk": {
+          "name": "improvement_item_assigned_to_user_id_fk",
+          "tableFrom": "improvement_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_broadcast": {
+      "name": "incident_broadcast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_relationship_id": {
+          "name": "customer_relationship_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "supplier_publication_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_count": {
+          "name": "delivery_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_incident_broadcast_incident": {
+          "name": "idx_incident_broadcast_incident",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incident_broadcast_relationship": {
+          "name": "idx_incident_broadcast_relationship",
+          "columns": [
+            {
+              "expression": "customer_relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incident_broadcast_status": {
+          "name": "idx_incident_broadcast_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_broadcast_incident_id_incident_id_fk": {
+          "name": "incident_broadcast_incident_id_incident_id_fk",
+          "tableFrom": "incident_broadcast",
+          "tableTo": "incident",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_broadcast_customer_relationship_id_supplier_id_fk": {
+          "name": "incident_broadcast_customer_relationship_id_supplier_id_fk",
+          "tableFrom": "incident_broadcast",
+          "tableTo": "supplier",
+          "columnsFrom": [
+            "customer_relationship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kpi_measurement": {
+      "name": "kpi_measurement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kpi_name": {
+          "name": "kpi_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measured_at": {
+          "name": "measured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "kpi_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kpi_measurement_company": {
+          "name": "idx_kpi_measurement_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kpi_measurement_name": {
+          "name": "idx_kpi_measurement_name",
+          "columns": [
+            {
+              "expression": "kpi_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kpi_measurement_date": {
+          "name": "idx_kpi_measurement_date",
+          "columns": [
+            {
+              "expression": "measured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kpi_measurement_company_id_company_id_fk": {
+          "name": "kpi_measurement_company_id_company_id_fk",
+          "tableFrom": "kpi_measurement",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_field": {
+          "name": "trigger_field",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "urgency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "escalation_level": {
+          "name": "escalation_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notification_company": {
+          "name": "idx_notification_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_recipient": {
+          "name": "idx_notification_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_recipient_email": {
+          "name": "idx_notification_recipient_email",
+          "columns": [
+            {
+              "expression": "recipient_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_status": {
+          "name": "idx_notification_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_scheduled": {
+          "name": "idx_notification_scheduled",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_entity": {
+          "name": "idx_notification_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notification_lifecycle_once": {
+          "name": "uq_notification_lifecycle_once",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"entity_type\" = 'lifecycle_email'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_company_id_company_id_fk": {
+          "name": "notification_company_id_company_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_recipient_id_user_id_fk": {
+          "name": "notification_recipient_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_notification_recipient_xor": {
+          "name": "chk_notification_recipient_xor",
+          "value": "(\"notification\".\"recipient_id\" IS NOT NULL) <> (\"notification\".\"recipient_email\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_form": {
+          "name": "legal_form",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_sector": {
+          "name": "sub_sector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_count": {
+          "name": "employee_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_revenue": {
+          "name": "annual_revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_turnover": {
+          "name": "global_turnover",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciso_name": {
+          "name": "ciso_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciso_reports_to": {
+          "name": "ciso_reports_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_name": {
+          "name": "bsi_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_email": {
+          "name": "bsi_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_phone": {
+          "name": "bsi_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_registration_id": {
+          "name": "bsi_registration_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_security_budget": {
+          "name": "annual_security_budget",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_locations": {
+          "name": "primary_locations",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_data_sharing": {
+          "name": "ai_data_sharing",
+          "type": "ai_data_sharing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Europe/Berlin'"
+        },
+        "digest_time": {
+          "name": "digest_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "acts_as_nis2_entity": {
+          "name": "acts_as_nis2_entity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acts_as_supplier": {
+          "name": "acts_as_supplier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_address": {
+          "name": "registered_address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_storage_key": {
+          "name": "logo_storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_contact_name": {
+          "name": "security_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_contact_email": {
+          "name": "incident_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_contact_phone": {
+          "name": "incident_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_isms": {
+          "name": "has_isms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_iso_27001_or_equivalent": {
+          "name": "has_iso_27001_or_equivalent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_security_training": {
+          "name": "staff_security_training",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_checks": {
+          "name": "background_checks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_handling": {
+          "name": "vulnerability_handling",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_policy_reviewed_annually": {
+          "name": "security_policy_reviewed_annually",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_incident_response_plan": {
+          "name": "has_incident_response_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_business_continuity_plan": {
+          "name": "has_business_continuity_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cryptography_policy": {
+          "name": "has_cryptography_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_privileged_access_mgmt": {
+          "name": "has_privileged_access_mgmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enforced_internal": {
+          "name": "mfa_enforced_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_asset_inventory": {
+          "name": "has_asset_inventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_penetration_testing_program": {
+          "name": "has_penetration_testing_program",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooperate_with_authorities": {
+          "name": "cooperate_with_authorities",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_breaches_disclosed": {
+          "name": "past_breaches_disclosed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_description": {
+          "name": "service_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_processing_locations": {
+          "name": "data_processing_locations",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_sla_hours": {
+          "name": "incident_sla_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_saas": {
+          "name": "is_saas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_on_prem": {
+          "name": "is_on_prem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_professional_services": {
+          "name": "is_professional_services",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_managed_service": {
+          "name": "is_managed_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_ai_systems": {
+          "name": "uses_ai_systems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accept_right_to_audit": {
+          "name": "accept_right_to_audit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_subprocessors": {
+          "name": "has_subprocessors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subprocessor_list": {
+          "name": "subprocessor_list",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_return_on_termination": {
+          "name": "data_return_on_termination",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpa_available": {
+          "name": "dpa_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_assistance_commitment": {
+          "name": "incident_assistance_commitment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_material_changes": {
+          "name": "notify_material_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_location_change": {
+          "name": "notify_on_location_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_exit_plan": {
+          "name": "has_exit_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provides_sbom_for_ai": {
+          "name": "provides_sbom_for_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_sbom_url": {
+          "name": "ai_sbom_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_hosting_region": {
+          "name": "saas_hosting_region",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_encryption_at_rest": {
+          "name": "saas_encryption_at_rest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_encryption_in_transit": {
+          "name": "saas_encryption_in_transit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_mfa_enforced": {
+          "name": "saas_mfa_enforced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_rto_hours": {
+          "name": "saas_rto_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_sbom_provided": {
+          "name": "on_prem_sbom_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_signed_releases": {
+          "name": "on_prem_signed_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_vulnerability_disclosure_policy": {
+          "name": "on_prem_vulnerability_disclosure_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_patch_sla_critical_hours": {
+          "name": "on_prem_patch_sla_critical_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_background_check_scope": {
+          "name": "pro_services_background_check_scope",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_nda_in_place": {
+          "name": "pro_services_nda_in_place",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_customer_premises_policy": {
+          "name": "pro_services_customer_premises_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_privileged_access_mgmt": {
+          "name": "managed_privileged_access_mgmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_session_recording": {
+          "name": "managed_session_recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_on_call_24x7": {
+          "name": "managed_on_call_24x7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionnaire_last_saved_at": {
+          "name": "questionnaire_last_saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_owner_id_user_id_fk": {
+          "name": "company_owner_id_user_id_fk",
+          "tableFrom": "company",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_management": {
+          "name": "is_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disposable_email": {
+          "name": "is_disposable_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_followups_disabled": {
+          "name": "email_followups_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "login_count": {
+          "name": "login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_dismissed_at": {
+          "name": "tour_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_tour_dismissed_at": {
+          "name": "requirement_tour_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "help_offer_dismissed_at": {
+          "name": "help_offer_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_company": {
+          "name": "idx_user_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_company_id_company_id_fk": {
+          "name": "user_company_id_company_id_fk",
+          "tableFrom": "user",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patch_record": {
+      "name": "patch_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patch_identifier": {
+          "name": "patch_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_reason": {
+          "name": "exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_approved_by": {
+          "name": "exception_approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_expires_at": {
+          "name": "exception_expires_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_patch_record_company": {
+          "name": "idx_patch_record_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_patch_record_asset": {
+          "name": "idx_patch_record_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_patch_record_status": {
+          "name": "idx_patch_record_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patch_record_company_id_company_id_fk": {
+          "name": "patch_record_company_id_company_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patch_record_asset_id_asset_id_fk": {
+          "name": "patch_record_asset_id_asset_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patch_record_exception_approved_by_user_id_fk": {
+          "name": "patch_record_exception_approved_by_user_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "exception_approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policy": {
+      "name": "policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approver_role": {
+          "name": "approver_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_due": {
+          "name": "review_due",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_policy_company": {
+          "name": "idx_policy_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_requirement": {
+          "name": "idx_policy_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_status": {
+          "name": "idx_policy_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "policy_company_id_company_id_fk": {
+          "name": "policy_company_id_company_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_requirement_id_requirement_id_fk": {
+          "name": "policy_requirement_id_requirement_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_approved_by_user_id_fk": {
+          "name": "policy_approved_by_user_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_policy_config": {
+      "name": "company_policy_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_type": {
+          "name": "policy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_policy_config_company_type": {
+          "name": "uq_policy_config_company_type",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "policy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_policy_config_company_id_company_id_fk": {
+          "name": "company_policy_config_company_id_company_id_fk",
+          "tableFrom": "company_policy_config",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.requirement_assignment": {
+      "name": "requirement_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_req_assign": {
+          "name": "uq_req_assign",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_assign_user": {
+          "name": "idx_req_assign_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirement_assignment_status_id_company_requirement_status_id_fk": {
+          "name": "requirement_assignment_status_id_company_requirement_status_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_assignment_user_id_user_id_fk": {
+          "name": "requirement_assignment_user_id_user_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_assignment_assigned_by_user_id_fk": {
+          "name": "requirement_assignment_assigned_by_user_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.management_review": {
+      "name": "management_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "topics_covered": {
+          "name": "topics_covered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "decisions": {
+          "name": "decisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file_key": {
+          "name": "minutes_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_management_review_company": {
+          "name": "idx_management_review_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_management_review_date": {
+          "name": "idx_management_review_date",
+          "columns": [
+            {
+              "expression": "review_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "management_review_company_id_company_id_fk": {
+          "name": "management_review_company_id_company_id_fk",
+          "tableFrom": "management_review",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_risk_methodology": {
+      "name": "company_risk_methodology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BSI 200-3'"
+        },
+        "likelihood_levels": {
+          "name": "likelihood_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_levels": {
+          "name": "impact_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "includes_ot": {
+          "name": "includes_ot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_risk_methodology_company": {
+          "name": "uq_risk_methodology_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_risk_methodology_company_id_company_id_fk": {
+          "name": "company_risk_methodology_company_id_company_id_fk",
+          "tableFrom": "company_risk_methodology",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.risk_treatment": {
+      "name": "risk_treatment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "risk_id": {
+          "name": "risk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_resources": {
+          "name": "required_resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_user_id": {
+          "name": "responsible_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_residual_likelihood": {
+          "name": "expected_residual_likelihood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_residual_impact": {
+          "name": "expected_residual_impact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_risk_treatment_risk": {
+          "name": "idx_risk_treatment_risk",
+          "columns": [
+            {
+              "expression": "risk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_risk_treatment_status": {
+          "name": "idx_risk_treatment_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "risk_treatment_risk_id_risk_id_fk": {
+          "name": "risk_treatment_risk_id_risk_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "risk",
+          "columnsFrom": [
+            "risk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "risk_treatment_responsible_user_id_user_id_fk": {
+          "name": "risk_treatment_responsible_user_id_user_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "responsible_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "risk_treatment_verified_by_user_id_fk": {
+          "name": "risk_treatment_verified_by_user_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sign_off_history": {
+      "name": "sign_off_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_checksum": {
+          "name": "previous_checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sign_off_history_status": {
+          "name": "idx_sign_off_history_status",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_company": {
+          "name": "idx_sign_off_history_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_requirement": {
+          "name": "idx_sign_off_history_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_created": {
+          "name": "idx_sign_off_history_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_sign_off_history_status_version": {
+          "name": "uq_sign_off_history_status_version",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sign_off_history_company_id_company_id_fk": {
+          "name": "sign_off_history_company_id_company_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_status_id_company_requirement_status_id_fk": {
+          "name": "sign_off_history_status_id_company_requirement_status_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_requirement_id_requirement_id_fk": {
+          "name": "sign_off_history_requirement_id_requirement_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_signed_off_by_user_id_fk": {
+          "name": "sign_off_history_signed_off_by_user_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_lesson_progress": {
+      "name": "training_lesson_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiz_score": {
+          "name": "quiz_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiz_passed": {
+          "name": "quiz_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_training_progress_company_course": {
+          "name": "idx_training_progress_company_course",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_lesson_progress_user_id_user_id_fk": {
+          "name": "training_lesson_progress_user_id_user_id_fk",
+          "tableFrom": "training_lesson_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "training_lesson_progress_company_id_company_id_fk": {
+          "name": "training_lesson_progress_company_id_company_id_fk",
+          "tableFrom": "training_lesson_progress",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_training_progress_user_course_lesson": {
+          "name": "uq_training_progress_user_course_lesson",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "course_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_record": {
+      "name": "training_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "training_type": {
+          "name": "training_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_name": {
+          "name": "participant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_role": {
+          "name": "participant_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_management": {
+          "name": "is_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trainer_name": {
+          "name": "trainer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trainer_qualification": {
+          "name": "trainer_qualification",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics_covered": {
+          "name": "topics_covered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "certificate_file_key": {
+          "name": "certificate_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_training_due": {
+          "name": "next_training_due",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_training_company": {
+          "name": "idx_training_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_training_user": {
+          "name": "idx_training_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_training_management": {
+          "name": "idx_training_management",
+          "columns": [
+            {
+              "expression": "is_management",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_record_company_id_company_id_fk": {
+          "name": "training_record_company_id_company_id_fk",
+          "tableFrom": "training_record",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "training_record_user_id_user_id_fk": {
+          "name": "training_record_user_id_user_id_fk",
+          "tableFrom": "training_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vulnerability": {
+      "name": "vulnerability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_id": {
+          "name": "cve_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cvss_score": {
+          "name": "cvss_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vulnerability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discovered'"
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "treatment_note": {
+          "name": "treatment_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_reason": {
+          "name": "acceptance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vulnerability_company": {
+          "name": "idx_vulnerability_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vulnerability_asset": {
+          "name": "idx_vulnerability_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vulnerability_status": {
+          "name": "idx_vulnerability_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_company_id_company_id_fk": {
+          "name": "vulnerability_company_id_company_id_fk",
+          "tableFrom": "vulnerability",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vulnerability_asset_id_asset_id_fk": {
+          "name": "vulnerability_asset_id_asset_id_fk",
+          "tableFrom": "vulnerability",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_data_sharing": {
+      "name": "ai_data_sharing",
+      "schema": "public",
+      "values": [
+        "none",
+        "basic",
+        "full"
+      ]
+    },
+    "public.audit_status": {
+      "name": "audit_status",
+      "schema": "public",
+      "values": [
+        "planned",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.change_status": {
+      "name": "change_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "implementing",
+        "implemented",
+        "rolled_back",
+        "closed"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "normal",
+        "emergency"
+      ]
+    },
+    "public.evidence_status": {
+      "name": "evidence_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "in_review",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.exercise_type": {
+      "name": "exercise_type",
+      "schema": "public",
+      "values": [
+        "tabletop",
+        "technical",
+        "red_team",
+        "full_scale"
+      ]
+    },
+    "public.finding_severity": {
+      "name": "finding_severity",
+      "schema": "public",
+      "values": [
+        "critical",
+        "major",
+        "minor",
+        "observation"
+      ]
+    },
+    "public.finding_status": {
+      "name": "finding_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "resolved",
+        "verified",
+        "deferred"
+      ]
+    },
+    "public.improvement_source": {
+      "name": "improvement_source",
+      "schema": "public",
+      "values": [
+        "audit",
+        "incident",
+        "pentest",
+        "management_review",
+        "kpi_breach",
+        "gap_analysis",
+        "regulatory_change",
+        "suggestion"
+      ]
+    },
+    "public.incident_report_type": {
+      "name": "incident_report_type",
+      "schema": "public",
+      "values": [
+        "early_warning",
+        "notification",
+        "intermediate",
+        "final",
+        "progress"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed",
+        "not_applicable",
+        "needs_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.kpi_status": {
+      "name": "kpi_status",
+      "schema": "public",
+      "values": [
+        "green",
+        "amber",
+        "red"
+      ]
+    },
+    "public.lead_intent": {
+      "name": "lead_intent",
+      "schema": "public",
+      "values": [
+        "entity",
+        "supplier",
+        "both",
+        "unknown"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "in_app",
+        "webhook"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "acknowledged",
+        "escalated",
+        "cancelled"
+      ]
+    },
+    "public.patch_status": {
+      "name": "patch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "applied",
+        "exception",
+        "not_applicable"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "guided",
+        "enterprise"
+      ]
+    },
+    "public.supplier_publication_broadcast_status": {
+      "name": "supplier_publication_broadcast_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed"
+      ]
+    },
+    "public.supplier_publication_event_type": {
+      "name": "supplier_publication_event_type",
+      "schema": "public",
+      "values": [
+        "questionnaire_updated",
+        "certification_added",
+        "certification_expiring",
+        "incident_published",
+        "subprocessor_changed",
+        "service_catalog_changed"
+      ]
+    },
+    "public.treatment_status": {
+      "name": "treatment_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed",
+        "verified"
+      ]
+    },
+    "public.urgency": {
+      "name": "urgency",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "urgent",
+        "critical"
+      ]
+    },
+    "public.vulnerability_status": {
+      "name": "vulnerability_status",
+      "schema": "public",
+      "values": [
+        "discovered",
+        "assessed",
+        "treating",
+        "resolved",
+        "accepted",
+        "mitigated"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/isms-schema/drizzle/meta/0012_snapshot.json
+++ b/packages/isms-schema/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,5903 @@
+{
+  "id": "73b72253-e47d-4f3b-b381-a729fb85f148",
+  "prevId": "1ca7682e-b7ba-4873-b918-5801bcf0c32a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.policy_acknowledgment": {
+      "name": "policy_acknowledgment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acknowledged_version": {
+          "name": "acknowledged_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_policy_ack_policy": {
+          "name": "idx_policy_ack_policy",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_ack_user": {
+          "name": "idx_policy_ack_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "policy_acknowledgment_policy_id_policy_id_fk": {
+          "name": "policy_acknowledgment_policy_id_policy_id_fk",
+          "tableFrom": "policy_acknowledgment",
+          "tableTo": "policy",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_acknowledgment_user_id_user_id_fk": {
+          "name": "policy_acknowledgment_user_id_user_id_fk",
+          "tableFrom": "policy_acknowledgment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applicability_lookup": {
+      "name": "applicability_lookup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_response": {
+          "name": "api_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "looked_up_at": {
+          "name": "looked_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_applicability_lookup_company": {
+          "name": "uq_applicability_lookup_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applicability_lookup_created": {
+          "name": "idx_applicability_lookup_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applicability_lookup_classification": {
+          "name": "idx_applicability_lookup_classification",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_assessment": {
+      "name": "company_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "framework_id": {
+          "name": "framework_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "total_requirements": {
+          "name": "total_requirements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "completed_requirements": {
+          "name": "completed_requirements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "compliance_percentage": {
+          "name": "compliance_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "entity_type_at_assessment": {
+          "name": "entity_type_at_assessment",
+          "type": "entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reassessment_date": {
+          "name": "next_reassessment_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reassessed_at": {
+          "name": "last_reassessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_assessment_company": {
+          "name": "idx_assessment_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_assessment_framework": {
+          "name": "idx_assessment_framework",
+          "columns": [
+            {
+              "expression": "framework_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_assessment_company_id_company_id_fk": {
+          "name": "company_assessment_company_id_company_id_fk",
+          "tableFrom": "company_assessment",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_assessment_framework_id_compliance_framework_id_fk": {
+          "name": "company_assessment_framework_id_compliance_framework_id_fk",
+          "tableFrom": "company_assessment",
+          "tableTo": "compliance_framework",
+          "columnsFrom": [
+            "framework_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_requirement_status": {
+      "name": "company_requirement_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "is_applicable": {
+          "name": "is_applicable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "not_applicable_reason": {
+          "name": "not_applicable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_template_version": {
+          "name": "signed_off_template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewed_at": {
+          "name": "last_reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_feedback": {
+          "name": "review_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign_off_snapshot": {
+          "name": "sign_off_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_req_status_assessment": {
+          "name": "idx_req_status_assessment",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_requirement": {
+          "name": "idx_req_status_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_unique": {
+          "name": "idx_req_status_unique",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_status_next_review": {
+          "name": "idx_req_status_next_review",
+          "columns": [
+            {
+              "expression": "next_review_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_requirement_status_assessment_id_company_assessment_id_fk": {
+          "name": "company_requirement_status_assessment_id_company_assessment_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_requirement_id_requirement_id_fk": {
+          "name": "company_requirement_status_requirement_id_requirement_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_completed_by_user_id_fk": {
+          "name": "company_requirement_status_completed_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_signed_off_by_user_id_fk": {
+          "name": "company_requirement_status_signed_off_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_reviewed_by_user_id_fk": {
+          "name": "company_requirement_status_reviewed_by_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_requirement_status_assigned_to_user_id_fk": {
+          "name": "company_requirement_status_assigned_to_user_id_fk",
+          "tableFrom": "company_requirement_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_company": {
+          "name": "idx_audit_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_entity": {
+          "name": "idx_audit_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created": {
+          "name": "idx_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_company_created": {
+          "name": "idx_audit_company_created",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_company_id_company_id_fk": {
+          "name": "audit_log_company_id_company_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_user_id_fk": {
+          "name": "audit_log_user_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_finding": {
+      "name": "audit_finding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "finding_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_cause": {
+          "name": "root_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "corrective_action": {
+          "name": "corrective_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_finding_audit": {
+          "name": "idx_audit_finding_audit",
+          "columns": [
+            {
+              "expression": "audit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_finding_status": {
+          "name": "idx_audit_finding_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_finding_audit_id_internal_audit_id_fk": {
+          "name": "audit_finding_audit_id_internal_audit_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "internal_audit",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_finding_assigned_to_user_id_fk": {
+          "name": "audit_finding_assigned_to_user_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_finding_verified_by_user_id_fk": {
+          "name": "audit_finding_verified_by_user_id_fk",
+          "tableFrom": "audit_finding",
+          "tableTo": "user",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_audit": {
+      "name": "internal_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audit_area": {
+          "name": "audit_area",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "audit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auditor_name": {
+          "name": "auditor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_file_key": {
+          "name": "report_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_internal_audit_company": {
+          "name": "idx_internal_audit_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_internal_audit_status": {
+          "name": "idx_internal_audit_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_audit_company_id_company_id_fk": {
+          "name": "internal_audit_company_id_company_id_fk",
+          "tableFrom": "internal_audit",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_assignment": {
+      "name": "category_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_category_owner": {
+          "name": "uq_category_owner",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_assignment_assessment_id_company_assessment_id_fk": {
+          "name": "category_assignment_assessment_id_company_assessment_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_category_id_requirement_category_id_fk": {
+          "name": "category_assignment_category_id_requirement_category_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "requirement_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_user_id_user_id_fk": {
+          "name": "category_assignment_user_id_user_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "category_assignment_assigned_by_user_id_fk": {
+          "name": "category_assignment_assigned_by_user_id_fk",
+          "tableFrom": "category_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_category_intake": {
+      "name": "company_category_intake",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "assessment_id": {
+          "name": "assessment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "completion_pct": {
+          "name": "completion_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_saved_by": {
+          "name": "last_saved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_saved_at": {
+          "name": "last_saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sign_off_snapshot": {
+          "name": "sign_off_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_intake_assessment_category": {
+          "name": "uq_intake_assessment_category",
+          "columns": [
+            {
+              "expression": "assessment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_category_intake_assessment_id_company_assessment_id_fk": {
+          "name": "company_category_intake_assessment_id_company_assessment_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "company_assessment",
+          "columnsFrom": [
+            "assessment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_category_id_requirement_category_id_fk": {
+          "name": "company_category_intake_category_id_requirement_category_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "requirement_category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_last_saved_by_user_id_fk": {
+          "name": "company_category_intake_last_saved_by_user_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_saved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "company_category_intake_signed_off_by_user_id_fk": {
+          "name": "company_category_intake_signed_off_by_user_id_fk",
+          "tableFrom": "company_category_intake",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change_request": {
+      "name": "change_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_justification": {
+          "name": "business_justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_impact_assessment": {
+          "name": "security_impact_assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "change_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "change_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implemented_by": {
+          "name": "implemented_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "implemented_at": {
+          "name": "implemented_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_at": {
+          "name": "tested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollback_plan": {
+          "name": "rollback_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_change_request_company": {
+          "name": "idx_change_request_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_change_request_status": {
+          "name": "idx_change_request_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_request_company_id_company_id_fk": {
+          "name": "change_request_company_id_company_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_asset_id_asset_id_fk": {
+          "name": "change_request_asset_id_asset_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_requested_by_user_id_fk": {
+          "name": "change_request_requested_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_approved_by_user_id_fk": {
+          "name": "change_request_approved_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "change_request_implemented_by_user_id_fk": {
+          "name": "change_request_implemented_by_user_id_fk",
+          "tableFrom": "change_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "implemented_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_preference": {
+      "name": "email_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_preference_user": {
+          "name": "idx_email_preference_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_email_preference_user_scope": {
+          "name": "uq_email_preference_user_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_preference_user_id_user_id_fk": {
+          "name": "email_preference_user_id_user_id_fk",
+          "tableFrom": "email_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evidence": {
+      "name": "evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "requirement_status_id": {
+          "name": "requirement_status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "evidence_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "previous_version_id": {
+          "name": "previous_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_evidence_requirement_status": {
+          "name": "idx_evidence_requirement_status",
+          "columns": [
+            {
+              "expression": "requirement_status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_evidence_status": {
+          "name": "idx_evidence_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidence_requirement_status_id_company_requirement_status_id_fk": {
+          "name": "evidence_requirement_status_id_company_requirement_status_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "requirement_status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evidence_uploaded_by_user_id_fk": {
+          "name": "evidence_uploaded_by_user_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evidence_reviewed_by_user_id_fk": {
+          "name": "evidence_reviewed_by_user_id_fk",
+          "tableFrom": "evidence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise": {
+      "name": "exercise",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_type": {
+          "name": "exercise_type",
+          "type": "exercise_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scenario_description": {
+          "name": "scenario_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "facilitator": {
+          "name": "facilitator",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identified_gaps": {
+          "name": "identified_gaps",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "lessons_learned": {
+          "name": "lessons_learned",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_action_report_file_key": {
+          "name": "after_action_report_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exercise_company": {
+          "name": "idx_exercise_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercise_type": {
+          "name": "idx_exercise_type",
+          "columns": [
+            {
+              "expression": "exercise_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exercise_domain": {
+          "name": "idx_exercise_domain",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exercise_company_id_company_id_fk": {
+          "name": "exercise_company_id_company_id_fk",
+          "tableFrom": "exercise",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gap_assessment": {
+      "name": "gap_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_password_hash": {
+          "name": "share_password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_at": {
+          "name": "shared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gap_assessment_user": {
+          "name": "idx_gap_assessment_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gap_assessment_company": {
+          "name": "idx_gap_assessment_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_gap_assessment_share_token": {
+          "name": "idx_gap_assessment_share_token",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gap_assessment_user_id_user_id_fk": {
+          "name": "gap_assessment_user_id_user_id_fk",
+          "tableFrom": "gap_assessment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gap_assessment_company_id_company_id_fk": {
+          "name": "gap_assessment_company_id_company_id_fk",
+          "tableFrom": "gap_assessment",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.improvement_item": {
+      "name": "improvement_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "improvement_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_reference_id": {
+          "name": "source_reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "finding_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "deferral_reason": {
+          "name": "deferral_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_notes": {
+          "name": "verification_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_improvement_item_company": {
+          "name": "idx_improvement_item_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_improvement_item_status": {
+          "name": "idx_improvement_item_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_improvement_item_source": {
+          "name": "idx_improvement_item_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "improvement_item_company_id_company_id_fk": {
+          "name": "improvement_item_company_id_company_id_fk",
+          "tableFrom": "improvement_item",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "improvement_item_assigned_to_user_id_fk": {
+          "name": "improvement_item_assigned_to_user_id_fk",
+          "tableFrom": "improvement_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incident_broadcast": {
+      "name": "incident_broadcast",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_relationship_id": {
+          "name": "customer_relationship_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "supplier_publication_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_count": {
+          "name": "delivery_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_incident_broadcast_incident": {
+          "name": "idx_incident_broadcast_incident",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incident_broadcast_relationship": {
+          "name": "idx_incident_broadcast_relationship",
+          "columns": [
+            {
+              "expression": "customer_relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incident_broadcast_status": {
+          "name": "idx_incident_broadcast_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incident_broadcast_incident_id_incident_id_fk": {
+          "name": "incident_broadcast_incident_id_incident_id_fk",
+          "tableFrom": "incident_broadcast",
+          "tableTo": "incident",
+          "columnsFrom": [
+            "incident_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "incident_broadcast_customer_relationship_id_supplier_id_fk": {
+          "name": "incident_broadcast_customer_relationship_id_supplier_id_fk",
+          "tableFrom": "incident_broadcast",
+          "tableTo": "supplier",
+          "columnsFrom": [
+            "customer_relationship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kpi_measurement": {
+      "name": "kpi_measurement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kpi_name": {
+          "name": "kpi_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measured_at": {
+          "name": "measured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "kpi_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kpi_measurement_company": {
+          "name": "idx_kpi_measurement_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kpi_measurement_name": {
+          "name": "idx_kpi_measurement_name",
+          "columns": [
+            {
+              "expression": "kpi_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kpi_measurement_date": {
+          "name": "idx_kpi_measurement_date",
+          "columns": [
+            {
+              "expression": "measured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kpi_measurement_company_id_company_id_fk": {
+          "name": "kpi_measurement_company_id_company_id_fk",
+          "tableFrom": "kpi_measurement",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_field": {
+          "name": "trigger_field",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "notification_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "urgency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "escalation_level": {
+          "name": "escalation_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notification_company": {
+          "name": "idx_notification_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_recipient": {
+          "name": "idx_notification_recipient",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_recipient_email": {
+          "name": "idx_notification_recipient_email",
+          "columns": [
+            {
+              "expression": "recipient_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_status": {
+          "name": "idx_notification_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_scheduled": {
+          "name": "idx_notification_scheduled",
+          "columns": [
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_entity": {
+          "name": "idx_notification_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notification_lifecycle_once": {
+          "name": "uq_notification_lifecycle_once",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"entity_type\" = 'lifecycle_email'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notification_digest_once_per_day": {
+          "name": "uq_notification_digest_once_per_day",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notification\".\"entity_type\" IN ('daily_digest', 'weekly_management_digest')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_company_id_company_id_fk": {
+          "name": "notification_company_id_company_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_recipient_id_user_id_fk": {
+          "name": "notification_recipient_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_notification_recipient_xor": {
+          "name": "chk_notification_recipient_xor",
+          "value": "(\"notification\".\"recipient_id\" IS NOT NULL) <> (\"notification\".\"recipient_email\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.company": {
+      "name": "company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_form": {
+          "name": "legal_form",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub_sector": {
+          "name": "sub_sector",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_count": {
+          "name": "employee_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_revenue": {
+          "name": "annual_revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_turnover": {
+          "name": "global_turnover",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciso_name": {
+          "name": "ciso_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciso_reports_to": {
+          "name": "ciso_reports_to",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_name": {
+          "name": "bsi_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_email": {
+          "name": "bsi_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_contact_phone": {
+          "name": "bsi_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bsi_registration_id": {
+          "name": "bsi_registration_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_security_budget": {
+          "name": "annual_security_budget",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_locations": {
+          "name": "primary_locations",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_data_sharing": {
+          "name": "ai_data_sharing",
+          "type": "ai_data_sharing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Europe/Berlin'"
+        },
+        "digest_time": {
+          "name": "digest_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "acts_as_nis2_entity": {
+          "name": "acts_as_nis2_entity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acts_as_supplier": {
+          "name": "acts_as_supplier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_address": {
+          "name": "registered_address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_storage_key": {
+          "name": "logo_storage_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_contact_name": {
+          "name": "security_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_contact_email": {
+          "name": "incident_contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_contact_phone": {
+          "name": "incident_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_isms": {
+          "name": "has_isms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_iso_27001_or_equivalent": {
+          "name": "has_iso_27001_or_equivalent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staff_security_training": {
+          "name": "staff_security_training",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_checks": {
+          "name": "background_checks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerability_handling": {
+          "name": "vulnerability_handling",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_policy_reviewed_annually": {
+          "name": "security_policy_reviewed_annually",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_incident_response_plan": {
+          "name": "has_incident_response_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_business_continuity_plan": {
+          "name": "has_business_continuity_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cryptography_policy": {
+          "name": "has_cryptography_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_privileged_access_mgmt": {
+          "name": "has_privileged_access_mgmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mfa_enforced_internal": {
+          "name": "mfa_enforced_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_asset_inventory": {
+          "name": "has_asset_inventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_penetration_testing_program": {
+          "name": "has_penetration_testing_program",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cooperate_with_authorities": {
+          "name": "cooperate_with_authorities",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_breaches_disclosed": {
+          "name": "past_breaches_disclosed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_description": {
+          "name": "service_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_processing_locations": {
+          "name": "data_processing_locations",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_sla_hours": {
+          "name": "incident_sla_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_saas": {
+          "name": "is_saas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_on_prem": {
+          "name": "is_on_prem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_professional_services": {
+          "name": "is_professional_services",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_managed_service": {
+          "name": "is_managed_service",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_ai_systems": {
+          "name": "uses_ai_systems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accept_right_to_audit": {
+          "name": "accept_right_to_audit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_subprocessors": {
+          "name": "has_subprocessors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subprocessor_list": {
+          "name": "subprocessor_list",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_return_on_termination": {
+          "name": "data_return_on_termination",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpa_available": {
+          "name": "dpa_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incident_assistance_commitment": {
+          "name": "incident_assistance_commitment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_material_changes": {
+          "name": "notify_material_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_on_location_change": {
+          "name": "notify_on_location_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_exit_plan": {
+          "name": "has_exit_plan",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provides_sbom_for_ai": {
+          "name": "provides_sbom_for_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_sbom_url": {
+          "name": "ai_sbom_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_hosting_region": {
+          "name": "saas_hosting_region",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_encryption_at_rest": {
+          "name": "saas_encryption_at_rest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_encryption_in_transit": {
+          "name": "saas_encryption_in_transit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_mfa_enforced": {
+          "name": "saas_mfa_enforced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saas_rto_hours": {
+          "name": "saas_rto_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_sbom_provided": {
+          "name": "on_prem_sbom_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_signed_releases": {
+          "name": "on_prem_signed_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_vulnerability_disclosure_policy": {
+          "name": "on_prem_vulnerability_disclosure_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_prem_patch_sla_critical_hours": {
+          "name": "on_prem_patch_sla_critical_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_background_check_scope": {
+          "name": "pro_services_background_check_scope",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_nda_in_place": {
+          "name": "pro_services_nda_in_place",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pro_services_customer_premises_policy": {
+          "name": "pro_services_customer_premises_policy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_privileged_access_mgmt": {
+          "name": "managed_privileged_access_mgmt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_session_recording": {
+          "name": "managed_session_recording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managed_on_call_24x7": {
+          "name": "managed_on_call_24x7",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionnaire_last_saved_at": {
+          "name": "questionnaire_last_saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_owner_id_user_id_fk": {
+          "name": "company_owner_id_user_id_fk",
+          "tableFrom": "company",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_management": {
+          "name": "is_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disposable_email": {
+          "name": "is_disposable_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_followups_disabled": {
+          "name": "email_followups_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "login_count": {
+          "name": "login_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_dismissed_at": {
+          "name": "tour_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_tour_dismissed_at": {
+          "name": "requirement_tour_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "help_offer_dismissed_at": {
+          "name": "help_offer_dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_company": {
+          "name": "idx_user_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_company_id_company_id_fk": {
+          "name": "user_company_id_company_id_fk",
+          "tableFrom": "user",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patch_record": {
+      "name": "patch_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patch_identifier": {
+          "name": "patch_identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_reason": {
+          "name": "exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_approved_by": {
+          "name": "exception_approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exception_expires_at": {
+          "name": "exception_expires_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_patch_record_company": {
+          "name": "idx_patch_record_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_patch_record_asset": {
+          "name": "idx_patch_record_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_patch_record_status": {
+          "name": "idx_patch_record_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patch_record_company_id_company_id_fk": {
+          "name": "patch_record_company_id_company_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patch_record_asset_id_asset_id_fk": {
+          "name": "patch_record_asset_id_asset_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patch_record_exception_approved_by_user_id_fk": {
+          "name": "patch_record_exception_approved_by_user_id_fk",
+          "tableFrom": "patch_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "exception_approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policy": {
+      "name": "policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approver_role": {
+          "name": "approver_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_due": {
+          "name": "review_due",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_policy_company": {
+          "name": "idx_policy_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_requirement": {
+          "name": "idx_policy_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_policy_status": {
+          "name": "idx_policy_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "policy_company_id_company_id_fk": {
+          "name": "policy_company_id_company_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_requirement_id_requirement_id_fk": {
+          "name": "policy_requirement_id_requirement_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "policy_approved_by_user_id_fk": {
+          "name": "policy_approved_by_user_id_fk",
+          "tableFrom": "policy",
+          "tableTo": "user",
+          "columnsFrom": [
+            "approved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_policy_config": {
+      "name": "company_policy_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_type": {
+          "name": "policy_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_policy_config_company_type": {
+          "name": "uq_policy_config_company_type",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "policy_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_policy_config_company_id_company_id_fk": {
+          "name": "company_policy_config_company_id_company_id_fk",
+          "tableFrom": "company_policy_config",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.requirement_assignment": {
+      "name": "requirement_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signed_off_at": {
+          "name": "signed_off_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_req_assign": {
+          "name": "uq_req_assign",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_req_assign_user": {
+          "name": "idx_req_assign_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirement_assignment_status_id_company_requirement_status_id_fk": {
+          "name": "requirement_assignment_status_id_company_requirement_status_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_assignment_user_id_user_id_fk": {
+          "name": "requirement_assignment_user_id_user_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_assignment_assigned_by_user_id_fk": {
+          "name": "requirement_assignment_assigned_by_user_id_fk",
+          "tableFrom": "requirement_assignment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.management_review": {
+      "name": "management_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "topics_covered": {
+          "name": "topics_covered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "decisions": {
+          "name": "decisions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file_key": {
+          "name": "minutes_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_review_date": {
+          "name": "next_review_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_management_review_company": {
+          "name": "idx_management_review_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_management_review_date": {
+          "name": "idx_management_review_date",
+          "columns": [
+            {
+              "expression": "review_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "management_review_company_id_company_id_fk": {
+          "name": "management_review_company_id_company_id_fk",
+          "tableFrom": "management_review",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_risk_methodology": {
+      "name": "company_risk_methodology",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'BSI 200-3'"
+        },
+        "likelihood_levels": {
+          "name": "likelihood_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_levels": {
+          "name": "impact_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acceptance_threshold": {
+          "name": "acceptance_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4
+        },
+        "includes_ot": {
+          "name": "includes_ot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_risk_methodology_company": {
+          "name": "uq_risk_methodology_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_risk_methodology_company_id_company_id_fk": {
+          "name": "company_risk_methodology_company_id_company_id_fk",
+          "tableFrom": "company_risk_methodology",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.risk_treatment": {
+      "name": "risk_treatment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "risk_id": {
+          "name": "risk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_resources": {
+          "name": "required_resources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_user_id": {
+          "name": "responsible_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_residual_likelihood": {
+          "name": "expected_residual_likelihood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_residual_impact": {
+          "name": "expected_residual_impact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_risk_treatment_risk": {
+          "name": "idx_risk_treatment_risk",
+          "columns": [
+            {
+              "expression": "risk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_risk_treatment_status": {
+          "name": "idx_risk_treatment_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "risk_treatment_risk_id_risk_id_fk": {
+          "name": "risk_treatment_risk_id_risk_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "risk",
+          "columnsFrom": [
+            "risk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "risk_treatment_responsible_user_id_user_id_fk": {
+          "name": "risk_treatment_responsible_user_id_user_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "responsible_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "risk_treatment_verified_by_user_id_fk": {
+          "name": "risk_treatment_verified_by_user_id_fk",
+          "tableFrom": "risk_treatment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sign_off_history": {
+      "name": "sign_off_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_off_by": {
+          "name": "signed_off_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_off_role": {
+          "name": "signed_off_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_checksum": {
+          "name": "previous_checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sign_off_history_status": {
+          "name": "idx_sign_off_history_status",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_company": {
+          "name": "idx_sign_off_history_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_requirement": {
+          "name": "idx_sign_off_history_requirement",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sign_off_history_created": {
+          "name": "idx_sign_off_history_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_sign_off_history_status_version": {
+          "name": "uq_sign_off_history_status_version",
+          "columns": [
+            {
+              "expression": "status_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sign_off_history_company_id_company_id_fk": {
+          "name": "sign_off_history_company_id_company_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_status_id_company_requirement_status_id_fk": {
+          "name": "sign_off_history_status_id_company_requirement_status_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "company_requirement_status",
+          "columnsFrom": [
+            "status_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_requirement_id_requirement_id_fk": {
+          "name": "sign_off_history_requirement_id_requirement_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "requirement",
+          "columnsFrom": [
+            "requirement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sign_off_history_signed_off_by_user_id_fk": {
+          "name": "sign_off_history_signed_off_by_user_id_fk",
+          "tableFrom": "sign_off_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "signed_off_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_lesson_progress": {
+      "name": "training_lesson_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiz_score": {
+          "name": "quiz_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiz_passed": {
+          "name": "quiz_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_training_progress_company_course": {
+          "name": "idx_training_progress_company_course",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_lesson_progress_user_id_user_id_fk": {
+          "name": "training_lesson_progress_user_id_user_id_fk",
+          "tableFrom": "training_lesson_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "training_lesson_progress_company_id_company_id_fk": {
+          "name": "training_lesson_progress_company_id_company_id_fk",
+          "tableFrom": "training_lesson_progress",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_training_progress_user_course_lesson": {
+          "name": "uq_training_progress_user_course_lesson",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "course_id",
+            "lesson_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_record": {
+      "name": "training_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "training_type": {
+          "name": "training_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_name": {
+          "name": "participant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_role": {
+          "name": "participant_role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_management": {
+          "name": "is_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trainer_name": {
+          "name": "trainer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trainer_qualification": {
+          "name": "trainer_qualification",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics_covered": {
+          "name": "topics_covered",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "certificate_file_key": {
+          "name": "certificate_file_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_training_due": {
+          "name": "next_training_due",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_training_company": {
+          "name": "idx_training_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_training_user": {
+          "name": "idx_training_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_training_management": {
+          "name": "idx_training_management",
+          "columns": [
+            {
+              "expression": "is_management",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "training_record_company_id_company_id_fk": {
+          "name": "training_record_company_id_company_id_fk",
+          "tableFrom": "training_record",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "training_record_user_id_user_id_fk": {
+          "name": "training_record_user_id_user_id_fk",
+          "tableFrom": "training_record",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vulnerability": {
+      "name": "vulnerability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cve_id": {
+          "name": "cve_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cvss_score": {
+          "name": "cvss_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vulnerability_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discovered'"
+        },
+        "discovered_at": {
+          "name": "discovered_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "treatment_note": {
+          "name": "treatment_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_reason": {
+          "name": "acceptance_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vulnerability_company": {
+          "name": "idx_vulnerability_company",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vulnerability_asset": {
+          "name": "idx_vulnerability_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vulnerability_status": {
+          "name": "idx_vulnerability_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vulnerability_company_id_company_id_fk": {
+          "name": "vulnerability_company_id_company_id_fk",
+          "tableFrom": "vulnerability",
+          "tableTo": "company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vulnerability_asset_id_asset_id_fk": {
+          "name": "vulnerability_asset_id_asset_id_fk",
+          "tableFrom": "vulnerability",
+          "tableTo": "asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.ai_data_sharing": {
+      "name": "ai_data_sharing",
+      "schema": "public",
+      "values": [
+        "none",
+        "basic",
+        "full"
+      ]
+    },
+    "public.audit_status": {
+      "name": "audit_status",
+      "schema": "public",
+      "values": [
+        "planned",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.change_status": {
+      "name": "change_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "approved",
+        "implementing",
+        "implemented",
+        "rolled_back",
+        "closed"
+      ]
+    },
+    "public.change_type": {
+      "name": "change_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "normal",
+        "emergency"
+      ]
+    },
+    "public.evidence_status": {
+      "name": "evidence_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "in_review",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.exercise_type": {
+      "name": "exercise_type",
+      "schema": "public",
+      "values": [
+        "tabletop",
+        "technical",
+        "red_team",
+        "full_scale"
+      ]
+    },
+    "public.finding_severity": {
+      "name": "finding_severity",
+      "schema": "public",
+      "values": [
+        "critical",
+        "major",
+        "minor",
+        "observation"
+      ]
+    },
+    "public.finding_status": {
+      "name": "finding_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "in_progress",
+        "resolved",
+        "verified",
+        "deferred"
+      ]
+    },
+    "public.improvement_source": {
+      "name": "improvement_source",
+      "schema": "public",
+      "values": [
+        "audit",
+        "incident",
+        "pentest",
+        "management_review",
+        "kpi_breach",
+        "gap_analysis",
+        "regulatory_change",
+        "suggestion"
+      ]
+    },
+    "public.incident_report_type": {
+      "name": "incident_report_type",
+      "schema": "public",
+      "values": [
+        "early_warning",
+        "notification",
+        "intermediate",
+        "final",
+        "progress"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed",
+        "not_applicable",
+        "needs_review",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.kpi_status": {
+      "name": "kpi_status",
+      "schema": "public",
+      "values": [
+        "green",
+        "amber",
+        "red"
+      ]
+    },
+    "public.lead_intent": {
+      "name": "lead_intent",
+      "schema": "public",
+      "values": [
+        "entity",
+        "supplier",
+        "both",
+        "unknown"
+      ]
+    },
+    "public.notification_channel": {
+      "name": "notification_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "in_app",
+        "webhook"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "acknowledged",
+        "escalated",
+        "cancelled"
+      ]
+    },
+    "public.patch_status": {
+      "name": "patch_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "applied",
+        "exception",
+        "not_applicable"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "guided",
+        "enterprise"
+      ]
+    },
+    "public.supplier_publication_broadcast_status": {
+      "name": "supplier_publication_broadcast_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "failed"
+      ]
+    },
+    "public.supplier_publication_event_type": {
+      "name": "supplier_publication_event_type",
+      "schema": "public",
+      "values": [
+        "questionnaire_updated",
+        "certification_added",
+        "certification_expiring",
+        "incident_published",
+        "subprocessor_changed",
+        "service_catalog_changed"
+      ]
+    },
+    "public.treatment_status": {
+      "name": "treatment_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "in_progress",
+        "completed",
+        "verified"
+      ]
+    },
+    "public.urgency": {
+      "name": "urgency",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "urgent",
+        "critical"
+      ]
+    },
+    "public.vulnerability_status": {
+      "name": "vulnerability_status",
+      "schema": "public",
+      "values": [
+        "discovered",
+        "assessed",
+        "treating",
+        "resolved",
+        "accepted",
+        "mitigated"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/isms-schema/drizzle/meta/_journal.json
+++ b/packages/isms-schema/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788876271648,
       "tag": "0011_email_preferences",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788883904391,
+      "tag": "0012_digest_once_per_day",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/isms-schema/drizzle/meta/_journal.json
+++ b/packages/isms-schema/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788860524812,
       "tag": "0010_lifecycle_email_foundations",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788876271648,
+      "tag": "0011_email_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/isms-schema/src/index.ts
+++ b/packages/isms-schema/src/index.ts
@@ -14,6 +14,7 @@ export * from "./tables/gap-assessment";
 export * from "./tables/improvement";
 export * from "./tables/incident-broadcast";
 export * from "./tables/kpi";
+export * from "./tables/email-preference";
 export * from "./tables/notification";
 export * from "./tables/organization";
 export * from "./tables/patch-management";

--- a/packages/isms-schema/src/tables/email-preference.ts
+++ b/packages/isms-schema/src/tables/email-preference.ts
@@ -1,0 +1,52 @@
+/**
+ * Email opt-outs — one row per thing a person switched off.
+ *
+ * Absence of a row means subscribed. That is deliberate: the default for
+ * optional mail is on, so the table only ever grows by an explicit act of the
+ * recipient, and reading it can never accidentally suppress mail that nobody
+ * asked to suppress. It also keeps the shape honest — a row IS the consent
+ * withdrawal, with the timestamp that proves when it happened, rather than a
+ * boolean column whose history is gone the moment it flips back.
+ *
+ * `scope` is one of:
+ *   "all"                        every optional message
+ *   "category:<category>"        e.g. "category:reminders"
+ *   "type:<email type id>"       e.g. "type:product.lifecycle_nudge"
+ * The vocabulary lives in lib/mail/email-types.ts; this table stores it as
+ * text so retiring an email type leaves old rows inert rather than dangling.
+ * Essential mail (sign-in codes, security notices) is never gated, so a row
+ * naming one has no effect — see the consent gate in lib/mail/consent.ts.
+ *
+ * The legacy `user.emailFollowupsDisabled` boolean still works and still
+ * means "all optional mail off"; the gate honours both. It is what the RFC
+ * 8058 one-click header has always flipped, so it stays as the coarse switch.
+ */
+import {
+  index,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { user } from "./organization";
+
+export const emailPreference = pgTable(
+  "email_preference",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .references(() => user.id, { onDelete: "cascade" })
+      .notNull(),
+    /** "all" | "category:<category>" | "type:<email type id>" */
+    scope: varchar("scope", { length: 100 }).notNull(),
+    /** How the opt-out was made: "one_click", "preference_centre", "admin". */
+    source: varchar("source", { length: 40 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_email_preference_user").on(table.userId),
+    // Re-clicking an unsubscribe link must be a no-op, not a second row.
+    uniqueIndex("uq_email_preference_user_scope").on(table.userId, table.scope),
+  ],
+);

--- a/packages/isms-schema/src/tables/notification.ts
+++ b/packages/isms-schema/src/tables/notification.ts
@@ -21,18 +21,19 @@
  *
  * References: companies, users
  */
+
+import { sql } from "drizzle-orm";
 import {
+  check,
+  index,
+  integer,
   pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
   uuid,
   varchar,
-  text,
-  integer,
-  timestamp,
-  index,
-  uniqueIndex,
-  check,
 } from "drizzle-orm/pg-core";
-import { sql } from "drizzle-orm";
 import { notificationChannelEnum, notificationStatusEnum, urgencyEnum } from "../enums";
 import { company, user } from "./organization";
 
@@ -99,11 +100,19 @@ export const notification = pgTable(
     uniqueIndex("uq_notification_lifecycle_once")
       .on(table.recipientId, table.triggerField)
       .where(sql`${table.entityType} = 'lifecycle_email'`),
+    // Digests are the other operator-sent mail, and they recur — so unlike a
+    // lifecycle claim the key carries the day. One row per recipient per
+    // digest kind per UTC day, inserted before the send, which is what makes
+    // the queue drain and what stops a second press (or a second browser tab)
+    // mailing the same person the same digest twice.
+    uniqueIndex("uq_notification_digest_once_per_day")
+      .on(table.recipientId, table.entityType, table.triggerField)
+      .where(sql`${table.entityType} IN ('daily_digest', 'weekly_management_digest')`),
     // Enforce the XOR invariant at the DB level: exactly one of recipientId
     // (in-portal user) or recipientEmail (external CISO) must be set.
     check(
       "chk_notification_recipient_xor",
       sql`(${table.recipientId} IS NOT NULL) <> (${table.recipientEmail} IS NOT NULL)`,
     ),
-  ]
+  ],
 );

--- a/server/trpc/helpers/setup-helpers.ts
+++ b/server/trpc/helpers/setup-helpers.ts
@@ -257,6 +257,7 @@ export async function processTeamRoleAssignments(
       const inviterName = opts.userName ?? "Your team admin";
 
       sendMail({
+        emailType: "account.invite",
         to: email,
         ...inviteEmail({
           companyName: opts.companyName,

--- a/server/trpc/routers/assessment.ts
+++ b/server/trpc/routers/assessment.ts
@@ -126,8 +126,16 @@ export const assessmentRouter = router({
           oldEmail: prev.contactEmail,
           newEmail: input.contactEmail,
         });
-        sendMail({ to: prev.contactEmail, ...template });
-        sendMail({ to: input.contactEmail, ...template });
+        sendMail({
+          emailType: "account.contact_email_changed",
+          to: prev.contactEmail,
+          ...template,
+        });
+        sendMail({
+          emailType: "account.contact_email_changed",
+          to: input.contactEmail,
+          ...template,
+        });
       }
 
       return updated;

--- a/server/trpc/routers/assignment.ts
+++ b/server/trpc/routers/assignment.ts
@@ -13,6 +13,7 @@ import {
   notification,
 } from "@/schema";
 import { verifyAssessmentOwnership, verifyStatusOwnership } from "../guards";
+import { preferenceFooterFor } from "@/lib/mail/footer";
 import {
   sendMail,
   categoryAssignedEmail,
@@ -107,6 +108,8 @@ export const assignmentRouter = router({
           const catName = categoriesEn[category.code as keyof typeof categoriesEn]?.name ?? category.code;
 
           sendMail({
+            emailType: "work.category_assigned",
+            recipientUserId: input.userId,
             to: assignee.email,
             ...categoryAssignedEmail({
               assigneeName: assignee.name,
@@ -115,6 +118,7 @@ export const assignmentRouter = router({
               companyName: companyRow?.name ?? "your company",
               assignerName: ctx.session.user.name ?? "Your admin",
               categoryUrl: `${getAppUrl()}/compliance/${category.slug}`,
+              footer: preferenceFooterFor(input.userId, "work.category_assigned"),
             }),
           }).then((r) => {
             if (r.success) {
@@ -202,12 +206,15 @@ export const assignmentRouter = router({
           const catName = categoriesEn[category.code as keyof typeof categoriesEn]?.name ?? category.code;
 
           sendMail({
+            emailType: "work.category_unassigned",
+            recipientUserId: input.userId,
             to: assignee.email,
             ...categoryUnassignedEmail({
               assigneeName: assignee.name,
               categoryName: catName,
               categoryCode: category.code,
               companyName: companyRow?.name ?? "your company",
+              footer: preferenceFooterFor(input.userId, "work.category_unassigned"),
             }),
           }).then((r) => {
             if (r.success) {

--- a/server/trpc/routers/newsletter.ts
+++ b/server/trpc/routers/newsletter.ts
@@ -113,13 +113,14 @@ function dispatchNewsletter(opts: {
           viewInBrowserUrl,
         });
         sendMail({
+          emailType: "newsletter.issue",
+          recipientUserId: r.id,
           to: r.email,
           subject: email.subject,
           html: email.html,
           text: email.text,
           replyTo: REPLY_TO,
           fromEmail: NEWS_FROM_EMAIL,
-          unsubscribeUrl: unsubUrl,
         }).catch(() => {});
       }
       if (i + BURST_SIZE < recipients.length) {
@@ -476,14 +477,16 @@ export const newsletterRouter = router({
         cta: await resolveEmailCta(input.ctaKey ?? null),
         viewInBrowserUrl: input.slug ? issuePermalink(slugify(input.slug)) : null,
       });
+      // internal.test_send: an admin previewing an issue must receive it even
+      // if they personally unsubscribed from the newsletter.
       const res = await sendMail({
+        emailType: "internal.test_send",
         to,
         subject: email.subject,
         html: email.html,
         text: email.text,
         replyTo: REPLY_TO,
         fromEmail: NEWS_FROM_EMAIL,
-        unsubscribeUrl: unsubUrl,
       });
       if (!res.success) {
         throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Test send failed." });

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -6,38 +6,45 @@
  * (which is company-scoped). This is a platform-level view across
  * ALL companies and users.
  */
-import { desc, count, eq, sql, and, isNotNull, gte, inArray } from "drizzle-orm";
-import { z } from "zod";
-import { randomUUID, randomBytes } from "node:crypto";
-import bcrypt from "bcryptjs";
-import { router, protectedProcedure } from "../init";
+
+import { randomBytes, randomUUID } from "node:crypto";
 import { TRPCError } from "@trpc/server";
+import bcrypt from "bcryptjs";
+import { and, count, desc, eq, gte, inArray, isNotNull, or, sql } from "drizzle-orm";
+import { z } from "zod";
+import { logAudit } from "@/lib/audit";
 import { isPlatformAdmin } from "@/lib/auth/platform-admin";
+import { mailSupportEmail } from "@/lib/env";
+import { answerMapSchema, getGapAssessmentData } from "@/lib/gap-assessment";
+import { computeScores } from "@/lib/gap-assessment/scoring";
 import {
-  user,
+  buildErasureCertificate,
+  erasureCertificateFilename,
+} from "@/lib/gdpr/certificate";
+import { eraseUser, previewUserErasure } from "@/lib/gdpr/erase-user";
+import { runLifecycleEmails } from "@/lib/lifecycle/dispatch";
+import { prepareActivationNudgeSample } from "@/lib/lifecycle/emails/activation-nudge";
+import { LIFECYCLE_ENTITY_TYPE } from "@/lib/lifecycle/types";
+import { loadEmailConsent } from "@/lib/mail/consent";
+import { isSuppressedSendId, sendMail } from "@/lib/mail/send";
+import { HINT_COLUMN, HINTS, resolveHints } from "@/lib/onboarding/hints";
+import { rateLimit } from "@/lib/rate-limit";
+import { COURSE_IDS, loadCourse } from "@/lib/training/course-loader";
+import {
   company,
   companyAssessment,
   companyRequirementStatus,
   complianceFramework,
-  trainingLessonProgress,
-  supplier,
-  notification,
-  gapAssessment,
   dataErasureLog,
+  emailPreference,
+  gapAssessment,
+  notification,
+  supplier,
+  trainingLessonProgress,
+  user,
 } from "@/schema";
-import { computeScores } from "@/lib/gap-assessment/scoring";
-import { getGapAssessmentData, answerMapSchema } from "@/lib/gap-assessment";
-import { loadCourse, COURSE_IDS } from "@/lib/training/course-loader";
-import { logAudit } from "@/lib/audit";
-import { eraseUser, previewUserErasure } from "@/lib/gdpr/erase-user";
-import { buildErasureCertificate, erasureCertificateFilename } from "@/lib/gdpr/certificate";
-import { rateLimit } from "@/lib/rate-limit";
 import { NIS2_FRAMEWORK_CODE } from "../helpers/nis2-scope";
-import { resolveHints, HINTS, HINT_COLUMN } from "@/lib/onboarding/hints";
-import { LIFECYCLE_ENTITY_TYPE } from "@/lib/lifecycle/types";
-import { prepareActivationNudgeSample } from "@/lib/lifecycle/emails/activation-nudge";
-import { isSuppressedSendId, sendMail } from "@/lib/mail/send";
-import { mailSupportEmail } from "@/lib/env";
+import { protectedProcedure, router } from "../init";
 
 /**
  * Sends to one recipient in one UTC day at which the email dashboard flags
@@ -51,7 +58,8 @@ const MULTI_SEND_ALERT_PER_DAY = 3;
 // confusable chars (0, O, I, l, 1) intentionally excluded so the password
 // can be typed without ambiguity. `gitleaks:allow` flags it as a known
 // safe constant so EW-16's scan doesn't trip on the high-entropy alphabet.
-const SHARE_PASSWORD_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789"; // gitleaks:allow
+const SHARE_PASSWORD_ALPHABET =
+  "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789"; // gitleaks:allow
 
 function generateSharePassword(): string {
   const bytes = randomBytes(12);
@@ -176,7 +184,9 @@ export const platformAdminRouter = router({
     // (trainingCertificate.getCourseCompletion): every lesson of the CURRENT
     // course definition completed — hence the lessonId membership filter, so
     // progress on since-removed lessons cannot inflate the count.
-    const ceoLessonIds = (await loadCourse("nis2-ceo")).modules.flatMap((m) => m.lessonIds);
+    const ceoLessonIds = (await loadCourse("nis2-ceo")).modules.flatMap(
+      (m) => m.lessonIds,
+    );
 
     const [
       totalUsersRow,
@@ -189,12 +199,18 @@ export const platformAdminRouter = router({
       ceoStartedRow,
     ] = await Promise.all([
       ctx.db.select({ count: count() }).from(user),
-      ctx.db.select({ count: count() }).from(user).where(gte(user.createdAt, sevenDaysAgo)),
+      ctx.db
+        .select({ count: count() })
+        .from(user)
+        .where(gte(user.createdAt, sevenDaysAgo)),
       ctx.db.select({ count: count() }).from(company),
       // Real orgs = activated (non-draft) companies. Every verified user now
       // auto-gets a draft shell, so a raw company/companyId count no longer
       // measures real activation — filter on activatedAt.
-      ctx.db.select({ count: count() }).from(company).where(isNotNull(company.activatedAt)),
+      ctx.db
+        .select({ count: count() })
+        .from(company)
+        .where(isNotNull(company.activatedAt)),
       ctx.db
         .select({ count: count() })
         .from(user)
@@ -212,9 +228,13 @@ export const platformAdminRouter = router({
           ),
         )
         .groupBy(trainingLessonProgress.userId)
-        .having(sql`count(distinct ${trainingLessonProgress.lessonId}) = ${ceoLessonIds.length}`),
+        .having(
+          sql`count(distinct ${trainingLessonProgress.lessonId}) = ${ceoLessonIds.length}`,
+        ),
       ctx.db
-        .select({ count: sql<number>`count(distinct ${trainingLessonProgress.userId})::int` })
+        .select({
+          count: sql<number>`count(distinct ${trainingLessonProgress.userId})::int`,
+        })
         .from(trainingLessonProgress)
         .where(eq(trainingLessonProgress.courseId, "nis2-ceo")),
     ]);
@@ -315,7 +335,10 @@ export const platformAdminRouter = router({
         notStarted: sql<number>`count(*) FILTER (WHERE ${companyRequirementStatus.status} = 'not_started')::int`,
       })
       .from(companyRequirementStatus)
-      .innerJoin(companyAssessment, eq(companyRequirementStatus.assessmentId, companyAssessment.id))
+      .innerJoin(
+        companyAssessment,
+        eq(companyRequirementStatus.assessmentId, companyAssessment.id),
+      )
       .innerJoin(company, eq(companyAssessment.companyId, company.id))
       // NIS 2 only. Without this the totals read 101 or 103 per company -- the
       // sum of every framework a tenant was ever provisioned -- and understate
@@ -329,7 +352,11 @@ export const platformAdminRouter = router({
         ),
       )
       .groupBy(company.id, company.name)
-      .orderBy(desc(sql`count(*) FILTER (WHERE ${companyRequirementStatus.status} IN ('completed', 'approved'))`));
+      .orderBy(
+        desc(
+          sql`count(*) FILTER (WHERE ${companyRequirementStatus.status} IN ('completed', 'approved'))`,
+        ),
+      );
 
     return rows;
   }),
@@ -474,9 +501,7 @@ export const platformAdminRouter = router({
       ctx.db
         .select({ count: count() })
         .from(notification)
-        .where(
-          and(eq(notification.channel, "email"), eq(notification.status, "sent")),
-        ),
+        .where(and(eq(notification.channel, "email"), eq(notification.status, "sent"))),
       ctx.db
         .select({ count: count() })
         .from(notification)
@@ -506,11 +531,13 @@ export const platformAdminRouter = router({
         .from(notification)
         .leftJoin(user, eq(notification.recipientId, user.id))
         .leftJoin(company, eq(notification.companyId, company.id))
-        .where(
-          and(eq(notification.channel, "email"), eq(notification.status, "sent")),
-        )
+        .where(and(eq(notification.channel, "email"), eq(notification.status, "sent")))
         .orderBy(desc(notification.sentAt))
         .limit(100),
+      // Everyone who has switched something off: the legacy all-off boolean
+      // OR any per-scope row. A person with only scope rows is just as
+      // unsubscribed as one with the boolean, and the admin view has to show
+      // both or the resubscribe button will not find them.
       ctx.db
         .select({
           id: user.id,
@@ -518,10 +545,18 @@ export const platformAdminRouter = router({
           name: user.name,
           companyName: company.name,
           updatedAt: user.updatedAt,
+          allOff: user.emailFollowupsDisabled,
+          scopes: sql<
+            string[]
+          >`COALESCE(array_agg(${emailPreference.scope}) FILTER (WHERE ${emailPreference.scope} IS NOT NULL), '{}')`,
         })
         .from(user)
         .leftJoin(company, eq(user.companyId, company.id))
-        .where(eq(user.emailFollowupsDisabled, true))
+        .leftJoin(emailPreference, eq(emailPreference.userId, user.id))
+        .where(
+          or(eq(user.emailFollowupsDisabled, true), isNotNull(emailPreference.scope)),
+        )
+        .groupBy(user.id, user.email, user.name, company.name, user.updatedAt)
         .orderBy(desc(user.updatedAt)),
       ctx.db
         .select({
@@ -529,9 +564,7 @@ export const platformAdminRouter = router({
           c: count(),
         })
         .from(notification)
-        .where(
-          and(eq(notification.channel, "email"), eq(notification.status, "sent")),
-        )
+        .where(and(eq(notification.channel, "email"), eq(notification.status, "sent")))
         .groupBy(notification.entityType),
       // Daily send volume, last 14 days. sent_at stores UTC wall time, so
       // to_char on the bare column groups by UTC day without timezone math.
@@ -679,10 +712,25 @@ export const platformAdminRouter = router({
     if (!sample) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Calling user not found." });
     }
-    // internal.test_send, not product.lifecycle_nudge: an admin asking to see
-    // the email must get it even if they have switched that message off.
+    // Sent as the REAL message type, so the consent gate applies exactly as it
+    // would to a customer. An earlier version sent this as internal.test_send
+    // to guarantee the admin saw it; that made the test useless as a test —
+    // it delivered to an admin who had unsubscribed, which reads as a broken
+    // unsubscribe rather than as a bypass. Refusing and saying why is more
+    // honest, and the caller can resubscribe themselves in one click.
+    const consent = await loadEmailConsent(ctx.db, ctx.userId);
+    if (!consent.allows("product.lifecycle_nudge")) {
+      return {
+        to: sample.to,
+        sent: false as const,
+        reason: "opted-out" as const,
+        suppressed: false,
+      };
+    }
     const res = await sendMail({
-      emailType: "internal.test_send",
+      emailType: "product.lifecycle_nudge",
+      recipientUserId: ctx.userId,
+      db: ctx.db,
       to: sample.to,
       subject: `[Test] ${sample.subject}`,
       html: sample.html,
@@ -690,12 +738,122 @@ export const platformAdminRouter = router({
       replyTo: mailSupportEmail(),
     });
     if (!res.success) {
-      throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Test send failed." });
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Test send failed.",
+      });
     }
     // res.id carries a sentinel instead of a Resend id when delivery was
     // suppressed (dev block / DISABLE_EMAIL / no API key).
-    return { to: sample.to, suppressed: isSuppressedSendId(res.id) };
+    return {
+      to: sample.to,
+      sent: true as const,
+      reason: null,
+      suppressed: "id" in res ? isSuppressedSendId(res.id) : false,
+    };
   }),
+
+  /**
+   * Who the activation nudge would go to right now, without sending.
+   *
+   * The same selection the sender uses, run in dry-run mode, so the list an
+   * operator approves is the list that ships — not a second implementation
+   * of "who is eligible" that could drift from the first.
+   */
+  lifecycleQueue: platformAdminProcedure.query(async ({ ctx }) => {
+    const result = await runLifecycleEmails(ctx.db, { dryRun: true });
+    if (result.skipped !== undefined) {
+      return { available: false as const, reason: result.skipped, types: [] };
+    }
+    return {
+      available: true as const,
+      reason: null,
+      types: Object.entries(result.types).map(([key, stats]) => ({
+        key,
+        prepared: stats.prepared,
+        error: stats.error ?? null,
+        recipients: (stats.wouldSend ?? []).map((r) => ({
+          to: r.to,
+          subject: r.subject,
+        })),
+      })),
+    };
+  }),
+
+  /**
+   * Send the next `limit` queued lifecycle emails, oldest-dormant first.
+   *
+   * Manual by design: nisd2.eu does not schedule the lifecycle cron, so
+   * nothing leaves the building unless a person presses the button. The
+   * at-most-once claim still guards every recipient, so pressing twice
+   * cannot double-send — the second press simply finds fewer people queued.
+   */
+  sendLifecycleBatch: platformAdminProcedure
+    .input(z.object({ limit: z.number().int().min(1).max(100) }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await runLifecycleEmails(ctx.db, { maxPerType: input.limit });
+      logAudit({
+        companyId: null,
+        userId: ctx.userId,
+        action: "email.lifecycle_batch_sent",
+        entityType: "system",
+        entityId: null,
+        description: `Platform admin sent a lifecycle batch (limit ${input.limit}): ${JSON.stringify(result, (k, v) => (k === "wouldSend" ? undefined : v))}`,
+      });
+      if (result.skipped !== undefined) {
+        return { skipped: result.skipped, sent: 0, failed: 0, deferred: 0 };
+      }
+      const totals = Object.values(result.types).reduce(
+        (acc, s) => ({
+          sent: acc.sent + s.sent,
+          failed: acc.failed + s.failed,
+          deferred: acc.deferred + s.deferred,
+        }),
+        { sent: 0, failed: 0, deferred: 0 },
+      );
+      return { skipped: null, ...totals };
+    }),
+
+  /**
+   * Put somebody back on the list, by hand.
+   *
+   * Clears both switches: the legacy all-off boolean and every per-scope
+   * opt-out row. Anything less would leave a person who looks resubscribed
+   * in the admin view still silently filtered at send time.
+   *
+   * This is an operator override of a recipient's own choice, so it writes an
+   * audit row naming the admin who did it. Use it for people who ask to come
+   * back, not to undo unsubscribes in bulk.
+   */
+  resubscribeUser: platformAdminProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const target = await ctx.db.query.user.findFirst({
+        where: eq(user.id, input.userId),
+        columns: { id: true, email: true, companyId: true },
+      });
+      if (!target) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "User not found." });
+      }
+      await ctx.db
+        .update(user)
+        .set({ emailFollowupsDisabled: false, updatedAt: new Date() })
+        .where(eq(user.id, target.id));
+      const removed = await ctx.db
+        .delete(emailPreference)
+        .where(eq(emailPreference.userId, target.id))
+        .returning({ id: emailPreference.id });
+
+      logAudit({
+        companyId: target.companyId,
+        userId: ctx.userId,
+        action: "email.resubscribed_by_admin",
+        entityType: "user",
+        entityId: target.id,
+        description: `Platform admin resubscribed ${target.email} to all optional email (${removed.length} scope opt-out(s) cleared)`,
+      });
+      return { email: target.email, scopesCleared: removed.length };
+    }),
 
   /** Supplier portal activity — companies acting as suppliers */
   supplierActivity: platformAdminProcedure.query(async ({ ctx }) => {
@@ -743,7 +901,10 @@ export const platformAdminRouter = router({
         })
         .returning({ id: company.id });
       if (!newCompany) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Company insert returned no rows" });
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Company insert returned no rows",
+        });
       }
 
       const [assessment] = await ctx.db
@@ -754,7 +915,10 @@ export const platformAdminRouter = router({
         })
         .returning({ id: gapAssessment.id });
       if (!assessment) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Assessment insert returned no rows" });
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Assessment insert returned no rows",
+        });
       }
 
       return { assessmentId: assessment.id, companyId: newCompany.id };
@@ -795,7 +959,8 @@ export const platformAdminRouter = router({
       if (Object.keys(answers).length === 0) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Cannot publish an assessment with no answers. Fill in at least one question first.",
+          message:
+            "Cannot publish an assessment with no answers. Fill in at least one question first.",
         });
       }
 
@@ -888,7 +1053,8 @@ export const platformAdminRouter = router({
       if (isPlatformAdmin(target.email)) {
         throw new TRPCError({
           code: "FORBIDDEN",
-          message: "Refusing to erase a platform-admin account. Remove them from PLATFORM_ADMIN_EMAILS first.",
+          message:
+            "Refusing to erase a platform-admin account. Remove them from PLATFORM_ADMIN_EMAILS first.",
         });
       }
       if (target.email.trim().toLowerCase() !== input.confirmEmail.trim().toLowerCase()) {

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -26,6 +26,7 @@ import { runLifecycleEmails } from "@/lib/lifecycle/dispatch";
 import { prepareActivationNudgeSample } from "@/lib/lifecycle/emails/activation-nudge";
 import { LIFECYCLE_ENTITY_TYPE } from "@/lib/lifecycle/types";
 import { loadEmailConsent } from "@/lib/mail/consent";
+import { buildDigestQueue, sendDigestBatch } from "@/lib/mail/digest-outbox";
 import { isSuppressedSendId, sendMail } from "@/lib/mail/send";
 import { HINT_COLUMN, HINTS, resolveHints } from "@/lib/onboarding/hints";
 import { rateLimit } from "@/lib/rate-limit";
@@ -812,6 +813,31 @@ export const platformAdminRouter = router({
         { sent: 0, failed: 0, deferred: 0 },
       );
       return { skipped: null, ...totals };
+    }),
+
+  /**
+   * The deadline digests waiting to go out, with the numbers each one would
+   * carry. Same builder the sender uses, so the list is the list.
+   */
+  digestQueue: platformAdminProcedure.query(async ({ ctx }) => {
+    const queue = await buildDigestQueue(ctx.db);
+    return {
+      total: queue.length,
+      items: queue.map((q) => ({
+        kind: q.kind,
+        email: q.email,
+        companyName: q.companyName,
+        subject: q.subject,
+        summary: q.summary,
+      })),
+    };
+  }),
+
+  /** Send the first `limit` queued digests. Manual by design; see the outbox. */
+  sendDigestBatch: platformAdminProcedure
+    .input(z.object({ limit: z.number().int().min(1).max(100) }))
+    .mutation(async ({ ctx, input }) => {
+      return sendDigestBatch(ctx.db, input.limit, ctx.userId);
     }),
 
   /**

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -679,13 +679,15 @@ export const platformAdminRouter = router({
     if (!sample) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Calling user not found." });
     }
+    // internal.test_send, not product.lifecycle_nudge: an admin asking to see
+    // the email must get it even if they have switched that message off.
     const res = await sendMail({
+      emailType: "internal.test_send",
       to: sample.to,
       subject: `[Test] ${sample.subject}`,
       html: sample.html,
       text: sample.text,
       replyTo: mailSupportEmail(),
-      unsubscribeUrl: sample.unsubscribeUrl,
     });
     if (!res.success) {
       throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Test send failed." });

--- a/server/trpc/routers/review.ts
+++ b/server/trpc/routers/review.ts
@@ -13,6 +13,7 @@ import { sendMail, reviewDecisionEmail } from "@/lib/mail";
 import { scheduleDeadlineReminders } from "@/lib/compliance/schedule-notifications";
 import type { Database } from "@/lib/db";
 import { getNis2AssessmentIds } from "../helpers/nis2-scope";
+import { preferenceFooterFor } from "@/lib/mail/footer";
 
 export const reviewRouter = router({
   /** All submission statuses for the reviewer's company */
@@ -328,6 +329,8 @@ async function notifySubmitter(
     const reqTitle = requirementsEn[reqKey]?.title ?? req.code;
 
     sendMail({
+      emailType: "work.review_decision",
+      recipientUserId: status.completedBy,
       to: submitter.email,
       ...reviewDecisionEmail({
         submitterName: submitter.name ?? "",
@@ -335,6 +338,7 @@ async function notifySubmitter(
         requirementTitle: reqTitle,
         decision,
         feedback,
+        footer: preferenceFooterFor(status.completedBy, "work.review_decision"),
       }),
     });
   } catch {

--- a/server/trpc/routers/supplier-invite.ts
+++ b/server/trpc/routers/supplier-invite.ts
@@ -95,6 +95,7 @@ export const supplierInviteRouter = router({
       // best-effort. The supplier could also be given the link directly.
       const inviteUrl = `${getAppUrl()}/supplier-invite/${row.token}`;
       sendMail({
+        emailType: "supplier.invite",
         to: email,
         ...entityInvitesSupplierEmail({
           entityName: entity?.name ?? "A NIS2 entity",

--- a/server/trpc/routers/supplier-portal/broadcast.ts
+++ b/server/trpc/routers/supplier-portal/broadcast.ts
@@ -100,6 +100,9 @@ export async function broadcastIncidentBroadcast(broadcastId: string): Promise<b
   const link = accessUrl(rel.unsubscribeToken);
 
   const result = await sendMail({
+    // External recipient: consent lives with the portal's own token
+    // (supplier.unsubscribedAt), checked when the relationship is selected.
+    emailType: "supplier.incident_broadcast",
     to: rel.customerEmail,
     ...supplierIncidentBroadcastEmail({
       supplierName,
@@ -145,7 +148,7 @@ export async function notifyCustomerAdded(
     profileUrl: link,
     unsubscribeUrl: link,
   });
-  await sendMail({ to: customerEmail, ...email });
+  await sendMail({ emailType: "supplier.added_you", to: customerEmail, ...email });
 }
 
 export async function drainQueuedBroadcasts(): Promise<{

--- a/server/trpc/routers/team.ts
+++ b/server/trpc/routers/team.ts
@@ -216,6 +216,7 @@ export const teamRouter = router({
       const emailRole = input.complianceRole ?? "member";
 
       sendMail({
+        emailType: "account.invite",
         to: email,
         ...inviteEmail({
           companyName: companyRow?.name ?? "your company",
@@ -461,6 +462,7 @@ export const teamRouter = router({
       });
 
       sendMail({
+        emailType: "account.member_removed",
         to: member.email,
         ...memberRemovedEmail({
           companyName: companyRow?.name ?? "your company",


### PR DESCRIPTION
Stacked on #141 (base will retarget to `main` once that merges).

## Why

Today a person has exactly one choice: all soft-touch email, or none (`user.emailFollowupsDisabled`). No message has an identity, nothing enforces the check, and three call sites each re-implement it. As we start sending proactively, that is both a product gap and a legal one — assignment and review-decision emails carried no opt-out link at all.

## The design

**1. A registry of every message we send** (`lib/mail/email-types.ts`). Each entry is the message's identity and declares a consent mode: `essential` (sign-in codes, security notices, account changes — never suppressible), `user` (optional, gated on stored preferences), `external` (supplier-portal mail, owns its own token), `operator` (mail to ourselves). Adding an email means adding a row here first, which is where someone decides whether it can be switched off.

**2. Illegal states made unrepresentable at the transport.** `sendMail`'s options are a discriminated union: an optional message *requires* a `recipientUserId`, because the gate needs an identity, and cannot take a bulk `to`. There is no way to spell a gated send without the data the check needs — "remember to check" stops being a convention and becomes a compile error. Wiring this enumerated and fixed all ~20 send sites; the compiler found them, not me.

**3. The gate runs inside `sendMail`**, not at the call sites. Three sources of no: recipient gone (fail closed), the legacy all-off boolean, or an opt-out row naming `all`, the message's category, or its own type. The digests and course reminders drop their hand-rolled checks and inherit it. The decision itself is pure and unit-tested in `consent-rules.ts`; the I/O lives in `consent.ts`.

**4. Opt-outs are rows, not columns** (`email_preference`). Absence means subscribed, so the table only grows by an explicit act and carries the timestamp proving when consent was withdrawn — the same row-shape-is-the-permission idea the supplier portal uses. Scope is `all` | `category:x` | `type:y`, validated against the registry so an unknown scope is a broken link, not a row that suppresses nothing.

## What recipients get

- A footer on every optional email with two links: switch off *this* message, or open the preference centre. Rendered by the layout, so a new email cannot forget it.
- The RFC 8058 one-click header is now derived from the message type, so the native Unsubscribe button switches off just that kind of mail instead of everything.
- A preference centre at `/email/preferences?u=&t=&lang=`, reachable from any email without signing in, with per-category and per-message switches and an explicit "always sent" section for the essentials.
- Links in already-delivered mail carry no scope, still mean "all", and still work.

## Verification

Migration 0011 is additive (one new table, no changes to existing rows). `bun run typecheck` clean; 203 unit + 120 l0 tests pass, including with `.env` removed; migration checks green.

## Not in this PR

The "delete all my data" button (deliberately deferred), and an in-app settings tab for signed-in users — the preference centre is reachable from any email today.