### PR TITLE
Digest CTA is the next step, not the dashboard

### DIFF
--- a/lib/compliance/digest.ts
+++ b/lib/compliance/digest.ts
@@ -4,9 +4,10 @@
  * Used by the cron job to batch pending email notifications into a single
  * digest email instead of individual emails per reminder.
  */
+import { nis2Categories } from "@nisd2/grc-data-model/frameworks";
 import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import type { Database } from "@/lib/db";
-import type { DigestItem } from "@/lib/mail";
+import type { DigestItem, DigestNextStep } from "@/lib/mail";
 import { getAppUrl } from "@/lib/utils";
 import requirementsEn from "@/messages/requirements/en.json";
 import {
@@ -15,6 +16,7 @@ import {
   companyRequirementStatus,
   notification,
   requirement,
+  requirementAssignment,
   requirementCategory,
   user,
 } from "@/schema";
@@ -26,12 +28,6 @@ import { isDoneStatus, journeyPosition } from "./journey-position";
 // Types
 // ---------------------------------------------------------------------------
 
-export interface NextJourneyStep {
-  requirementCode: string;
-  requirementTitle: string;
-  url: string;
-}
-
 export interface DigestData {
   recipientId: string;
   recipientName: string;
@@ -42,7 +38,7 @@ export interface DigestData {
   urgentItems: DigestItem[];
   upcomingItems: DigestItem[];
   /** First open requirement in journey order; null when the path is done. */
-  nextStep: NextJourneyStep | null;
+  nextStep: DigestNextStep | null;
   compliancePercentage: string;
   dashboardUrl: string;
 }
@@ -60,9 +56,14 @@ export interface ManagementDigestData {
   totalRequirements: number;
   completedRequirements: number;
   /** First open requirement in journey order; null when the path is done. */
-  nextStep: NextJourneyStep | null;
+  nextStep: DigestNextStep | null;
   dashboardUrl: string;
 }
+
+/** English category names live in the framework data, not the DB. */
+const CATEGORY_NAME_BY_SLUG: Record<string, string> = Object.fromEntries(
+  nis2Categories.map((c) => [c.slug ?? "", c.name ?? ""]),
+);
 
 // ---------------------------------------------------------------------------
 // Next journey step — shared by both digests
@@ -80,15 +81,17 @@ function requirementTitle(code: string): string {
  * The first not-done requirement in journey order — the same
  * category-weighted order the path view and the activation-nudge email use
  * (journeyPosition), so every email names the step the journey page
- * highlights when the reader clicks through.
+ * highlights when the reader clicks through. Carries the progress numbers
+ * the templates turn into the payoff line ("20 of 49; finishing 12.1
+ * completes Registration") and, for the management digest, who owns it.
  */
 async function findNextJourneyStep(
   db: Database,
   assessmentIds: string[],
-): Promise<NextJourneyStep | null> {
+): Promise<DigestNextStep | null> {
   const rows = await db.query.companyRequirementStatus.findMany({
     where: inArray(companyRequirementStatus.assessmentId, assessmentIds),
-    columns: { status: true },
+    columns: { id: true, status: true },
     with: {
       requirement: {
         columns: { code: true, sortOrder: true },
@@ -100,6 +103,7 @@ async function findNextJourneyStep(
   const next = rows
     .filter((r) => !isDoneStatus(r.status))
     .map((r) => ({
+      statusId: r.id,
       code: r.requirement.code,
       slug: r.requirement.category?.slug ?? "unknown",
       position: journeyPosition(
@@ -110,10 +114,25 @@ async function findNextJourneyStep(
     .sort((a, b) => a.position - b.position || a.code.localeCompare(b.code))[0];
 
   if (!next) return null;
+
+  const categoryRows = rows.filter(
+    (r) => (r.requirement.category?.slug ?? "unknown") === next.slug,
+  );
+  const assignment = await db.query.requirementAssignment.findFirst({
+    where: eq(requirementAssignment.statusId, next.statusId),
+    with: { user: { columns: { name: true } } },
+  });
+
   return {
     requirementCode: next.code,
     requirementTitle: requirementTitle(next.code),
     url: `${getAppUrl()}/compliance/${next.slug}#${next.code}`,
+    done: rows.filter((r) => isDoneStatus(r.status)).length,
+    total: rows.length,
+    categoryName: CATEGORY_NAME_BY_SLUG[next.slug] ?? next.slug,
+    categoryDone: categoryRows.filter((r) => isDoneStatus(r.status)).length,
+    categoryTotal: categoryRows.length,
+    assigneeName: assignment?.user?.name ?? null,
   };
 }
 

--- a/lib/mail/templates.ts
+++ b/lib/mail/templates.ts
@@ -282,10 +282,11 @@ export interface DigestItem {
 }
 
 function digestItemRow(item: DigestItem): string {
+  // Only the daily digest renders item tables, so the campaign is fixed here.
   return `
     <tr>
       <td style="padding: 8px 12px; border-bottom: 1px solid ${BRAND.border};">
-        <a href="${item.categoryUrl}" style="color: ${BRAND.primary}; font-weight: 500; text-decoration: none;">${escapeHtml(item.requirementCode)}</a>
+        <a href="${withUtm(item.categoryUrl, "daily_digest")}" style="color: ${BRAND.primary}; font-weight: 500; text-decoration: none;">${escapeHtml(item.requirementCode)}</a>
       </td>
       <td style="padding: 8px 12px; border-bottom: 1px solid ${BRAND.border}; color: ${BRAND.foreground};">${escapeHtml(item.requirementTitle)}</td>
       <td style="padding: 8px 12px; border-bottom: 1px solid ${BRAND.border}; color: ${BRAND.foreground}; white-space: nowrap;">${escapeHtml(item.deadline)}</td>
@@ -322,30 +323,65 @@ function digestItemText(item: DigestItem): string {
  * The reader's next open step on the journey, in the path view's order.
  * Every digest carries it so the mail always ends on a concrete action:
  * either "these reviews are overdue" or "this is next up" — never a bare
- * count with nothing to do about it.
+ * count with nothing to do about it. The progress numbers feed the payoff
+ * line; assigneeName is for the management digest's "who owns it".
  */
 export interface DigestNextStep {
   requirementCode: string;
   requirementTitle: string;
   url: string;
+  /** Journey-wide progress: steps done of total. */
+  done: number;
+  total: number;
+  categoryName: string;
+  categoryDone: number;
+  categoryTotal: number;
+  /** First assigned owner of the step; null when nobody is assigned yet. */
+  assigneeName: string | null;
 }
 
-function nextStepHtml(nextStep: DigestNextStep | null): string {
-  if (!nextStep) return "";
+type DigestCampaign = "daily_digest" | "weekly_management_digest";
+
+/**
+ * utm_* tags on digest links so Umami can attribute return visits to the
+ * digest that caused them. The requirement deep links end in a #<code>
+ * fragment, and the fragment must stay last, so the query is spliced in
+ * before it.
+ */
+function withUtm(url: string, campaign: DigestCampaign): string {
+  const [base, fragment] = url.split("#");
+  const sep = base.includes("?") ? "&" : "?";
+  const tagged = `${base}${sep}utm_source=email&utm_medium=digest&utm_campaign=${campaign}`;
+  return fragment ? `${tagged}#${fragment}` : tagged;
+}
+
+/**
+ * What completing the next step does to the numbers the reader already
+ * owns. When it is the category's last open step, say so: "completes
+ * Registration" pulls harder than another fraction.
+ */
+function payoffLine(nextStep: DigestNextStep): string {
+  const categoryLeft = nextStep.categoryTotal - nextStep.categoryDone;
+  const categoryPart =
+    categoryLeft === 1
+      ? `completes ${nextStep.categoryName}`
+      : `moves ${nextStep.categoryName} to ${nextStep.categoryDone + 1} of ${nextStep.categoryTotal}`;
+  return `You are at ${nextStep.done} of ${nextStep.total} steps. Finishing ${nextStep.requirementCode} makes it ${nextStep.done + 1} and ${categoryPart}.`;
+}
+
+function continueButtonHtml(nextStep: DigestNextStep, campaign: DigestCampaign): string {
   return `
-    <p style="color: ${BRAND.foreground}; line-height: 1.6; margin: 0 0 24px;">
-      Next up in your journey:
-      <a href="${nextStep.url}" style="color: ${BRAND.primary}; font-weight: 600; text-decoration: none;">${escapeHtml(nextStep.requirementCode)} ${escapeHtml(nextStep.requirementTitle)}</a>
-    </p>`;
+    <p style="color: ${BRAND.foreground}; line-height: 1.6; margin: 0 0 16px;">${escapeHtml(payoffLine(nextStep))}</p>
+    <a href="${withUtm(nextStep.url, campaign)}" style="display: inline-block; background: ${BRAND.primary}; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+      Continue: ${escapeHtml(nextStep.requirementCode)} ${escapeHtml(nextStep.requirementTitle)}
+    </a>`;
 }
 
-function nextStepText(nextStep: DigestNextStep | null): string[] {
-  if (!nextStep) return [];
-  return [
-    `Next up in your journey: ${nextStep.requirementCode} ${nextStep.requirementTitle}`,
-    `${nextStep.url}`,
-    ``,
-  ];
+function dashboardButtonHtml(dashboardUrl: string, campaign: DigestCampaign, label: string): string {
+  return `
+    <a href="${withUtm(dashboardUrl, campaign)}" style="display: inline-block; background: ${BRAND.primary}; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+      ${escapeHtml(label)}
+    </a>`;
 }
 
 export function dailyDigestEmail(opts: {
@@ -387,10 +423,14 @@ export function dailyDigestEmail(opts: {
         ${digestSection("Overdue", SEVERITY.destructive, overdueItems)}
         ${digestSection("Due This Week", SEVERITY.warning, urgentItems)}
         ${digestSection("Upcoming", BRAND.mutedForeground, upcomingItems)}
-        ${nextStepHtml(nextStep)}
-        <a href="${dashboardUrl}" style="display: inline-block; background: ${BRAND.primary}; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
-          View Dashboard
-        </a>
+        ${
+          nextStep
+            ? `${continueButtonHtml(nextStep, "daily_digest")}
+        <p style="font-size: 13px; margin: 12px 0 0;">
+          <a href="${withUtm(dashboardUrl, "daily_digest")}" style="color: ${BRAND.mutedForeground};">or open the dashboard</a>
+        </p>`
+            : dashboardButtonHtml(dashboardUrl, "daily_digest", "View Dashboard")
+        }
         <p style="color: ${BRAND.mutedForeground}; font-size: 13px; margin: 24px 0 0; line-height: 1.5;">
           You are receiving this digest because you are a member of ${safeCo}.
         </p>
@@ -413,8 +453,15 @@ export function dailyDigestEmail(opts: {
       ...(upcomingItems.length > 0
         ? [`Upcoming (${upcomingItems.length}):`, ...upcomingItems.map(digestItemText), ``]
         : []),
-      ...nextStepText(nextStep),
-      `View dashboard: ${dashboardUrl}`,
+      ...(nextStep
+        ? [
+            payoffLine(nextStep),
+            `Continue: ${nextStep.requirementCode} ${nextStep.requirementTitle}`,
+            withUtm(nextStep.url, "daily_digest"),
+            ``,
+          ]
+        : []),
+      `View dashboard: ${withUtm(dashboardUrl, "daily_digest")}`,
       ``,
       `Unsubscribe from digest emails: ${unsubscribeUrl}`,
     ].join("\n"),
@@ -491,10 +538,25 @@ export function weeklyManagementDigestEmail(opts: {
             <td style="padding: 10px 12px; border-bottom: 1px solid ${BRAND.border}; font-weight: 600; text-align: right; color: ${escalationCount > 0 ? SEVERITY.destructive : SEVERITY.success};">${escalationCount}</td>
           </tr>
         </table>
-        ${nextStepHtml(nextStep)}
-        <a href="${dashboardUrl}" style="display: inline-block; background: ${BRAND.primary}; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
-          View Dashboard
-        </a>
+        ${
+          nextStep
+            ? `<p style="color: ${BRAND.foreground}; line-height: 1.6; margin: 0 0 8px;">
+          Next up: <a href="${withUtm(nextStep.url, "weekly_management_digest")}" style="color: ${BRAND.primary}; font-weight: 600; text-decoration: none;">${escapeHtml(nextStep.requirementCode)} ${escapeHtml(nextStep.requirementTitle)}</a> (${escapeHtml(nextStep.categoryName)}), ${nextStep.assigneeName ? `assigned to ${escapeHtml(nextStep.assigneeName)}` : "not yet assigned"}.
+        </p>`
+            : ""
+        }
+        ${
+          completedRequirements < totalRequirements
+            ? `<p style="color: ${BRAND.mutedForeground}; font-size: 13px; line-height: 1.6; margin: 0 0 16px;">
+          Open items return in every weekly report until they are done. Completed items land in the audit trail as evidence.
+        </p>`
+            : ""
+        }
+        ${dashboardButtonHtml(
+          dashboardUrl,
+          "weekly_management_digest",
+          completedRequirements < totalRequirements ? "Review the open items" : "View Dashboard",
+        )}
         <div style="margin: 24px 0 0; padding: 16px; background: ${BRAND.muted}; border: 1px solid ${BRAND.border}; border-radius: 6px; font-size: 12px; color: ${BRAND.mutedForeground}; line-height: 1.5;">
           This email serves as documentation of management notification per Art. 20 NIS 2 / &sect;38 BSIG.<br/>
           Diese E-Mail dient als Nachweis der Leitungsunterrichtung gem&auml;&szlig; Art. 20 NIS 2 / &sect;38 BSIG.
@@ -516,8 +578,20 @@ export function weeklyManagementDigestEmail(opts: {
       `Urgent Items: ${urgentCount}`,
       `Escalations: ${escalationCount}`,
       ``,
-      ...nextStepText(nextStep),
-      `View dashboard: ${dashboardUrl}`,
+      ...(nextStep
+        ? [
+            `Next up: ${nextStep.requirementCode} ${nextStep.requirementTitle} (${nextStep.categoryName}), ${nextStep.assigneeName ? `assigned to ${nextStep.assigneeName}` : "not yet assigned"}.`,
+            withUtm(nextStep.url, "weekly_management_digest"),
+            ``,
+          ]
+        : []),
+      ...(completedRequirements < totalRequirements
+        ? [
+            `Open items return in every weekly report until they are done. Completed items land in the audit trail as evidence.`,
+            ``,
+          ]
+        : []),
+      `View dashboard: ${withUtm(dashboardUrl, "weekly_management_digest")}`,
       ``,
       `---`,
       `This email serves as documentation of management notification per Art. 20 NIS 2 / §38 BSIG.`,


### PR DESCRIPTION
## What

The digest button said "View Dashboard" and linked to `/`, while the one motivating thing in the mail — the named next step — was an informational line. This swaps the roles.

**Daily digest**
- Primary button: **Continue: 12.1 NIS2 Classification & Scope**, deep-linked into the requirement. Dashboard becomes a secondary text link.
- Computed payoff line above it: *"You are at 20 of 49 steps. Finishing 12.1 makes it 21 and completes Registration."* Endowed progress plus category-completion pull, all from real data — no invented numbers.

**Weekly management digest**
- Next step named with category and owner: *"assigned to Maria K"* or *"not yet assigned"* (from `requirement_assignment`) — the management-shaped action is assigning, not doing.
- One operational cost line, no fear framing: *"Open items return in every weekly report until they are done. Completed items land in the audit trail as evidence."*
- Button reads **Review the open items** while anything is open.

**Measurement**: every digest link (buttons, item rows, dashboard) now carries `utm_source=email&utm_medium=digest&utm_campaign=daily_digest|weekly_management_digest`, spliced before the `#code` fragment, so Umami can attribute digest-driven returns.

`DigestNextStep` gains done/total, category progress and assigneeName, computed in `findNextJourneyStep` from the same journey-order source the path view uses.

The digest recurs, so no urgency rhetoric anywhere — the pull is specificity and low friction.

## Tests
- typecheck clean, 325 unit + 216 l0 pass (CI parity, no .env)
- rendered both templates with sample data and eyeballed HTML + text output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkHp2TCgHzEVywZ1F6dJEh