### PR TITLE
Digest review findings: deterministic assignee, one truth for open items

### DIFF
--- a/lib/compliance/digest.ts
+++ b/lib/compliance/digest.ts
@@ -5,7 +5,7 @@
  * digest email instead of individual emails per reminder.
  */
 import { nis2Categories } from "@nisd2/grc-data-model/frameworks";
-import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import type { Database } from "@/lib/db";
 import type { DigestItem, DigestNextStep } from "@/lib/mail";
 import { getAppUrl } from "@/lib/utils";
@@ -60,9 +60,13 @@ export interface ManagementDigestData {
   dashboardUrl: string;
 }
 
-/** English category names live in the framework data, not the DB. */
+/**
+ * English category names live in the framework data, not the DB. Only named
+ * entries go into the map: an entry stored as "" would defeat the lookup
+ * site's `?? slug` fallback, since the empty string is not nullish.
+ */
 const CATEGORY_NAME_BY_SLUG: Record<string, string> = Object.fromEntries(
-  nis2Categories.map((c) => [c.slug ?? "", c.name ?? ""]),
+  nis2Categories.flatMap((c) => (c.slug && c.name ? [[c.slug, c.name]] : [])),
 );
 
 // ---------------------------------------------------------------------------
@@ -84,10 +88,15 @@ function requirementTitle(code: string): string {
  * highlights when the reader clicks through. Carries the progress numbers
  * the templates turn into the payoff line ("20 of 49; finishing 12.1
  * completes Registration") and, for the management digest, who owns it.
+ *
+ * includeAssignee: only the weekly management template renders the owner,
+ * so the daily path skips that query — it runs per member of every active
+ * company, and twice per send (queue build, then send time).
  */
 async function findNextJourneyStep(
   db: Database,
   assessmentIds: string[],
+  includeAssignee: boolean,
 ): Promise<DigestNextStep | null> {
   const rows = await db.query.companyRequirementStatus.findMany({
     where: inArray(companyRequirementStatus.assessmentId, assessmentIds),
@@ -118,10 +127,17 @@ async function findNextJourneyStep(
   const categoryRows = rows.filter(
     (r) => (r.requirement.category?.slug ?? "unknown") === next.slug,
   );
-  const assignment = await db.query.requirementAssignment.findFirst({
-    where: eq(requirementAssignment.statusId, next.statusId),
-    with: { user: { columns: { name: true } } },
-  });
+  // A status row can carry several assignments (unique index is
+  // statusId+userId). Without an ORDER BY, LIMIT 1 returns an arbitrary
+  // row, and the §38-evidence email could name a different owner each
+  // week; assignedAt pins it to the first assigned owner.
+  const assignment = includeAssignee
+    ? await db.query.requirementAssignment.findFirst({
+        where: eq(requirementAssignment.statusId, next.statusId),
+        orderBy: asc(requirementAssignment.assignedAt),
+        with: { user: { columns: { name: true } } },
+      })
+    : null;
 
   return {
     requirementCode: next.code,
@@ -265,7 +281,7 @@ export async function compileDailyDigest(
     overdueItems,
     urgentItems,
     upcomingItems,
-    nextStep: await findNextJourneyStep(db, assessmentIds),
+    nextStep: await findNextJourneyStep(db, assessmentIds, false),
     compliancePercentage: pct,
     dashboardUrl: `${appUrl}/`,
   };
@@ -382,7 +398,7 @@ export async function compileManagementDigest(
     escalationCount: escalationRows.length,
     totalRequirements: totalReq,
     completedRequirements: completedReq,
-    nextStep: await findNextJourneyStep(db, assessmentIds),
+    nextStep: await findNextJourneyStep(db, assessmentIds, true),
     dashboardUrl: `${getAppUrl()}/`,
   };
 }

--- a/lib/mail/templates.ts
+++ b/lib/mail/templates.ts
@@ -546,7 +546,11 @@ export function weeklyManagementDigestEmail(opts: {
             : ""
         }
         ${
-          completedRequirements < totalRequirements
+          // Gate on nextStep, not the persisted assessment counters: nextStep
+          // is derived from the live status rows, so "there are open items"
+          // and "here is the next one" cannot contradict each other when the
+          // counters are stale.
+          nextStep
             ? `<p style="color: ${BRAND.mutedForeground}; font-size: 13px; line-height: 1.6; margin: 0 0 16px;">
           Open items return in every weekly report until they are done. Completed items land in the audit trail as evidence.
         </p>`
@@ -555,7 +559,7 @@ export function weeklyManagementDigestEmail(opts: {
         ${dashboardButtonHtml(
           dashboardUrl,
           "weekly_management_digest",
-          completedRequirements < totalRequirements ? "Review the open items" : "View Dashboard",
+          nextStep ? "Review the open items" : "View Dashboard",
         )}
         <div style="margin: 24px 0 0; padding: 16px; background: ${BRAND.muted}; border: 1px solid ${BRAND.border}; border-radius: 6px; font-size: 12px; color: ${BRAND.mutedForeground}; line-height: 1.5;">
           This email serves as documentation of management notification per Art. 20 NIS 2 / &sect;38 BSIG.<br/>
@@ -585,7 +589,7 @@ export function weeklyManagementDigestEmail(opts: {
             ``,
           ]
         : []),
-      ...(completedRequirements < totalRequirements
+      ...(nextStep
         ? [
             `Open items return in every weekly report until they are done. Completed items land in the audit trail as evidence.`,
             ``,


### PR DESCRIPTION
Fixes the four verified findings from the post-merge review of #151:

1. **Nondeterministic assignee**: `findFirst` on `requirement_assignment` had no `orderBy`, but multiple assignments per status row are legal — the §38-evidence email could name a different owner each week. Now ordered by `assignedAt` (first assigned owner, matching the field's doc).
2. **Two progress sources**: the weekly 'open items' gate used persisted `companyAssessment` counters while 'Next up' came from live rows; stale counters could make one email contradict itself. Both gates now key on the live-row `nextStep`.
3. **Self-defeating name fallback**: the category-name map stored `""` for unnamed categories, so the `?? slug` fallback could never fire. Only named entries are mapped now.
4. **Wasted query**: the daily digest compiled the assignee it never renders, per member and twice per send. The lookup now runs only on the weekly path.

Typecheck clean, 325 unit + 216 l0 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkHp2TCgHzEVywZ1F6dJEh