### PR TITLE
fix(i18n): persist the language switch so email can read it

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,13 +1,13 @@
-import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { user } from "@/schema";
-import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
-import { sendAuthCode } from "@/lib/mail";
+import { NextResponse } from "next/server";
 import { isDisposableEmail } from "@/lib/auth/disposable";
+import { OtpRateLimitedError, requestOtp } from "@/lib/auth/otp";
 import { getClientIp } from "@/lib/client-ip";
+import { db } from "@/lib/db";
 import { isLocaleCode } from "@/lib/locale";
+import { sendAuthCode } from "@/lib/mail";
 import type { Locale } from "@/lib/seo";
+import { user } from "@/schema";
 
 // In-memory IP rate limit. Matches the pattern used by /api/auth/register.
 // Per-email rate limiting lives in requestOtp itself.

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -6,7 +6,7 @@ import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
 import { sendAuthCode } from "@/lib/mail";
 import { isDisposableEmail } from "@/lib/auth/disposable";
 import { getClientIp } from "@/lib/client-ip";
-import { LOCALES } from "@/lib/locale";
+import { isLocaleCode } from "@/lib/locale";
 import type { Locale } from "@/lib/seo";
 
 // In-memory IP rate limit. Matches the pattern used by /api/auth/register.
@@ -59,9 +59,7 @@ export async function POST(request: Request) {
   const email = (body.email as string | undefined)?.toLowerCase().trim();
   const rawLocale = body.locale as string | undefined;
   // Full app-locale validation: the OTP templates carry all 10 locales.
-  const locale: Locale = LOCALES.some((l) => l.code === rawLocale)
-    ? (rawLocale as Locale)
-    : "de";
+  const locale: Locale = isLocaleCode(rawLocale) ? rawLocale : "de";
 
   if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     // Shape validation only — still return the generic success shape so

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { eq } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { user } from "@/schema";
-import { sendAuthCode } from "@/lib/mail";
-import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
+import { NextResponse } from "next/server";
 import { checkEmailQuality } from "@/lib/auth/email-quality";
+import { OtpRateLimitedError, requestOtp } from "@/lib/auth/otp";
 import { getClientIp } from "@/lib/client-ip";
+import { db } from "@/lib/db";
 import { isLocaleCode, type LocaleCode } from "@/lib/locale";
+import { sendAuthCode } from "@/lib/mail";
 import type { Locale } from "@/lib/seo";
+import { user } from "@/schema";
 
 // Simple in-memory rate limiter: max 5 attempts per IP per 15 minutes
 const attempts = new Map<string, { count: number; resetAt: number }>();
@@ -83,10 +83,7 @@ export async function POST(request: Request) {
   }
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return NextResponse.json(
-      { error: "Invalid email format" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
   }
 
   if (email.length > 255) {
@@ -141,15 +138,18 @@ export async function POST(request: Request) {
     // onConflictDoNothing guards against two concurrent registrations for the
     // same new email racing past the findFirst check and both attempting the
     // insert — without this the loser hits a unique-constraint 500.
-    await db.insert(user).values({
-      email,
-      name,
-      passwordHash,
-      role: "member",
-      isDisposableEmail: disposable,
-      locale: persistedLocale,
-      // emailVerifiedAt left null — set by /api/auth/verify-email
-    }).onConflictDoNothing({ target: user.email });
+    await db
+      .insert(user)
+      .values({
+        email,
+        name,
+        passwordHash,
+        role: "member",
+        isDisposableEmail: disposable,
+        locale: persistedLocale,
+        // emailVerifiedAt left null — set by /api/auth/verify-email
+      })
+      .onConflictDoNothing({ target: user.email });
   }
 
   // Disposable email: user record is kept so we can see the scoping/bot
@@ -157,10 +157,7 @@ export async function POST(request: Request) {
   // permanently unverified and unable to sign in. Response shape matches
   // the happy path to avoid leaking which domains are blocked.
   if (disposable) {
-    console.log(
-      `[register] Silent block (${quality.reason}):`,
-      email.split("@")[1],
-    );
+    console.log(`[register] Silent block (${quality.reason}):`, email.split("@")[1]);
     return NextResponse.json({ success: true, verificationRequired: true });
   }
 
@@ -171,7 +168,9 @@ export async function POST(request: Request) {
   } catch (err) {
     if (err instanceof OtpRateLimitedError) {
       return NextResponse.json(
-        { error: "Too many verification emails. Please wait a few minutes and try again." },
+        {
+          error: "Too many verification emails. Please wait a few minutes and try again.",
+        },
         { status: 429 },
       );
     }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -7,7 +7,7 @@ import { sendAuthCode } from "@/lib/mail";
 import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
 import { checkEmailQuality } from "@/lib/auth/email-quality";
 import { getClientIp } from "@/lib/client-ip";
-import { LOCALES, type LocaleCode } from "@/lib/locale";
+import { isLocaleCode, type LocaleCode } from "@/lib/locale";
 import type { Locale } from "@/lib/seo";
 
 // Simple in-memory rate limiter: max 5 attempts per IP per 15 minutes
@@ -70,10 +70,8 @@ export async function POST(request: Request) {
   // for all 10 locales, and the same value is persisted on the user row so
   // emails sent outside a request (lifecycle crons) can localize later.
   // Unknown values stay null on the row and fall back to "de" for the email.
-  const persistedLocale: LocaleCode | null = LOCALES.some(
-    (l) => l.code === localeInput,
-  )
-    ? (localeInput as LocaleCode)
+  const persistedLocale: LocaleCode | null = isLocaleCode(localeInput)
+    ? localeInput
     : null;
   const locale: Locale = persistedLocale ?? "de";
 

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { user } from "@/schema";
 import { sendAuthCode } from "@/lib/mail";
 import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
-import { LOCALES } from "@/lib/locale";
+import { isLocaleCode } from "@/lib/locale";
 import type { Locale } from "@/lib/seo";
 
 /**
@@ -31,9 +31,7 @@ export async function POST(request: Request) {
   const email = (body.email as string | undefined)?.toLowerCase().trim();
   const localeInput = body.locale as string | undefined;
   // Full app-locale validation: the OTP templates carry all 10 locales.
-  const locale: Locale = LOCALES.some((l) => l.code === localeInput)
-    ? (localeInput as Locale)
-    : "de";
+  const locale: Locale = isLocaleCode(localeInput) ? localeInput : "de";
 
   if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return NextResponse.json({ error: "Invalid email" }, { status: 400 });

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -1,11 +1,11 @@
+import { and, eq, isNull } from "drizzle-orm";
 import { NextResponse } from "next/server";
-import { eq, isNull, and } from "drizzle-orm";
+import { OtpRateLimitedError, requestOtp } from "@/lib/auth/otp";
 import { db } from "@/lib/db";
-import { user } from "@/schema";
-import { sendAuthCode } from "@/lib/mail";
-import { requestOtp, OtpRateLimitedError } from "@/lib/auth/otp";
 import { isLocaleCode } from "@/lib/locale";
+import { sendAuthCode } from "@/lib/mail";
 import type { Locale } from "@/lib/seo";
+import { user } from "@/schema";
 
 /**
  * Resend the email-verification OTP for a pending-verify account.

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -12,15 +12,26 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Globe } from "lucide-react";
 import { LOCALES, type LocaleCode } from "@/lib/locale";
+import { trpc } from "@/lib/trpc/client";
 
 export function LocaleSwitcher() {
   const locale = useLocale();
   const router = useRouter();
   const pathname = usePathname();
   const params = useParams();
+  const setLocale = trpc.user.setLocale.useMutation();
 
-  function switchTo(next: string) {
+  function switchTo(next: LocaleCode) {
     if (next === locale) return;
+
+    // Switching the language is also a statement about which language this
+    // person wants to be written to in, and mail sent from a cron has no
+    // browser to ask. The URL and the cookie below reach the next render; this
+    // reaches the daily digest. A no-op when signed out, and deliberately not
+    // awaited: a language switch should not wait on a write, and a TanStack
+    // mutation runs to completion regardless of what unmounts behind it.
+    setLocale.mutate({ locale: next });
+
     // `usePathname()` returns the route template (e.g.
     // `/compliance/[categorySlug]/[requirementCode]`); the dynamic segments
     // are filled from `params` so they survive the locale switch. Passing the
@@ -28,7 +39,7 @@ export function LocaleSwitcher() {
     // breaks every dynamic route.
     router.replace(
       { pathname, params } as Parameters<typeof router.replace>[0],
-      { locale: next as LocaleCode },
+      { locale: next },
     );
   }
 

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, usePathname } from "@/i18n/navigation";
+import { Globe } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useLocale } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Globe } from "lucide-react";
+import { usePathname, useRouter } from "@/i18n/navigation";
 import { LOCALES, type LocaleCode } from "@/lib/locale";
 import { trpc } from "@/lib/trpc/client";
 
@@ -37,10 +37,9 @@ export function LocaleSwitcher() {
     // are filled from `params` so they survive the locale switch. Passing the
     // bare template without params leaves the `[..]` placeholders literal and
     // breaks every dynamic route.
-    router.replace(
-      { pathname, params } as Parameters<typeof router.replace>[0],
-      { locale: next },
-    );
+    router.replace({ pathname, params } as Parameters<typeof router.replace>[0], {
+      locale: next,
+    });
   }
 
   return (

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -284,8 +284,7 @@ export const routing = defineRouting({
     // Training (logged in)
     "/training/courses": "/training/courses",
     "/training/courses/[courseId]": "/training/courses/[courseId]",
-    "/training/courses/[courseId]/[lessonId]":
-      "/training/courses/[courseId]/[lessonId]",
+    "/training/courses/[courseId]/[lessonId]": "/training/courses/[courseId]/[lessonId]",
 
     // Admin
     "/platform-admin": "/platform-admin",

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,5 +1,6 @@
 import { defineRouting } from "next-intl/routing";
 import { wikiPathnames } from "@/lib/content/wiki-toc";
+import { LOCALE_COOKIE } from "@/lib/locale";
 
 /**
  * Routing config — locales + localized pathnames.
@@ -48,6 +49,9 @@ export const routing = defineRouting({
   defaultLocale: "de",
   localePrefix: "as-needed",
   localeCookie: {
+    // Same string next-intl would have defaulted to, stated explicitly because
+    // lib/auth/config.ts reads this cookie to seed user.locale on OAuth signup.
+    name: LOCALE_COOKIE,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
   },

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,28 +1,23 @@
 import "@/lib/server-guard";
-import { cache } from "react";
-import { cookies } from "next/headers";
-import NextAuth, { CredentialsSignin } from "next-auth";
-import Google from "next-auth/providers/google";
-import Credentials from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
 import { eq, sql } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { user, company } from "@/schema";
+import { cookies } from "next/headers";
 import type { Session } from "next-auth";
+import NextAuth, { CredentialsSignin } from "next-auth";
 import type { Provider } from "next-auth/providers";
-
-import { env } from "@/lib/env";
-import {
-  sendMail,
-  sendWelcomeEmail,
-  newUserSignupEmail,
-} from "@/lib/mail";
-import { getAppUrl } from "@/lib/utils";
+import Credentials from "next-auth/providers/credentials";
+import Google from "next-auth/providers/google";
+import { cache } from "react";
 import { checkEmailQuality } from "@/lib/auth/email-quality";
 import { getPlatformAdminEmails } from "@/lib/auth/platform-admin";
-import { createDraftCompany } from "@/server/trpc/helpers/setup-helpers";
-import { LOCALE_COOKIE, isLocaleCode, type LocaleCode } from "@/lib/locale";
+import { db } from "@/lib/db";
+import { env } from "@/lib/env";
+import { isLocaleCode, LOCALE_COOKIE, type LocaleCode } from "@/lib/locale";
+import { newUserSignupEmail, sendMail, sendWelcomeEmail } from "@/lib/mail";
 import { resolveHints } from "@/lib/onboarding/hints";
+import { getAppUrl } from "@/lib/utils";
+import { company, user } from "@/schema";
+import { createDraftCompany } from "@/server/trpc/helpers/setup-helpers";
 
 // Dummy hash for timing-safe comparison when user doesn't exist
 const DUMMY_HASH = "$2a$12$000000000000000000000uGBYRMjo5lsWIKE/k.HdGZfR5YmKKKu";
@@ -144,10 +139,7 @@ const providers: Provider[] = [
 // in a production environment is a full auth bypass, so the env-var alone is
 // not sufficient — the production check is the belt and the env-var is the
 // suspenders.
-if (
-  process.env.NODE_ENV !== "production" &&
-  process.env.ENABLE_DEV_AUTH === "true"
-) {
+if (process.env.NODE_ENV !== "production" && process.env.ENABLE_DEV_AUTH === "true") {
   providers.push(
     Credentials({
       id: "dev",
@@ -162,7 +154,7 @@ if (
         if (!dbUser) return null;
         return { id: dbUser.id, email: dbUser.email, name: dbUser.name };
       },
-    })
+    }),
   );
 }
 
@@ -270,11 +262,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
               ? sendMail({
                   emailType: "internal.new_signup_alert",
                   to: admins,
-                  ...newUserSignupEmail({ userEmail: authUser.email, userName: newName, provider: account.provider }),
-                }).catch((err) => console.error("[auth] Failed to send admin signup alert:", err))
+                  ...newUserSignupEmail({
+                    userEmail: authUser.email,
+                    userName: newName,
+                    provider: account.provider,
+                  }),
+                }).catch((err) =>
+                  console.error("[auth] Failed to send admin signup alert:", err),
+                )
               : Promise.resolve(),
-            sendWelcomeEmail({ name: newName, email: authUser.email })
-              .catch((err) => console.error("[auth] Failed to send welcome email:", err)),
+            sendWelcomeEmail({ name: newName, email: authUser.email }).catch((err) =>
+              console.error("[auth] Failed to send welcome email:", err),
+            ),
           ]);
         }
 

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,5 +1,6 @@
 import "@/lib/server-guard";
 import { cache } from "react";
+import { cookies } from "next/headers";
 import NextAuth, { CredentialsSignin } from "next-auth";
 import Google from "next-auth/providers/google";
 import Credentials from "next-auth/providers/credentials";
@@ -20,6 +21,7 @@ import { getAppUrl } from "@/lib/utils";
 import { checkEmailQuality } from "@/lib/auth/email-quality";
 import { getPlatformAdminEmails } from "@/lib/auth/platform-admin";
 import { createDraftCompany } from "@/server/trpc/helpers/setup-helpers";
+import { LOCALE_COOKIE, isLocaleCode, type LocaleCode } from "@/lib/locale";
 import { resolveHints } from "@/lib/onboarding/hints";
 
 // Dummy hash for timing-safe comparison when user doesn't exist
@@ -40,6 +42,29 @@ class CredentialsFlowError extends CredentialsSignin {
   constructor(code: string) {
     super();
     this.code = code;
+  }
+}
+
+/**
+ * The language a Google signup was reading the site in, or null.
+ *
+ * Credentials signup posts its locale in the request body; an OAuth callback
+ * has no body, so the only trace of the choice is the cookie next-intl set when
+ * the visitor used the switcher. Absent for anyone who never touched it, which
+ * is the honest answer — `resolveEmailLocale` then falls back to the company's
+ * country rather than to a guess made here.
+ *
+ * `cookies()` throws outside a request scope. The signIn callback always runs
+ * inside one, so the catch is for the case that stops being true: a language
+ * nobody can read is worth strictly less than a sign-in that completes.
+ */
+async function signupLocaleFromCookie(): Promise<LocaleCode | null> {
+  try {
+    const store = await cookies();
+    const value = store.get(LOCALE_COOKIE)?.value;
+    return isLocaleCode(value) ? value : null;
+  } catch {
+    return null;
   }
 }
 
@@ -202,6 +227,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             // Google verified `profile.email_verified` upstream so we trust
             // the address — no separate OTP step for OAuth signups.
             emailVerifiedAt: now,
+            // /api/auth/register receives the locale in its POST body; an OAuth
+            // callback has no body to put it in, so the cookie next-intl
+            // already set is the only thing carrying it. Null when the visitor
+            // never touched the switcher, which resolveEmailLocale handles.
+            locale: await signupLocaleFromCookie(),
           })
           .onConflictDoNothing({ target: user.email })
           .returning({ id: user.id });

--- a/lib/locale.test.ts
+++ b/lib/locale.test.ts
@@ -6,8 +6,8 @@
  * user.locale, where resolveEmailLocale would quietly turn it into English.
  */
 import { describe, expect, test } from "bun:test";
-import { isLocaleCode, LOCALES, LOCALE_COOKIE } from "./locale";
 import { routing } from "@/i18n/routing";
+import { isLocaleCode, LOCALE_COOKIE, LOCALES } from "./locale";
 
 describe("isLocaleCode", () => {
   test("accepts every locale the switcher offers", () => {

--- a/lib/locale.test.ts
+++ b/lib/locale.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `isLocaleCode` is the gate on every locale that reaches the database:
+ * the three auth routes narrow their request body with it, the OAuth path
+ * narrows a cookie a browser can set to anything, and user.setLocale narrows
+ * its tRPC input. A guard that said yes too readily would write junk into
+ * user.locale, where resolveEmailLocale would quietly turn it into English.
+ */
+import { describe, expect, test } from "bun:test";
+import { isLocaleCode, LOCALES, LOCALE_COOKIE } from "./locale";
+import { routing } from "@/i18n/routing";
+
+describe("isLocaleCode", () => {
+  test("accepts every locale the switcher offers", () => {
+    for (const { code } of LOCALES) {
+      expect(isLocaleCode(code)).toBe(true);
+    }
+  });
+
+  test("rejects absent values", () => {
+    expect(isLocaleCode(null)).toBe(false);
+    expect(isLocaleCode(undefined)).toBe(false);
+    expect(isLocaleCode("")).toBe(false);
+  });
+
+  test("rejects real locales the app does not serve", () => {
+    for (const code of ["da", "sv", "fi", "el", "hu", "en-GB", "de-AT"]) {
+      expect(isLocaleCode(code)).toBe(false);
+    }
+  });
+
+  test("rejects near-misses rather than coercing them", () => {
+    // A cookie is attacker-settable and a request body is user-settable, so
+    // the guard has to be exact rather than forgiving. "DE" reaching the
+    // column would resolve to English mail for a German reader.
+    for (const code of ["DE", "De", " de", "de ", "de;en", "../de"]) {
+      expect(isLocaleCode(code)).toBe(false);
+    }
+  });
+});
+
+describe("locale sources agree", () => {
+  test("every switcher code is a locale the router serves", () => {
+    // lib/locale.ts says "every `code` must exist in i18n/routing.ts" in a
+    // comment. This is that comment as a test: a code that drifts out of
+    // routing would render a switcher entry that navigates to a 404.
+    const served: readonly string[] = routing.locales;
+    for (const { code } of LOCALES) {
+      expect(served).toContain(code);
+    }
+  });
+
+  test("the router serves nothing the switcher hides", () => {
+    const offered = LOCALES.map((l) => l.code);
+    for (const code of routing.locales) {
+      expect(offered).toContain(code);
+    }
+  });
+
+  test("the cookie name is the one next-intl is configured with", () => {
+    // lib/auth/config.ts reads this cookie by name to seed a signup's locale.
+    // If routing stopped passing LOCALE_COOKIE, that read would silently
+    // return undefined and every Google signup would land back on null.
+    expect(routing.localeCookie).toMatchObject({ name: LOCALE_COOKIE });
+  });
+});

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -35,3 +35,25 @@ export const LOCALES = [
 ] as const;
 
 export type LocaleCode = (typeof LOCALES)[number]["code"];
+
+/**
+ * Narrows an untrusted string to a locale the app actually serves.
+ *
+ * The three auth routes each carried their own copy of
+ * `LOCALES.some((l) => l.code === x) ? (x as LocaleCode) : fallback`, and each
+ * copy needed the cast because `.some()` proves nothing to the compiler. A type
+ * predicate proves it once and the casts go away.
+ */
+export function isLocaleCode(value: string | null | undefined): value is LocaleCode {
+  return LOCALES.some((l) => l.code === value);
+}
+
+/**
+ * The cookie next-intl writes when a visitor switches language.
+ *
+ * "NEXT_LOCALE" is next-intl's own default; naming it here and passing it to
+ * `localeCookie` in i18n/routing.ts makes the string one value rather than a
+ * default on one side and a guess on the other. The OAuth signup path reads it
+ * to seed `user.locale`, which is the only reason it has to be nameable at all.
+ */
+export const LOCALE_COOKIE = "NEXT_LOCALE";

--- a/server/trpc/routers/user.test.ts
+++ b/server/trpc/routers/user.test.ts
@@ -9,9 +9,9 @@
  * never names a user.
  */
 import { describe, expect, test } from "bun:test";
+import type { TRPCContext } from "../init";
 import { createCallerFactory } from "../init";
 import { userRouter } from "./user";
-import type { TRPCContext } from "../init";
 
 type Recorded = { set: Record<string, unknown>; where: unknown };
 

--- a/server/trpc/routers/user.test.ts
+++ b/server/trpc/routers/user.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `setLocale` is a public procedure that writes to the user table, which is an
+ * unusual enough shape to be worth pinning rather than trusting to review.
+ *
+ * Two things have to stay true. A signed-out call must touch no row at all
+ * (`db` here throws if anything reaches it). And a signed-in call must write to
+ * `ctx.userId` and nothing the caller supplied, because the only reason it is
+ * safe to leave this procedure public is that the caller names a language and
+ * never names a user.
+ */
+import { describe, expect, test } from "bun:test";
+import { createCallerFactory } from "../init";
+import { userRouter } from "./user";
+import type { TRPCContext } from "../init";
+
+type Recorded = { set: Record<string, unknown>; where: unknown };
+
+/**
+ * The thinnest thing that satisfies the drizzle chain the mutation uses.
+ * `where` resolves the promise, so the mutation's `await` completes.
+ */
+function recordingDb(recorded: Recorded[]) {
+  return {
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (condition: unknown) => {
+          recorded.push({ set: values, where: condition });
+          return Promise.resolve();
+        },
+      }),
+    }),
+  };
+}
+
+const REFUSING_DB = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      throw new Error(`signed-out setLocale touched the database: .${String(prop)}`);
+    },
+  },
+);
+
+function callerWith(ctx: Partial<TRPCContext>) {
+  const base = {
+    session: null,
+    userId: null,
+    companyId: null,
+    ip: "test",
+    userAgent: null,
+  };
+  return createCallerFactory(userRouter)({ ...base, ...ctx } as TRPCContext);
+}
+
+describe("user.setLocale", () => {
+  test("signed out: reports nothing persisted and never reaches the db", async () => {
+    const caller = callerWith({ db: REFUSING_DB as TRPCContext["db"] });
+
+    expect(await caller.setLocale({ locale: "en" })).toEqual({ persisted: false });
+  });
+
+  test("signed in: writes the locale and stamps updatedAt", async () => {
+    const recorded: Recorded[] = [];
+    const caller = callerWith({
+      userId: "user-1",
+      db: recordingDb(recorded) as unknown as TRPCContext["db"],
+    });
+
+    expect(await caller.setLocale({ locale: "en" })).toEqual({ persisted: true });
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].set.locale).toBe("en");
+    expect(recorded[0].set.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test("signed in: writes nothing but the locale and the timestamp", async () => {
+    // A future edit that widened the input into a `.set(input)` spread would
+    // let a caller write role, email or passwordHash through a public
+    // procedure. The column list is the guard, so assert on it directly.
+    const recorded: Recorded[] = [];
+    const caller = callerWith({
+      userId: "user-1",
+      db: recordingDb(recorded) as unknown as TRPCContext["db"],
+    });
+
+    await caller.setLocale({ locale: "nl" });
+
+    expect(Object.keys(recorded[0].set).sort()).toEqual(["locale", "updatedAt"]);
+  });
+
+  test("rejects a locale the app does not serve", async () => {
+    const caller = callerWith({
+      userId: "user-1",
+      db: REFUSING_DB as TRPCContext["db"],
+    });
+
+    // Not a 500 from the column's varchar(10), and not a silent write: the
+    // input schema refuses it before ctx.db is ever reached.
+    for (const locale of ["DE", "da", "", "de-AT", "'; drop table user; --"]) {
+      await expect(caller.setLocale({ locale })).rejects.toThrow();
+    }
+  });
+});

--- a/server/trpc/routers/user.ts
+++ b/server/trpc/routers/user.ts
@@ -1,10 +1,11 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { router, protectedProcedure } from "../init";
+import { router, protectedProcedure, publicProcedure } from "../init";
 import { user } from "@/schema";
 import { userUpdateSchema } from "@/schema/validators";
 import { HINTS, HINT_COLUMN } from "@/lib/onboarding/hints";
+import { isLocaleCode } from "@/lib/locale";
 
 export const userRouter = router({
   /**
@@ -30,6 +31,38 @@ export const userRouter = router({
         .where(eq(user.id, ctx.userId));
 
       return { name };
+    }),
+
+  /**
+   * Remember which language this account reads the platform in.
+   *
+   * The language switcher used to be navigation and nothing else: it rewrote
+   * the URL and let next-intl set its cookie, both of which live in one
+   * browser. A cron has neither. So lifecycle mail read `user.locale`, a column
+   * only ever written at registration, and somebody who signed up on the German
+   * page and then switched to English got German mail forever with no way to
+   * correct it. This is the way to correct it.
+   *
+   * Public rather than protected because the switcher also renders in the
+   * marketing nav and the footer, and neither knows whether anyone is signed
+   * in: there is no SessionProvider on the client, and PublicFooter
+   * deliberately never calls auth() so its pages stay prerendered. Making this
+   * protected would mean either threading a session prop through both, or
+   * letting every signed-out language switch answer 401. A signed-out switch is
+   * simply a no-op instead. Nothing is read, and the only row that can be
+   * written is ctx.userId's own — the caller names a language, never a user.
+   */
+  setLocale: publicProcedure
+    .input(z.object({ locale: z.string().refine(isLocaleCode) }))
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.userId) return { persisted: false };
+
+      await ctx.db
+        .update(user)
+        .set({ locale: input.locale, updatedAt: new Date() })
+        .where(eq(user.id, ctx.userId));
+
+      return { persisted: true };
     }),
 
   /**

--- a/server/trpc/routers/user.ts
+++ b/server/trpc/routers/user.ts
@@ -1,11 +1,11 @@
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { TRPCError } from "@trpc/server";
-import { router, protectedProcedure, publicProcedure } from "../init";
+import { isLocaleCode } from "@/lib/locale";
+import { HINT_COLUMN, HINTS } from "@/lib/onboarding/hints";
 import { user } from "@/schema";
 import { userUpdateSchema } from "@/schema/validators";
-import { HINTS, HINT_COLUMN } from "@/lib/onboarding/hints";
-import { isLocaleCode } from "@/lib/locale";
+import { protectedProcedure, publicProcedure, router } from "../init";
 
 export const userRouter = router({
   /**


### PR DESCRIPTION
## The bug

The language switcher was navigation and nothing else. It rewrote the URL and let next-intl set its cookie, both of which live in one browser. Mail sent from a cron has neither, so it read `user.locale` — a column written once at registration (`app/api/auth/register/route.ts`) and never again.

Somebody who signed up at `nisd2.eu` (German at the bare domain, `defaultLocale: "de"` + `localePrefix: "as-needed"`) and then switched the portal to English got German mail forever, with no way to correct it. Google signups had it worse: `locale` was never written at all, so they fell through to `company.country`, which for a German market is German again.

Found because Cory got a German lifecycle email while using the platform in English. The fallback chain is right for most of the current user base, which is why it survived; it is wrong for exactly the English-speaking self-host and OSS audience.

## The change

- **`user.setLocale`** writes the switch. Public rather than protected: the switcher also renders in `PublicNav` and `PublicFooter`, and neither knows whether anyone is signed in — there is no `SessionProvider` on the client, and `PublicFooter` deliberately never calls `auth()` so its pages stay prerendered. Signed out is a no-op, not a 401. The only row it can write is `ctx.userId`'s own; the caller names a language, never a user.
- **OAuth signup** seeds `locale` from next-intl's cookie, the only thing carrying the choice through a callback with no request body. `i18n/routing.ts` now names that cookie explicitly instead of leaning on the default.
- **`isLocaleCode`** replaces the `LOCALES.some(...) ? (x as Locale) : fallback` that all three auth routes had their own copy of, casts included.

**No schema change** — `user.locale` already exists.

## Verification

- `bun run typecheck` clean, `bun run lint:ci` exit 0, `bun run build` compiles and prerenders all 70 static pages (including the 24 `/docs` pages, which render `PublicNav` outside `TRPCProvider` — the check that the new `trpc` import in the switcher does not break them).
- `bun run test:unit` 363 pass / 0 fail, including 11 new ones: `lib/locale.test.ts` (the guard, plus a test that the switcher list and `routing.locales` cannot drift apart, and that the cookie name stays wired) and `server/trpc/routers/user.test.ts` (signed-out never touches the db, signed-in writes only `locale` + `updatedAt`, unknown codes rejected before the db).
- Against the real dev database: a row with `locale = NULL` resolved to `"de"`; after `setLocale("en")` the column held `en` and `resolveEmailLocale` returned `"en"`; a signed-out call changed nothing.

## What this does not fix

Most templates are still English-only. `lib/mail/templates.ts` localizes the OTP and password-reset copy (all 10 locales) and the digest footer (de/en/nl), and `lib/lifecycle/emails/activation-nudge.ts` carries de/en/nl. The daily and weekly digest bodies, invites, assignment, review-decision and supplier-broadcast mail are English regardless. This PR makes the stored language correct; the copy that reads it still has gaps.

Closes the switcher half of the problem only.