### PR TITLE
Let people reach the preference centre without signing in

### DIFF
--- a/e2e/l0/email-links-public.test.ts
+++ b/e2e/l0/email-links-public.test.ts
@@ -1,0 +1,45 @@
+/**
+ * L0: the pages people reach FROM an email are reachable without signing in.
+ *
+ * These pages carry their credential in the URL (an HMAC token), not in a
+ * cookie, because they are opened from a mail client by someone who may have
+ * no account session and, in the unsubscribe case, may be actively trying to
+ * stop hearing from us. Behind the default-deny gate they redirect to
+ * /auth/signin, which for an unsubscribe surface is worse than a dead link:
+ * it reads as being made to log in before you are allowed to leave, which is
+ * both a bad look and a consent problem.
+ *
+ * That is not hypothetical. /email/preferences shipped to production missing
+ * from the bypass list and 307'd to the sign-in page; /email/unsubscribed,
+ * added earlier, was in the list and worked. Nothing caught it, because the
+ * browser suite signs in before it does anything and so never sees the
+ * signed-out path. This test reads the allowlist itself.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const proxySource = readFileSync(join(import.meta.dir, "../../proxy.ts"), "utf8");
+
+/**
+ * Every page whose only credential is a token in the URL. Add a new one here
+ * at the same time as you add its route, and this test tells you if you
+ * forgot the proxy.
+ */
+const EMAIL_LINK_PAGES = ["/email/unsubscribed", "/email/preferences"] as const;
+
+describe("email-link landing pages bypass the auth gate", () => {
+  for (const path of EMAIL_LINK_PAGES) {
+    test(`${path} is in the proxy bypass list`, () => {
+      expect(proxySource).toContain(`pathname.startsWith("${path}")`);
+    });
+  }
+
+  test("the bypass list is checked before the default-deny gate", () => {
+    const bypassAt = proxySource.indexOf('pathname.startsWith("/email/');
+    const denyAt = proxySource.indexOf("Default-deny");
+    expect(bypassAt).toBeGreaterThan(-1);
+    expect(denyAt).toBeGreaterThan(-1);
+    expect(bypassAt).toBeLessThan(denyAt);
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -324,7 +324,14 @@ async function route(request: NextRequest) {
     pathname.startsWith("/docs/") ||
     pathname.startsWith("/.well-known/") ||
     pathname.startsWith("/pitch-preview") ||
+    // Both email-link landing pages, and for the same reason: they are opened
+    // from a mail client with no session, and their credential is the HMAC
+    // token in the URL rather than a cookie. Sending them through the
+    // default-deny gate redirects the reader to a sign-in screen, which for
+    // an unsubscribe surface is worse than a dead link — it reads as being
+    // made to create an account in order to stop receiving email.
     pathname.startsWith("/email/unsubscribed") ||
+    pathname.startsWith("/email/preferences") ||
     pathname === "/sitemap.xml" ||
     pathname === "/robots.txt" ||
     pathname === "/site.webmanifest"


### PR DESCRIPTION
Hotfix for #143, which is already deployed.

`/email/preferences` was missing from the proxy bypass list, so the default-deny gate redirects it to `/auth/signin`. Verified on production right now:

```
/email/preferences?u=…&t=…  ->  307  https://nisd2.eu/auth/signin?callbackUrl=%2Femail%2Fpreferences
/email/unsubscribed         ->  200
```

The page is designed to be opened from an email by someone with no session — its credential is the HMAC token in the URL, not a cookie. For an unsubscribe surface the redirect is worse than a dead link: it reads as being made to create an account before you're allowed to stop receiving email.

Its older sibling `/email/unsubscribed` was already in the list and works, which is why nothing looked wrong in review.

**Why nothing caught it:** the Playwright suite signs in during setup and never walks the signed-out path, and no test read the allowlist. The new `e2e/l0/email-links-public.test.ts` does exactly that — it asserts every email-link landing page appears in the bypass list, ahead of the default-deny gate. Mutation-checked: with the proxy line removed the test fails (1 fail / 215 pass), with it present the suite is green (216 pass).

typecheck clean, l0 216 pass.