### PR TITLE
fix(guidance): four wrong legal claims, and the guard holes that hid them

### DIFF
--- a/data/guidance/de.json
+++ b/data/guidance/de.json
@@ -50,10 +50,10 @@
     }
   },
   "1.4": {
-    "summary": "Jedes Mitglied Ihrer Geschäftsführung muss eine persönliche Erklärung zur Haftung für Cybersicherheitsmaßnahmen unterschreiben. Sie sind fertig, wenn alle aktuellen Geschäftsführer das individuell bestätigt haben. Die Plattform trackt das pro Person.",
+    "summary": "§38(1) BSIG verpflichtet die Geschäftsleitung, die Risikomanagementmaßnahmen umzusetzen und ihre Umsetzung zu überwachen. §38(2) knüpft daran die Haftung: Wer diese Pflicht verletzt, haftet der eigenen Einrichtung für den schuldhaft verursachten Schaden nach dem Gesellschaftsrecht. Eine gesetzlich vorgeschriebene Unterschrift gibt es dafür nicht. Diese Plattform lässt jedes Mitglied einzeln bestätigen, dass es die Pflicht kennt, damit die Überwachung nach §38(1) belegt ist. Sie sind fertig, wenn alle aktuellen Mitglieder bestätigt haben.",
     "applicability": "Das müssen alle Mitglieder der Geschäftsführung machen; andere Mitarbeiter können das überspringen.",
     "quickTip": "Sammeln Sie zuerst die Namen aller aktuellen Geschäftsführer und schicken Sie ihnen den Link zur Plattform zum Unterschreiben.",
-    "implementationSteps": "Listen Sie alle aktuellen Mitglieder der Geschäftsführung auf.\nLassen Sie jedes Mitglied individuell die Haftungserklärung auf der Plattform unterschreiben.\nErklären Sie ihnen klar: Sie haften persönlich für Cybersicherheit, das kann der Arbeitgeber nicht abwälzen, und Verstöße können Bußgelder bis 500.000 € nach sich ziehen.\nÜberprüfen Sie auf der Plattform, ob alle bestätigt haben.\nWiederholen Sie das, wenn sich die Geschäftsführung ändert.",
+    "implementationSteps": "Listen Sie alle aktuellen Mitglieder der Geschäftsführung auf.\nLassen Sie jedes Mitglied einzeln auf der Plattform bestätigen, dass es die Pflicht aus §38(1) kennt.\nErklären Sie den Unterschied: §38(2) begründet eine Haftung gegenüber der eigenen Einrichtung nach Gesellschaftsrecht. Die Bußgelder in §65 BSIG richten sich dagegen an die Einrichtung, nicht an die einzelne Person.\nÜberprüfen Sie auf der Plattform, ob alle bestätigt haben.\nWiederholen Sie das, wenn sich die Geschäftsführung ändert.",
     "evidenceExample": "Individuelle Bestätigungen jedes Geschäftsführers auf der Plattform, die zeigen, dass sie die persönliche Haftung für Cybersicherheitsmaßnahmen verstanden und anerkannt haben.",
     "fields": {
       "liabilityAcknowledged": {
@@ -323,10 +323,10 @@
     }
   },
   "3.5": {
-    "summary": "Nach jedem großen Vorfall führen Sie innerhalb von zwei Wochen eine strukturierte Nachbesprechung durch und dokumentieren Ursache, Ablauf, was gut lief und was nicht, sowie konkrete Verbesserungen mit Verantwortlichen und Fristen. Sie erstellen zudem genehmigte Vorlagen für die Kommunikation an Kunden und Öffentlichkeit, die erklären, was passiert ist, welche Daten betroffen sind und was zu tun ist.",
+    "summary": "Nach jedem großen Vorfall führen Sie eine strukturierte Nachbesprechung durch, innerhalb einer Frist, die Sie selbst festlegen (CIR 3.6 verlangt die Nachbesprechung, nennt aber keine Frist) und dokumentieren Ursache, Ablauf, was gut lief und was nicht, sowie konkrete Verbesserungen mit Verantwortlichen und Fristen. Sie erstellen zudem genehmigte Vorlagen für die Kommunikation an Kunden und Öffentlichkeit, die erklären, was passiert ist, welche Daten betroffen sind und was zu tun ist.",
     "applicability": "Jedes Unternehmen, das kritische Vorfälle haben kann, muss das machen. Kleine Firmen ohne Vorfälle in der Vergangenheit können es erst bei Bedarf einrichten.",
     "quickTip": "Schauen Sie in Ihrem IT-Team nach, wer schon mal einen Vorfall bearbeitet hat, und fragen Sie die Person, ob sie die Nachbesprechungen leiten kann.",
-    "implementationSteps": "Richten Sie einen Prozess ein, dass nach jedem großen Vorfall innerhalb von 2 Wochen eine Nachbesprechung stattfindet.\nDokumentieren Sie in einem Bericht: Ursache, vollständigen Zeitverlauf, was gut und schlecht lief, und Verbesserungsmaßnahmen mit Verantwortlichen und Fristen.\nErstellen Sie Vorlagen für Kunden- und Öffentlichkeitsmitteilungen, die abdecken: Was passiert ist, betroffene Daten, Ihre Maßnahmen und Tipps für Empfänger.\nLassen Sie Vorlagen vom Vorstand oder der Geschäftsleitung genehmigen.\nFüttern Sie alle Verbesserungen in Ihren Plan für kontinuierliche Verbesserungen ein.",
+    "implementationSteps": "Richten Sie einen Prozess ein, dass nach jedem großen Vorfall eine Nachbesprechung stattfindet, und legen Sie die Frist dafür selbst fest.\nDokumentieren Sie in einem Bericht: Ursache, vollständigen Zeitverlauf, was gut und schlecht lief, und Verbesserungsmaßnahmen mit Verantwortlichen und Fristen.\nErstellen Sie Vorlagen für Kunden- und Öffentlichkeitsmitteilungen, die abdecken: Was passiert ist, betroffene Daten, Ihre Maßnahmen und Tipps für Empfänger.\nLassen Sie Vorlagen vom Vorstand oder der Geschäftsleitung genehmigen.\nFüttern Sie alle Verbesserungen in Ihren Plan für kontinuierliche Verbesserungen ein.",
     "evidenceExample": "Ein Bericht über eine Nachbesprechung, der Ursachenanalyse, Zeitlinie, Erfolge und Misserfolge sowie zugewiesene Verbesserungsmaßnahmen mit Fristen zeigt, plus genehmigte Vorlagen für Kundenmitteilungen, die den Vorfall, betroffene Daten und nächsten Schritte beschreiben.",
     "fields": {
       "postIncidentReviewOwner": {
@@ -657,7 +657,7 @@
     "fields": {}
   },
   "6.5": {
-    "summary": "Ihr Unternehmen braucht einen formalen Change-Management-Prozess, der Risikobewertung vor Änderungen, Tests vor Produktivnahme und nachträgliche Dokumentation von Notfalländerungen umfasst. Diese drei Kontrollen sind nach CIR 6(4) verpflichtend. Sie sind fertig, wenn der Prozess dokumentiert ist und Änderungen getrackt werden.",
+    "summary": "Ihr Unternehmen braucht einen formalen Change-Management-Prozess, der Risikobewertung vor Änderungen, Tests vor Produktivnahme und nachträgliche Dokumentation von Notfalländerungen umfasst. Diese drei Kontrollen stehen in CIR Anhang Nr. 6.4 (Änderungsmanagement, Reparatur und Wartung). Sie sind fertig, wenn der Prozess dokumentiert ist und Änderungen getrackt werden.",
     "applicability": "Jedes Unternehmen mit kritischen IT-Systemen muss das umsetzen; kleine Firmen ohne IT-Änderungen können es überspringen.",
     "quickTip": "Sprechen Sie mit Ihrem IT-Leiter: Welches Tool nutzen Sie schon für Änderungsanfragen?",
     "implementationSteps": "Nennen Sie Ihr Change-Tracking-Tool im Intake-Feld.\nStellen Sie sicher, dass Ihr Prozess die drei CIR 6(4)-Pflichtkontrollen abdeckt: Risikobewertung vor Änderungen, Tests vor Produktivnahme, nachträgliche Dokumentation von Notfalländerungen.\nErfassen Sie Änderungen im Änderungsregister mit vollständigem Lebenszyklus (Entwurf → genehmigt → umgesetzt).\nÜberprüfen Sie die Änderungshistorie vierteljährlich.",
@@ -982,7 +982,7 @@
     "summary": "Dokumentieren Sie Ihre unternehmensweiten Prozesse für den Mitarbeiter-Lifecycle (Eintritt, Versetzung, Austritt) und Ihr Privileged Access Management. Sie sind fertig, wenn Tools, Hintergrundprüfungen und PAM-Ansatz dokumentiert sind.",
     "applicability": "Jedes Unternehmen mit Mitarbeitern braucht JML-Prozesse; PAM-Tooling ist nötig bei Admin- oder Service-Accounts.",
     "quickTip": "Fragen Sie HR: 'Was passiert, wenn jemand anfängt oder aufhört?' Fragen Sie IT: 'Welches Tool verwaltet Admin-Accounts?'",
-    "implementationSteps": "Dokumentieren Sie Ihren Joiner-Mover-Leaver-Prozess mit Checklisten.\nBenennen Sie die verwendeten Tools (HR-System, Ticketing, Tabelle).\nDefinieren Sie den Umfang der Hintergrundprüfungen gemäß CIR Art. 10.\nBenennen Sie Ihr PAM-Tool oder Ihren Ansatz.\nLassen Sie die Prozesse von der Geschäftsleitung genehmigen.",
+    "implementationSteps": "Dokumentieren Sie Ihren Joiner-Mover-Leaver-Prozess mit Checklisten.\nBenennen Sie die verwendeten Tools (HR-System, Ticketing, Tabelle).\nDefinieren Sie den Umfang der Hintergrundprüfungen nach CIR Anhang Nr. 10 (Personalsicherheit).\nBenennen Sie Ihr PAM-Tool oder Ihren Ansatz.\nLassen Sie die Prozesse von der Geschäftsleitung genehmigen.",
     "evidenceExample": "Dokumentation des JML-Prozesses mit Checklisten, PAM-Tool-Konfiguration und Hintergrundprüfungsrichtlinie.",
     "fields": {
       "jmlTool": {
@@ -1114,10 +1114,10 @@
     }
   },
   "12.1": {
-    "summary": "Ihre Firma prüft, ob sie unter NIS2 fällt, und klassifiziert sich als 'wesentlich', 'wichtig' oder verpflichtet. Sie sind fertig, wenn Sie das schriftlich dokumentiert haben mit Sektoren, Größe und Begründung.",
-    "applicability": "Jede Firma mit 50+ Mitarbeitern oder 10 Mio. € Umsatz in kritischen Sektoren muss das machen. Kleinere oder nicht betroffene können es überspringen.",
+    "summary": "Ihre Firma prüft, ob sie unter NIS2 fällt, und klassifiziert sich nach §28 BSIG als 'besonders wichtige Einrichtung', 'wichtige Einrichtung' oder als nicht betroffen. Sie sind fertig, wenn Sie das schriftlich dokumentiert haben mit Sektoren, Größe und Begründung.",
+    "applicability": "Betroffen ist, wer in einem Sektor der Anlagen 1 oder 2 tätig ist und die Größenschwellen des §28 BSIG erreicht. Achtung auf das \"und\": mindestens 50 Mitarbeiter ODER Jahresumsatz und Jahresbilanzsumme von jeweils über 10 Millionen Euro. Umsatz allein genügt nicht.",
     "quickTip": "Schauen Sie zuerst Ihre Mitarbeiterzahl und Umsatz der letzten zwei Jahre an, und vergleichen Sie mit den NIS2-Sektoren.",
-    "implementationSteps": "1. Listen Sie auf, in welchen Branchen (Sektoren) Ihre Firma arbeitet, z.B. Energie oder Gesundheit.\n2. Prüfen Sie Größe: Mindestens 50 Mitarbeiter oder 10 Mio. € Umsatz?\n3. Bestimmen Sie die Klassifizierung: wesentlich (250+ MA oder 50 Mio. €), wichtig (50+ MA oder 10 Mio. €) oder verpflichtet.\n4. Schreiben Sie alles in ein Dokument mit Begründung und Gesetzesstellen aus §28 BSIG.\n5. Lassen Sie es vom Vorstand oder Rechtsberater prüfen.",
+    "implementationSteps": "1. Listen Sie auf, in welchen Branchen (Sektoren) Ihre Firma arbeitet, z.B. Energie oder Gesundheit.\n2. Prüfen Sie die Größe nach §28 BSIG: mindestens 50 Mitarbeiter, oder Jahresumsatz UND Jahresbilanzsumme von jeweils über 10 Millionen Euro.\n3. Bestimmen Sie die Einstufung nach §28 BSIG: besonders wichtige Einrichtung (mindestens 250 Mitarbeiter, oder Jahresumsatz über 50 Millionen Euro UND Jahresbilanzsumme über 43 Millionen Euro), wichtige Einrichtung (mindestens 50 Mitarbeiter, oder Umsatz und Bilanzsumme jeweils über 10 Millionen Euro), oder nicht betroffen.\n4. Schreiben Sie alles in ein Dokument mit Begründung und Gesetzesstellen aus §28 BSIG.\n5. Lassen Sie es vom Vorstand oder Rechtsberater prüfen.",
     "evidenceExample": "Ein internes Dokument, das Ihre Sektoren, Firmengröße, Klassifizierung und die rechtliche Begründung mit Verweisen auf §28 BSIG zeigt.",
     "fields": {
       "entityClassification": {

--- a/data/guidance/en.json
+++ b/data/guidance/en.json
@@ -50,10 +50,10 @@
     }
   },
   "1.4": {
-    "summary": "Your company's management board members must each personally confirm they understand their personal liability for cybersecurity failures. You're done when every board member has signed off individually on the platform.",
+    "summary": "§38(1) BSIG obliges the management board to implement the risk-management measures and supervise that implementation. §38(2) attaches liability to that: a member who breaches the duty is liable to their own entity for culpably caused damage, under company law. No statute requires a signature for this. This platform has each member confirm individually that they know the duty, so the §38(1) supervision is evidenced. You're done when every current member has confirmed.",
     "applicability": "Every member of the management board must do this; other employees can skip it.",
     "quickTip": "List out all your current management board members and have the first one log in to sign the acknowledgment.",
-    "implementationSteps": "List all current members of your management board.\nHave each one log into the platform and review the liability info.\nGet each to click 'acknowledge' or sign digitally, do it one by one.\nCheck the platform shows all as confirmed.\nSet a reminder to re-do this if your board changes.",
+    "implementationSteps": "List all current members of your management board.\nHave each one log into the platform and review the liability info.\nHave each confirm individually that they know the duty under §38(1).\nCheck the platform shows all as confirmed.\nSet a reminder to re-do this if your board changes.",
     "evidenceExample": "Screenshot or platform record showing each management board member's name, date, and confirmation that they personally acknowledged their liability for cybersecurity.",
     "fields": {
       "liabilityAcknowledged": {
@@ -323,10 +323,10 @@
     }
   },
   "3.5": {
-    "summary": "After every major security incident, hold a review meeting within 2 weeks to figure out what went wrong and how to fix it. Document the lessons learned and create ready-to-use message templates for telling customers and the public what happened.",
+    "summary": "After every major security incident, hold a review meeting within a deadline you set yourself (CIR 3.6 requires the review but names no deadline) to figure out what went wrong and how to fix it. Document the lessons learned and create ready-to-use message templates for telling customers and the public what happened.",
     "applicability": "Every company handling this requirement must assign someone to lead these reviews; smaller companies without incidents yet still need to name a responsible person.",
     "quickTip": "Pick one trusted person on your team to own these reviews and jot down their name and role right now.",
-    "implementationSteps": "Choose one person to lead post-incident reviews and write down their name and contact info.\nSet up a simple review process: meet within 2 weeks after an incident ends, cover what caused it, timeline, what worked or failed, and fix actions with deadlines and owners.\nCreate message templates ahead of time for customers and public notices, including what happened, data affected, your response, and their next steps.\nAfter each review, add the improvement actions to your company's to-do list for fixes.\nTest the process once by doing a fake incident review with your team.",
+    "implementationSteps": "Choose one person to lead post-incident reviews and write down their name and contact info.\nSet up a simple review process: meet within your own deadline after an incident ends, cover what caused it, timeline, what worked or failed, and fix actions with deadlines and owners.\nCreate message templates ahead of time for customers and public notices, including what happened, data affected, your response, and their next steps.\nAfter each review, add the improvement actions to your company's to-do list for fixes.\nTest the process once by doing a fake incident review with your team.",
     "evidenceExample": "A document showing the review process details, including who leads it, what gets covered in reviews, sample communication templates, and how actions feed into improvements.",
     "fields": {
       "postIncidentReviewOwner": {
@@ -657,7 +657,7 @@
     "fields": {}
   },
   "6.5": {
-    "summary": "Your company must have a formal change management process covering risk assessment before changes, testing before production, and retroactive documentation of emergency changes. These three controls are mandatory under CIR 6(4). You're done when you have a documented process and are tracking changes.",
+    "summary": "Your company must have a formal change management process covering risk assessment before changes, testing before production, and retroactive documentation of emergency changes. These three controls sit in CIR Annex point 6.4 (change management, repairs and maintenance). You're done when you have a documented process and are tracking changes.",
     "applicability": "Every company with IT or OT systems that could affect critical operations needs this; small firms without complex systems might use a simple spreadsheet version.",
     "quickTip": "Talk to your IT team about how they currently handle updates or changes to systems. That's your starting point.",
     "implementationSteps": "Name your change tracking tool in the intake field below.\nEnsure your process covers the three CIR 6(4) mandatory controls: risk assessment before changes, testing before production, and retroactive documentation of emergency changes.\nTrack actual changes in the change register with full lifecycle (draft → approved → implemented).\nReview change history quarterly for patterns.",
@@ -982,7 +982,7 @@
     "summary": "Document your company-wide processes for managing user access throughout the employee lifecycle (joining, moving roles, leaving) and how you handle privileged/admin accounts. You're done when you've named your tools, defined background check scope, and identified your PAM approach.",
     "applicability": "Every company with employees needs JML processes; PAM tooling is needed if you have any admin or service accounts.",
     "quickTip": "Ask HR: 'What happens when someone starts or leaves?' Ask IT: 'What tool manages admin accounts?'",
-    "implementationSteps": "Document your joiner-mover-leaver process: onboarding checklist, role change procedure, offboarding steps.\nName the tool(s) used to track JML (HR system, ticketing, spreadsheet).\nDefine background check scope per CIR Art. 10 (all employees, security roles, management).\nName your PAM tool or approach for admin account management.\nGet management approval for the documented processes.",
+    "implementationSteps": "Document your joiner-mover-leaver process: onboarding checklist, role change procedure, offboarding steps.\nName the tool(s) used to track JML (HR system, ticketing, spreadsheet).\nDefine background check scope per CIR Annex point 10 (human resources security), covering all employees, security roles and management.\nName your PAM tool or approach for admin account management.\nGet management approval for the documented processes.",
     "evidenceExample": "A document describing your JML process with checklists, your PAM tool configuration, and background check policy, uploaded as evidence or maintained in the platform's policy module.",
     "fields": {
       "jmlTool": {
@@ -1114,10 +1114,10 @@
     }
   },
   "12.1": {
-    "summary": "Figure out if your company falls under NIS2 rules by checking your sector and size, then classify it as essential, important, or required. You're done when you have a written document explaining your classification with legal reasons.",
+    "summary": "Figure out if your company falls under NIS2 rules by checking your sector and size, then classify it under §28 BSIG as a 'besonders wichtige Einrichtung' (essential), a 'wichtige Einrichtung' (important), or out of scope. You're done when you have a written document explaining your classification with legal reasons.",
     "applicability": "Managers at companies in key sectors like energy, transport, or health with 50+ employees or certain revenue need this; smaller companies outside those sectors can skip it.",
     "quickTip": "List what your company does and check if it matches the critical sectors in NIS2 Annex I or II.",
-    "implementationSteps": "List the sectors your company works in, like energy or banking.\nCheck your employee count and revenue against the thresholds: 250+ employees or €50M+ revenue for essential, 50+ for important.\nPick your classification: essential (high risk), important (medium risk), or required (special cases).\nWrite a short document explaining your sector, size, why you chose that class, and cite §28 BSIG.\nGet your legal team or external lawyer to review it if unsure.",
+    "implementationSteps": "List the sectors your company works in, like energy or banking.\nCheck your size against §28 BSIG, and note the \"and\": besonders wichtig means at least 250 employees, or annual turnover over 50 million euro AND a balance sheet total over 43 million euro. Wichtig means at least 50 employees, or turnover and balance sheet total each over 10 million euro. Turnover on its own is not enough.\nPick your classification: essential (high risk), important (medium risk), or required (special cases).\nWrite a short document explaining your sector, size, why you chose that class, and cite §28 BSIG.\nGet your legal team or external lawyer to review it if unsure.",
     "evidenceExample": "A document that lists your company's sectors, employee count, revenue, chosen classification, and legal reasons why it fits under §28 BSIG.",
     "fields": {
       "entityClassification": {

--- a/e2e/l0/guidance-numbers.test.ts
+++ b/e2e/l0/guidance-numbers.test.ts
@@ -34,9 +34,37 @@ const PROSE_FIELDS = [
   "evidenceExample",
 ] as const;
 
-/** A quantity with a unit — the shape a threshold claim takes. */
-const QUANTITY =
-  /\d[\d.,]*\s*(Stunden|Stunde|Tage|Tagen|Monate|Monaten|Jahre|Jahren|%|Prozent|EUR|Euro|hours|hour|days|day|months|month|years|year|percent)/gi;
+/**
+ * A quantity with a unit — the shape a threshold claim takes.
+ *
+ * Digits alone were not enough. The first version of this test matched only
+ * `\d`, and a follow-up factcheck found two claims it had waved through: a
+ * post-incident review due "innerhalb von zwei Wochen" (spelled out) and a
+ * "Bußgelder bis 500.000 €" (currency symbol rather than the word "Euro").
+ * Both were wrong. Number words and currency symbols are in the pattern now.
+ */
+const NUMBER = String.raw`(?:\d[\d.,]*|ein|eine|einem|einer|zwei|drei|vier|fünf|sechs|sieben|acht|neun|zehn|zwölf|one|two|three|four|five|six|seven|eight|nine|ten|twelve)`;
+const UNIT = String.raw`(?:Stunden?|Tage[n]?|Wochen?|Monate[n]?|Jahre[n]?|Prozent|EUR|Euro|hours?|days?|weeks?|months?|years?|percent)`;
+/** Scale words that sit between the figure and its currency: "10 Mio. €". */
+const SCALE = String.raw`(?:\s*(?:Mio\.?|Mrd\.?|Millionen|Milliarden|million|billion|M|k))?`;
+const QUANTITY = new RegExp(
+  // "3 Jahre", "zwei Wochen", "50 %", "10 Mio. €", "€50M", "500.000 €".
+  // The trailing \b matters: without it "einem Jahresplan" reads as "einem Jahre".
+  String.raw`\b${NUMBER}\s*(?:${UNIT})\b|\b${NUMBER}${SCALE}\s*[%€$£]|[%€$£]\s*${NUMBER}${SCALE}`,
+  "gi",
+);
+
+/**
+ * Compare on a normalised form so a German dative or an English plural does
+ * not need its own allowlist entry: "90 Tagen" is the same claim as "90 Tage".
+ */
+function normalise(quantity: string): string {
+  return quantity
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[ns]$/, "");
+}
 
 /**
  * Numbers allowed to appear in a requirement's guidance, and why.
@@ -49,6 +77,30 @@ const QUANTITY =
  * A number with no entry here is a claim nobody has checked.
  */
 const ALLOWED: Record<string, { values: string[]; why: string }> = {
+  "1.1": {
+    values: ["drei Jahre", "three years"],
+    why: "This platform's own default review interval, and the sentence says so: §38(3) BSIG says 'regelmäßig' and the text tells the reader to set and justify their own.",
+  },
+  "12.1": {
+    values: [
+      "50 Millionen Euro",
+      "43 Millionen Euro",
+      "10 Millionen Euro",
+      "50 million euro",
+      "43 million euro",
+      "10 million euro",
+      "zwei Jahre",
+    ],
+    why: "§28 BSIG size thresholds, verbatim. Note the conjunction: turnover AND balance-sheet total, not either. The two-year look-back is the practical instruction for reading your own figures.",
+  },
+  "12.3": {
+    values: ["zwei Wochen", "2 Wochen", "two weeks"],
+    why: "§33(5) BSIG: changes to registration data go to the BSI 'unverzüglich, spätestens jedoch binnen zwei Wochen'. Verbatim in the statute.",
+  },
+  "7.1": {
+    values: ["one month"],
+    why: "Suggests piloting the KPI dashboard for a month before fixing it. A trial period, not a duty.",
+  },
   "3.1": {
     values: ["24 hours", "72 hours", "1 month"],
     why: "§32(1) BSIG: Erstmeldung 24h, Meldung 72h, Abschlussmeldung one month. Verbatim in the statute.",
@@ -128,7 +180,8 @@ describe("every number in the rendered guidance is accounted for", () => {
             `or it was invented and belongs out of the guidance.`,
         ).toBeDefined();
 
-        const unlisted = quantities.filter((q) => !allowed.values.includes(q));
+        const permitted = new Set(allowed.values.map(normalise));
+        const unlisted = quantities.filter((q) => !permitted.has(normalise(q)));
         expect(
           unlisted,
           `${code} (${locale}) states ${unlisted.join(", ")}, which ALLOWED does not cover. ${allowed?.why ?? ""}`,


### PR DESCRIPTION
Follow-up to #142. That PR fixed the guidance numbers; this one reads the **claims** against the law each requirement actually cites. Four are wrong, all verified against gesetze-im-internet and EUR-Lex rather than our own surfaces.

## 1.4 invented a signing duty, and mis-stated the penalty

> "Jedes Mitglied Ihrer Geschäftsführung **muss eine persönliche Erklärung zur Haftung unterschreiben**."

§38(2) BSIG creates no signature. It reads: a management member who breaches §38(1) *"haftet ihrer Einrichtung für einen schuldhaft verursachten Schaden nach den auf die Rechtsform der Einrichtung anwendbaren Regeln des Gesellschaftsrechts"*. That is civil liability to the company, not a form to sign. The platform's per-person acknowledgement is **our** control for evidencing the §38(1) supervision duty, and the text now says that instead of implying a statutory signature.

The same steps then told the reader: *"Verstöße können Bußgelder bis 500.000 € nach sich ziehen."* The figure is real but attaches, under §65 BSIG, to specific violations **by the entity** (Abs. 2 Nr. 1c, 6, 8, 12–16 and Abs. 4). Different instrument from §38(2) civil liability, different addressee. Replaced with the distinction itself — which is the thing a Geschäftsführer actually needs to understand. It was also fear-based, which our voice rules rule out.

## 12.1 understated the scope threshold

> "50+ Mitarbeitern **oder** 10 Mio. € Umsatz" … "wesentlich (250+ MA **oder** 50 Mio. €)"

§28 BSIG uses **"und"**: at least 250 employees, *or* annual turnover over 50 million **and** a balance-sheet total over 43 million. Wichtig is at least 50 employees, *or* turnover and balance sheet **each** over 10 million.

A company with €51M turnover and a €20M balance sheet would have read our guidance and classified itself as besonders wichtig when it is not. Scoping errors are the most consequential kind here — they decide whether the regime applies at all, and at which tier. Also swapped "wesentlich" for the BSIG's own "besonders wichtige Einrichtung".

## 10.3 and 6.5 cited the wrong instrument level

"CIR Art. 10" and "CIR 6(4)". The Regulation's Articles are a short list and there is no Article 10 — these are **Annex points**: 10 is "Human resources security", 6.4 is "Change management, repairs and maintenance". Our own framework data already draws this distinction, reserving `CIR Art. N` for real Articles like `CIR Art. 4`. Same class as the Art. 27-for-Art. 3(4) mix-up the deck retro was written about: right idea, wrong instrument, and an auditor looking it up finds nothing.

## 3.5 invented a two-week review deadline

CIR 3.6 requires the post-incident review and names no clock. Handed back to the reader.

## Three holes in the guard from #142

Each was found by a claim that walked straight through it:

- It matched **digits only**, so "innerhalb von zwei Wochen" was invisible. Number words are in the pattern now.
- It matched the word "Euro" but not the **symbol**, so "500.000 €" was invisible. Currency symbols and scale words ("10 Mio. €") now match.
- A missing word boundary read "einem **Jahres**plan" as a quantity. Fixed, and allowlist comparison now normalises German dative and English plural, so "90 Tagen" no longer needs its own entry next to "90 Tage".

Newly allowlisted **with citations**: the §28 size thresholds, §33(5)'s two-week change notification (genuinely in the statute — a good reminder that banning numbers outright would be wrong), this platform's own three-year training default, and a one-month dashboard trial.

## What this does not cover

The guard catches numbers and the three named fabrications. It does **not** catch a wrong article reference or an inverted duty — all four content errors above were found by reading, not by the test. The remaining ~37 requirements' prose has now had one pass, but "one pass by one reader" is the honest description of its assurance level.

160 unit / 207 l0 / 108 e2e green.
