### PR TITLE
Email console: per-row sends, previews, digest tests, honest graph

### DIFF
--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -413,6 +413,97 @@ function SendTestNudgeButton() {
 }
 
 /**
+ * One-paragraph TLDR per email type, shown under the queue titles so the
+ * operator knows what a row will actually put in someone's inbox without
+ * opening the template code.
+ */
+const EMAIL_TYPE_DESCRIPTIONS: Record<string, string> = {
+  activation_nudge_v1:
+    "A short, personal re-engagement mail (plain style, sent from a person, not a noreply). Goes to verified users who signed up, did a step or two, and have been quiet for 2+ days. Names their real progress (X of 49 requirements done) and the one concrete next step, links to their journey. German, English or Dutch by stored locale. Once ever per person.",
+  daily:
+    "Daily digest: the recipient's own overdue, urgent and upcoming requirement deadlines in their company, as a short list with a dashboard link. Recurs, at most one per person per UTC day, only when there is something to report.",
+  weekly:
+    "Weekly management report: compliance percentage, overdue and escalation counts across the whole framework. Goes to admins and management members only. Recurs, at most one per person per UTC day.",
+};
+
+type PreviewTemplate = "activation-nudge" | "daily-digest" | "weekly-digest";
+
+/** Opens the rendered template in a new tab, exactly as the send would render it. */
+function PreviewEmailButton({ template }: { template: PreviewTemplate }) {
+  const utils = trpc.useUtils();
+  const [loading, setLoading] = useState(false);
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={loading}
+      onClick={async () => {
+        setLoading(true);
+        try {
+          const r = await utils.platformAdmin.emailPreview.fetch(
+            { template },
+            { staleTime: 0 },
+          );
+          if (!r.html) {
+            toast.warning(r.reason ?? "Nothing to preview.");
+            return;
+          }
+          const w = window.open("", "_blank");
+          if (!w) {
+            toast.error("Popup blocked — allow popups for this page to preview.");
+            return;
+          }
+          w.document.write(r.html);
+          w.document.close();
+        } catch (e) {
+          toast.error(e instanceof Error ? e.message : "Preview failed");
+        } finally {
+          setLoading(false);
+        }
+      }}
+    >
+      {loading ? "Rendering..." : "Preview"}
+    </Button>
+  );
+}
+
+/** Sends the daily or weekly digest to the calling admin, [Test]-prefixed. */
+function SendTestDigestButton({ kind }: { kind: "daily" | "weekly" }) {
+  const utils = trpc.useUtils();
+  const send = trpc.platformAdmin.sendDigestTestEmail.useMutation({
+    onSuccess: (r) => {
+      if (!r.sent) {
+        toast.warning(
+          r.reason === "opted-out"
+            ? `Nothing sent — ${r.to} is unsubscribed from this email. Resubscribe below to test it.`
+            : r.reason === "no-content"
+              ? "Nothing sent — your company has nothing to report, so this digest would be empty."
+              : `Nothing sent — your account has no company to build a digest from.`,
+        );
+        return;
+      }
+      toast.success(
+        r.suppressed
+          ? `Rendered for ${r.to}; delivery suppressed in this environment`
+          : `Test ${kind} digest sent to ${r.to}`,
+      );
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => send.mutate({ kind })}
+      disabled={send.isPending}
+    >
+      {send.isPending ? "Sending..." : `Send me a test (${kind})`}
+    </Button>
+  );
+}
+
+/**
  * The send console: what is queued, how many to send, and the button that
  * sends them. Nothing about the lifecycle campaign goes out on a timer —
  * this is the only path, so the queue is always reviewed by a person before
@@ -472,9 +563,17 @@ function LifecycleQueuePanel() {
         {queue.data?.types.map((t) => (
           <div key={t.key} className="space-y-2">
             <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">{t.key}</span>
+              <div className="flex items-center gap-1">
+                <span className="text-sm font-medium">{t.key}</span>
+                <PreviewEmailButton template="activation-nudge" />
+              </div>
               <span className="text-sm text-muted-foreground">{t.prepared} queued</span>
             </div>
+            {EMAIL_TYPE_DESCRIPTIONS[t.key] && (
+              <p className="text-xs text-muted-foreground">
+                {EMAIL_TYPE_DESCRIPTIONS[t.key]}
+              </p>
+            )}
             {t.error && (
               <p className="text-sm text-destructive">
                 Campaign failed to run: {t.error}
@@ -491,6 +590,9 @@ function LifecycleQueuePanel() {
                         </td>
                         <td className="py-1.5 pr-4">{r.to}</td>
                         <td className="py-1.5 pr-3 text-muted-foreground">{r.subject}</td>
+                        <td className="py-1 pr-2 text-right">
+                          <SendOneLifecycleButton userId={r.userId} email={r.to} />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -526,6 +628,68 @@ function LifecycleQueuePanel() {
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+/** The per-row send for one queued lifecycle recipient. */
+function SendOneLifecycleButton({ userId, email }: { userId: string; email: string }) {
+  const utils = trpc.useUtils();
+  const send = trpc.platformAdmin.sendLifecycleToUser.useMutation({
+    onSuccess: (r) => {
+      if (r.skipped) toast.warning(`Nothing sent: ${r.skipped}`);
+      else if (r.sent > 0) toast.success(`Sent to ${email}`);
+      else toast.warning(`Nothing sent to ${email} — no longer eligible or already claimed.`);
+      void utils.platformAdmin.lifecycleQueue.invalidate();
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => send.mutate({ userId })}
+      disabled={send.isPending}
+      title={`Send only to ${email}`}
+    >
+      {send.isPending ? "..." : "Send"}
+    </Button>
+  );
+}
+
+/** The per-row send for one queued digest (recipient + kind). */
+function SendOneDigestButton({
+  userId,
+  kind,
+  email,
+}: {
+  userId: string;
+  kind: "daily" | "weekly";
+  email: string;
+}) {
+  const utils = trpc.useUtils();
+  const send = trpc.platformAdmin.sendDigestToRecipient.useMutation({
+    onSuccess: (r) => {
+      if (r.skipped) toast.warning(`Nothing sent: ${r.skipped}`);
+      else if (r.sent > 0) toast.success(`${kind} digest sent to ${email}`);
+      else if (r.alreadySentToday > 0)
+        toast.warning(`${email} already received today's ${kind} digest.`);
+      else toast.warning(`Nothing sent to ${email} — nothing left to report.`);
+      void utils.platformAdmin.digestQueue.invalidate();
+      void utils.platformAdmin.emailActivity.invalidate();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => send.mutate({ userId, kind })}
+      disabled={send.isPending}
+      title={`Send only to ${email}`}
+    >
+      {send.isPending ? "..." : "Send"}
+    </Button>
   );
 }
 
@@ -576,6 +740,19 @@ function DigestQueuePanel() {
           you send, so the numbers are never stale.
         </p>
 
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs">daily</span>
+            <PreviewEmailButton template="daily-digest" />
+          </div>
+          <p className="text-xs text-muted-foreground">{EMAIL_TYPE_DESCRIPTIONS.daily}</p>
+          <div className="flex items-center gap-1 pt-1">
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs">weekly</span>
+            <PreviewEmailButton template="weekly-digest" />
+          </div>
+          <p className="text-xs text-muted-foreground">{EMAIL_TYPE_DESCRIPTIONS.weekly}</p>
+        </div>
+
         {queue.isLoading && (
           <p className="text-sm text-muted-foreground">Building digests...</p>
         )}
@@ -609,6 +786,13 @@ function DigestQueuePanel() {
                       {item.companyName}
                     </td>
                     <td className="py-1.5 pr-3 text-muted-foreground">{item.summary}</td>
+                    <td className="py-1 pr-2 text-right">
+                      <SendOneDigestButton
+                        userId={item.userId}
+                        kind={item.kind}
+                        email={item.email}
+                      />
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -638,6 +822,8 @@ function DigestQueuePanel() {
           >
             {send.isPending ? "Sending..." : `Send ${Math.min(limit, total)} now`}
           </Button>
+          <SendTestDigestButton kind="daily" />
+          <SendTestDigestButton kind="weekly" />
         </div>
       </CardContent>
     </Card>
@@ -1142,7 +1328,11 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
 
       {/* KPI strip */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-        <StatCard label="Sent (all time)" value={data.totalSent} sub="cron-driven only" />
+        <StatCard
+          label="Sent (all time)"
+          value={data.totalSent}
+          sub="everything the notification table records"
+        />
         <StatCard label="Sent (last 7 days)" value={data.sentLast7d} />
         <StatCard
           label="Subscribed users"
@@ -1165,10 +1355,10 @@ function EmailsPanel({ data }: { data: EmailActivity }) {
       <p className="text-xs text-muted-foreground italic">
         Scope: emails recorded in the notification table (course follow-ups, daily
         digests, weekly management digests, deadline reminders, lifecycle nudges,
-        newsletter sends). Transactional emails (invites, welcome, contact-change notices,
-        supplier incident broadcasts) are not yet logged here. Lifecycle rows record
-        claims, not confirmed deliveries; the send-failures counter is the reconciliation
-        signal.
+        newsletter sends, and [Test] sends from this console). Transactional emails
+        (invites, welcome, contact-change notices, supplier incident broadcasts) are not
+        yet logged here. Lifecycle rows record claims, not confirmed deliveries; the
+        send-failures counter is the reconciliation signal.
       </p>
 
       {/* Daily volume, last 14 days */}

--- a/lib/lifecycle/dispatch.test.ts
+++ b/lib/lifecycle/dispatch.test.ts
@@ -258,11 +258,40 @@ describe("runLifecycleEmails", () => {
     const stats = result.types.test_type_v1;
     expect(stats).toMatchObject({ prepared: 3, sent: 0, failed: 0 });
     expect(stats.wouldSend).toEqual([
-      { to: "user-0@example.com", subject: "Subject 0" },
-      { to: "user-1@example.com", subject: "Subject 1" },
-      { to: "user-2@example.com", subject: "Subject 2" },
+      { userId: "user-0", to: "user-0@example.com", subject: "Subject 0" },
+      { userId: "user-1", to: "user-1@example.com", subject: "Subject 1" },
+      { userId: "user-2", to: "user-2@example.com", subject: "Subject 2" },
     ]);
     expect(inserted).toHaveLength(0);
+    expect(sendMail).toHaveBeenCalledTimes(0);
+  });
+
+  test("onlyUserId narrows the run to that one recipient and sends nobody else", async () => {
+    reset();
+    setTypes(stubType(prepared(3)));
+    const { db } = makeDb();
+
+    const result = await runLifecycleEmails(db, { ...FAST, onlyUserId: "user-1" });
+
+    if (result.skipped !== undefined) throw new Error("unexpected skip");
+    expect(result.types.test_type_v1).toMatchObject({
+      prepared: 1,
+      sent: 1,
+      deferred: 0,
+    });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail.mock.calls[0][0].to).toBe("user-1@example.com");
+  });
+
+  test("onlyUserId with a user outside the prepared batch sends nothing", async () => {
+    reset();
+    setTypes(stubType(prepared(2)));
+    const { db } = makeDb();
+
+    const result = await runLifecycleEmails(db, { ...FAST, onlyUserId: "stranger" });
+
+    if (result.skipped !== undefined) throw new Error("unexpected skip");
+    expect(result.types.test_type_v1).toMatchObject({ prepared: 0, sent: 0 });
     expect(sendMail).toHaveBeenCalledTimes(0);
   });
 

--- a/lib/lifecycle/dispatch.ts
+++ b/lib/lifecycle/dispatch.ts
@@ -67,7 +67,7 @@ export interface LifecycleTypeStats {
   deferred: number;
   error?: string;
   /** Dry runs only: who the batch WOULD have gone to, nothing sent or claimed. */
-  wouldSend?: Array<{ to: string; subject: string }>;
+  wouldSend?: Array<{ userId: string; to: string; subject: string }>;
 }
 
 export interface LifecycleRunOptions {
@@ -83,6 +83,13 @@ export interface LifecycleRunOptions {
    * values above the cap are clamped down.
    */
   maxPerType?: number;
+  /**
+   * Restrict the run to one recipient: the per-row "Send" button in the admin
+   * console. Selection and eligibility are unchanged — the person must still
+   * be in the prepared batch — so this cannot mail someone the campaign
+   * would not have mailed, and the once-ever claim still arbitrates.
+   */
+  onlyUserId?: string;
 }
 
 export type LifecycleRunResult =
@@ -187,7 +194,12 @@ async function deliverOne(
 async function runType(
   db: DbOrTx,
   type: LifecycleEmailType,
-  opts: { sendIntervalMs: number; dryRun: boolean; maxPerType: number },
+  opts: {
+    sendIntervalMs: number;
+    dryRun: boolean;
+    maxPerType: number;
+    onlyUserId?: string;
+  },
 ): Promise<LifecycleTypeStats> {
   const stats: LifecycleTypeStats = {
     prepared: 0,
@@ -199,14 +211,21 @@ async function runType(
     deferred: 0,
   };
 
-  const prepared = await type.prepare(db);
+  const allPrepared = await type.prepare(db);
+  const prepared = opts.onlyUserId
+    ? allPrepared.filter((email) => email.userId === opts.onlyUserId)
+    : allPrepared;
   stats.prepared = prepared.length;
   const cap = Math.min(MAX_SENDS_PER_TYPE_PER_RUN, Math.max(1, opts.maxPerType));
   const batch = prepared.slice(0, cap);
   stats.deferred = prepared.length - batch.length;
 
   if (opts.dryRun) {
-    stats.wouldSend = batch.map((email) => ({ to: email.to, subject: email.subject }));
+    stats.wouldSend = batch.map((email) => ({
+      userId: email.userId,
+      to: email.to,
+      subject: email.subject,
+    }));
     return stats;
   }
 
@@ -257,6 +276,7 @@ export async function runLifecycleEmails(
     sendIntervalMs: opts?.sendIntervalMs ?? SEND_INTERVAL_MS,
     dryRun: opts?.dryRun ?? false,
     maxPerType: opts?.maxPerType ?? MAX_SENDS_PER_TYPE_PER_RUN,
+    onlyUserId: opts?.onlyUserId,
   });
   activeRun = run;
   try {
@@ -268,7 +288,12 @@ export async function runLifecycleEmails(
 
 async function executeRun(
   db: DbOrTx,
-  opts: { sendIntervalMs: number; dryRun: boolean; maxPerType: number },
+  opts: {
+    sendIntervalMs: number;
+    dryRun: boolean;
+    maxPerType: number;
+    onlyUserId?: string;
+  },
 ): Promise<LifecycleRunResult> {
   const types: Record<string, LifecycleTypeStats> = {};
   for (const type of LIFECYCLE_EMAIL_TYPES) {

--- a/lib/mail/digest-outbox.ts
+++ b/lib/mail/digest-outbox.ts
@@ -230,6 +230,13 @@ export async function sendDigestBatch(
   db: Database,
   limit: number,
   actorUserId: string,
+  /**
+   * Restrict the batch to one queued (recipient, kind) pair: the per-row
+   * "Send" button. The person must still be in the built queue, so this
+   * cannot mail anyone the digest logic would not have mailed, and the
+   * per-day claim still arbitrates duplicates.
+   */
+  only?: { userId: string; kind: DigestKind },
 ): Promise<DigestSendResult> {
   if (activeDigestRun) {
     return {
@@ -241,7 +248,7 @@ export async function sendDigestBatch(
       deferred: 0,
     };
   }
-  const run = executeDigestBatch(db, limit, actorUserId);
+  const run = executeDigestBatch(db, limit, actorUserId, only);
   activeDigestRun = run;
   try {
     return await run;
@@ -254,6 +261,7 @@ async function executeDigestBatch(
   db: Database,
   limit: number,
   actorUserId: string,
+  only?: { userId: string; kind: DigestKind },
 ): Promise<DigestSendResult> {
   const suppression = mailSuppressionReason();
   if (suppression) {
@@ -267,7 +275,10 @@ async function executeDigestBatch(
     };
   }
 
-  const queue = await buildDigestQueue(db);
+  const allQueued = await buildDigestQueue(db);
+  const queue = only
+    ? allQueued.filter((q) => q.userId === only.userId && q.kind === only.kind)
+    : allQueued;
   const batch = queue.slice(0, Math.max(1, limit));
   const result: DigestSendResult = {
     skipped: null,

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -25,9 +25,17 @@ import { eraseUser, previewUserErasure } from "@/lib/gdpr/erase-user";
 import { runLifecycleEmails } from "@/lib/lifecycle/dispatch";
 import { prepareActivationNudgeSample } from "@/lib/lifecycle/emails/activation-nudge";
 import { LIFECYCLE_ENTITY_TYPE } from "@/lib/lifecycle/types";
+import { compileDailyDigest, compileManagementDigest } from "@/lib/compliance/digest";
 import { loadEmailConsent } from "@/lib/mail/consent";
-import { buildDigestQueue, sendDigestBatch } from "@/lib/mail/digest-outbox";
+import {
+  buildDigestQueue,
+  type DigestKind,
+  sendDigestBatch,
+} from "@/lib/mail/digest-outbox";
 import { isSuppressedSendId, sendMail } from "@/lib/mail/send";
+import { dailyDigestEmail, weeklyManagementDigestEmail } from "@/lib/mail/templates";
+import type { Database } from "@/lib/db";
+import { preferenceFooterFor } from "@/lib/mail/footer";
 import { HINT_COLUMN, HINTS, resolveHints } from "@/lib/onboarding/hints";
 import { rateLimit } from "@/lib/rate-limit";
 import { COURSE_IDS, loadCourse } from "@/lib/training/course-loader";
@@ -54,6 +62,80 @@ import { protectedProcedure, router } from "../init";
  * a producer is misbehaving.
  */
 const MULTI_SEND_ALERT_PER_DAY = 3;
+
+/** Compile and render one digest for one user, or null when there is nothing to say. */
+async function buildDigestContent(
+  db: Database,
+  userId: string,
+  companyId: string,
+  kind: DigestKind,
+): Promise<{ subject: string; html: string; text: string } | null> {
+  const footer = preferenceFooterFor(
+    userId,
+    kind === "daily" ? "reminders.daily_digest" : "reminders.weekly_management_digest",
+  );
+  if (kind === "daily") {
+    const d = await compileDailyDigest(db, userId, companyId);
+    if (!d) return null;
+    return dailyDigestEmail({
+      recipientName: d.recipientName,
+      companyName: d.companyName,
+      overdueItems: d.overdueItems,
+      urgentItems: d.urgentItems,
+      upcomingItems: d.upcomingItems,
+      compliancePercentage: d.compliancePercentage,
+      dashboardUrl: d.dashboardUrl,
+      unsubscribeUrl: footer.unsubscribeUrl,
+    });
+  }
+  const m = await compileManagementDigest(db, userId, companyId);
+  if (!m) return null;
+  return weeklyManagementDigestEmail({
+    recipientName: m.recipientName,
+    companyName: m.companyName,
+    compliancePercentage: m.compliancePercentage,
+    overdueCount: m.overdueCount,
+    urgentCount: m.urgentCount,
+    escalationCount: m.escalationCount,
+    totalRequirements: m.totalRequirements,
+    completedRequirements: m.completedRequirements,
+    dashboardUrl: m.dashboardUrl,
+    unsubscribeUrl: footer.unsubscribeUrl,
+  });
+}
+
+/**
+ * Record a [Test] send in the notification table so the activity view (graph,
+ * totals, recent list) counts every email that actually left the building.
+ * Not a claim: internal.test_send is under no dedup index and no campaign
+ * reads it, so admins can test as often as they like. Best-effort — the
+ * bookkeeping row must never fail a test send that already went out.
+ */
+async function logTestSend(
+  db: Database,
+  userId: string,
+  companyId: string,
+  info: { subject: string; triggerField: string },
+): Promise<void> {
+  const now = new Date();
+  await db
+    .insert(notification)
+    .values({
+      companyId,
+      recipientId: userId,
+      entityType: "internal.test_send",
+      entityId: userId,
+      triggerField: info.triggerField,
+      subject: info.subject,
+      channel: "email" as const,
+      status: "sent" as const,
+      scheduledFor: now,
+      sentAt: now,
+      urgency: "info" as const,
+      escalationLevel: 0,
+    })
+    .catch(() => {});
+}
 
 // Character set (not a secret) for human-friendly share passwords —
 // confusable chars (0, O, I, l, 1) intentionally excluded so the password
@@ -746,11 +828,24 @@ export const platformAdminRouter = router({
     }
     // res.id carries a sentinel instead of a Resend id when delivery was
     // suppressed (dev block / DISABLE_EMAIL / no API key).
+    const suppressed = "id" in res ? isSuppressedSendId(res.id) : false;
+    if (!suppressed) {
+      const caller = await ctx.db.query.user.findFirst({
+        where: eq(user.id, ctx.userId),
+        columns: { companyId: true },
+      });
+      if (caller?.companyId) {
+        await logTestSend(ctx.db, ctx.userId, caller.companyId, {
+          subject: `[Test] ${sample.subject}`,
+          triggerField: "activation_nudge_v1",
+        });
+      }
+    }
     return {
       to: sample.to,
       sent: true as const,
       reason: null,
-      suppressed: "id" in res ? isSuppressedSendId(res.id) : false,
+      suppressed,
     };
   }),
 
@@ -774,6 +869,7 @@ export const platformAdminRouter = router({
         prepared: stats.prepared,
         error: stats.error ?? null,
         recipients: (stats.wouldSend ?? []).map((r) => ({
+          userId: r.userId,
           to: r.to,
           subject: r.subject,
         })),
@@ -825,6 +921,7 @@ export const platformAdminRouter = router({
       total: queue.length,
       items: queue.map((q) => ({
         kind: q.kind,
+        userId: q.userId,
         email: q.email,
         companyName: q.companyName,
         subject: q.subject,
@@ -838,6 +935,177 @@ export const platformAdminRouter = router({
     .input(z.object({ limit: z.number().int().min(1).max(100) }))
     .mutation(async ({ ctx, input }) => {
       return sendDigestBatch(ctx.db, input.limit, ctx.userId);
+    }),
+
+  /**
+   * The per-row "Send" button: one queued lifecycle recipient, nobody else.
+   * Same selection, same once-ever claim — the run is simply narrowed to
+   * this user, so a stale row (someone who became ineligible since the page
+   * loaded) sends nothing rather than sending wrongly.
+   */
+  sendLifecycleToUser: platformAdminProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await runLifecycleEmails(ctx.db, {
+        onlyUserId: input.userId,
+        maxPerType: 1,
+      });
+      logAudit({
+        companyId: null,
+        userId: ctx.userId,
+        action: "email.lifecycle_batch_sent",
+        entityType: "system",
+        entityId: null,
+        description: `Platform admin sent a single lifecycle email to user ${input.userId}: ${JSON.stringify(result, (k, v) => (k === "wouldSend" ? undefined : v))}`,
+      });
+      if (result.skipped !== undefined) {
+        return { skipped: result.skipped, sent: 0, failed: 0 };
+      }
+      const totals = Object.values(result.types).reduce(
+        (acc, s) => ({ sent: acc.sent + s.sent, failed: acc.failed + s.failed }),
+        { sent: 0, failed: 0 },
+      );
+      return { skipped: null, ...totals };
+    }),
+
+  /**
+   * The per-row "Send" button for one queued digest. The queue is rebuilt and
+   * narrowed to this (recipient, kind); the per-day claim still arbitrates,
+   * so a double-click cannot double-send.
+   */
+  sendDigestToRecipient: platformAdminProcedure
+    .input(
+      z.object({
+        userId: z.string().uuid(),
+        kind: z.enum(["daily", "weekly"]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      return sendDigestBatch(ctx.db, 1, ctx.userId, {
+        userId: input.userId,
+        kind: input.kind as DigestKind,
+      });
+    }),
+
+  /**
+   * Send the daily or weekly digest to the CALLING admin's own mailbox,
+   * subject-prefixed [Test]. Rendered from the admin's own company state via
+   * the real compilers; writes no per-day claim, so it never blocks the real
+   * digest, and the consent gate applies exactly as it would to a customer.
+   * Logged as internal.test_send so the activity view counts it.
+   */
+  sendDigestTestEmail: platformAdminProcedure
+    .input(z.object({ kind: z.enum(["daily", "weekly"]) }))
+    .mutation(async ({ ctx, input }) => {
+      const caller = await ctx.db.query.user.findFirst({
+        where: eq(user.id, ctx.userId),
+        columns: { email: true, companyId: true },
+      });
+      if (!caller) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Calling user not found." });
+      }
+      if (!caller.companyId) {
+        return {
+          to: caller.email,
+          sent: false as const,
+          reason: "no-company" as const,
+          suppressed: false,
+        };
+      }
+      const emailType =
+        input.kind === "daily"
+          ? ("reminders.daily_digest" as const)
+          : ("reminders.weekly_management_digest" as const);
+      const consent = await loadEmailConsent(ctx.db, ctx.userId);
+      if (!consent.allows(emailType)) {
+        return {
+          to: caller.email,
+          sent: false as const,
+          reason: "opted-out" as const,
+          suppressed: false,
+        };
+      }
+      const content = await buildDigestContent(
+        ctx.db,
+        ctx.userId,
+        caller.companyId,
+        input.kind,
+      );
+      if (!content) {
+        return {
+          to: caller.email,
+          sent: false as const,
+          reason: "no-content" as const,
+          suppressed: false,
+        };
+      }
+      const res = await sendMail({
+        emailType,
+        recipientUserId: ctx.userId,
+        db: ctx.db,
+        to: caller.email,
+        subject: `[Test] ${content.subject}`,
+        html: content.html,
+        text: content.text,
+        replyTo: mailSupportEmail(),
+      });
+      if (!res.success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Test send failed.",
+        });
+      }
+      const suppressed = "id" in res ? isSuppressedSendId(res.id) : false;
+      if (!suppressed) {
+        await logTestSend(ctx.db, ctx.userId, caller.companyId, {
+          subject: `[Test] ${content.subject}`,
+          triggerField: `${input.kind}_digest`,
+        });
+      }
+      return { to: caller.email, sent: true as const, reason: null, suppressed };
+    }),
+
+  /**
+   * The rendered HTML of one email template, for the "Preview" button.
+   * Rendered from the calling admin's own data through the same code the
+   * real send uses, returned to the client, never sent anywhere.
+   */
+  emailPreview: platformAdminProcedure
+    .input(
+      z.object({
+        template: z.enum(["activation-nudge", "daily-digest", "weekly-digest"]),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      if (input.template === "activation-nudge") {
+        const sample = await prepareActivationNudgeSample(ctx.db, ctx.userId);
+        if (!sample) {
+          return { html: null, subject: null, reason: "Calling user not found." };
+        }
+        return { html: sample.html, subject: sample.subject, reason: null };
+      }
+      const caller = await ctx.db.query.user.findFirst({
+        where: eq(user.id, ctx.userId),
+        columns: { companyId: true },
+      });
+      if (!caller?.companyId) {
+        return {
+          html: null,
+          subject: null,
+          reason: "Your account has no company, so there is no digest to render.",
+        };
+      }
+      const kind: DigestKind = input.template === "daily-digest" ? "daily" : "weekly";
+      const content = await buildDigestContent(ctx.db, ctx.userId, caller.companyId, kind);
+      if (!content) {
+        return {
+          html: null,
+          subject: null,
+          reason:
+            "Your company has nothing to report right now, so this digest renders empty. It looks the same for customers: no content, no send.",
+        };
+      }
+      return { html: content.html, subject: content.subject, reason: null };
     }),
 
   /**


### PR DESCRIPTION
## What

Four operator asks on the /platform-admin email dashboard:

1. **Send individually**: every queued row (lifecycle nudge and both digest kinds) gets its own Send button. Implementation narrows the existing run to one recipient; eligibility checks and DB claims are untouched, so a per-row send cannot mail someone the batch would not have mailed, and double-clicks cannot double-send.
2. **What is this email?** One-paragraph TLDR under each type, plus a **Preview** button that opens the rendered template in a new tab (rendered from the calling admin's own data via the real compilers).
3. **Send me a test of this email**: existed for the nudge; now also for daily and weekly digests. Consent-gated exactly like a customer send; refuses honestly when the caller is unsubscribed or their company has nothing to report.
4. **Graph fix**: test sends are now recorded as `internal.test_send` notification rows (after a confirmed non-suppressed send), so the sends-per-day graph, totals and recent-outbound list count them. Previously the test nudge deliberately wrote no row, which made the graph look broken. Stat-card caption and scope note updated to match.

## Verification

- `bun test lib/lifecycle/dispatch.test.ts`: 13 pass, including two new tests for onlyUserId narrowing (sends exactly the target; a non-queued target sends nothing).
- `bun run typecheck` clean (the 3 pre-existing package/tsup module errors also occur on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkHp2TCgHzEVywZ1F6dJEh