### PR TITLE
refactor(i18n): one source for the locale set, and fix three defects from #160

### DIFF
--- a/app/[locale]/wiki/zeit-und-status/nis2-tracker-eu/page.tsx
+++ b/app/[locale]/wiki/zeit-und-status/nis2-tracker-eu/page.tsx
@@ -1,20 +1,20 @@
 import type { Metadata } from "next";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Link } from "@/i18n/navigation";
-import { pageAlternates, pageOg, type Locale } from "@/lib/seo";
-import { pickLocalized } from "@/lib/locale";
-import { routing } from "@/i18n/routing";
+import { GlossedProse } from "@/components/wiki/GlossedProse";
 import { WikiPageJsonLd } from "@/components/wiki/WikiPageJsonLd";
 import { WikiPageMeta } from "@/components/wiki/WikiPageMeta";
-import { GlossedProse } from "@/components/wiki/GlossedProse";
+import { Link } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+import { isLocaleCode, pickLocalized } from "@/lib/locale";
 import {
   getRegistrationPortals,
   getTranspositionStatus,
   type RegistrationPortal,
   type TranspositionStatus,
 } from "@/lib/registration-portals";
+import { type Locale, pageAlternates, pageOg } from "@/lib/seo";
 
 /**
  * A locale-keyed string bundle. de/en are always authored; fr/it/es/pl are
@@ -41,9 +41,7 @@ function resolveLocale(rawLocale: string): Locale {
   // The tracker bundles carry de/en/fr/it/es/pl; nl has no strings here and
   // rendered German before the new locales existed, so keep that behaviour.
   if (rawLocale === "nl") return "de";
-  return (routing.locales as readonly string[]).includes(rawLocale)
-    ? (rawLocale as Locale)
-    : "de";
+  return isLocaleCode(rawLocale) ? rawLocale : "de";
 }
 
 export async function generateMetadata({
@@ -84,10 +82,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: pageAlternates(
-      "wiki/zeit-und-status/nis2-tracker-eu",
-      locale,
-    ),
+    alternates: pageAlternates("wiki/zeit-und-status/nis2-tracker-eu", locale),
     ...pageOg({
       slug: "wiki/zeit-und-status/nis2-tracker-eu",
       locale,
@@ -134,7 +129,7 @@ const STATUS_LABELS: Record<TranspositionStatus, Localized> = {
     pt: "Projeto de lei pendente",
     ro: "Proiect de lege în curs",
   },
-  "drafting": {
+  drafting: {
     de: "Im Entwurf",
     en: "Drafting",
     fr: "En préparation",
@@ -145,7 +140,7 @@ const STATUS_LABELS: Record<TranspositionStatus, Localized> = {
     pt: "Em elaboração",
     ro: "În pregătire",
   },
-  "unknown": {
+  unknown: {
     de: "Unbekannt",
     en: "Unknown",
     fr: "Inconnu",
@@ -204,9 +199,7 @@ export default async function Nis2TrackerEuPage({
     inForce: rows.filter((r) => r.transpositionStatus === "in-force").length,
     pending: rows.filter((r) => r.transpositionStatus === "bill-pending").length,
     drafting: rows.filter(
-      (r) =>
-        r.transpositionStatus === "drafting" ||
-        r.transpositionStatus === "unknown",
+      (r) => r.transpositionStatus === "drafting" || r.transpositionStatus === "unknown",
     ).length,
   };
 
@@ -291,11 +284,7 @@ export default async function Nis2TrackerEuPage({
 
         <WikiPageMeta
           authorSlug="simon-orzel"
-          locale={
-            locale === "de" || locale === "en" || locale === "nl"
-              ? locale
-              : "en"
-          }
+          locale={locale === "de" || locale === "en" || locale === "nl" ? locale : "en"}
           lastReviewedAt="2026-06-01"
           sourceLocale="en"
         />
@@ -512,10 +501,7 @@ export default async function Nis2TrackerEuPage({
               {rows.map((r) => {
                 const act = r.nationalLaw ?? "-";
                 const note = trackerNote(r, locale);
-                const statusLabel = pick(
-                  STATUS_LABELS[r.transpositionStatus],
-                  locale,
-                );
+                const statusLabel = pick(STATUS_LABELS[r.transpositionStatus], locale);
                 return (
                   <tr key={r.countryCode} className="border-t">
                     <td className="px-4 py-3 align-top">
@@ -525,9 +511,7 @@ export default async function Nis2TrackerEuPage({
                         </span>
                         {r.wikiSlug ? (
                           <Link
-                            href={
-                              `/wiki/zeit-und-status/${r.wikiSlug}` as never
-                            }
+                            href={`/wiki/zeit-und-status/${r.wikiSlug}` as never}
                             className="font-medium hover:underline"
                           >
                             {r.name}
@@ -601,9 +585,7 @@ export default async function Nis2TrackerEuPage({
                       </span>
                       <span className="text-sm font-medium">{r.name}</span>
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {r.authority}
-                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">{r.authority}</p>
                   </Link>
                 ))}
             </div>

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,6 +1,6 @@
 import { defineRouting } from "next-intl/routing";
 import { wikiPathnames } from "@/lib/content/wiki-toc";
-import { LOCALE_COOKIE } from "@/lib/locale";
+import { LOCALE_CODES, LOCALE_COOKIE, type LocaleCode } from "@/lib/locale";
 
 /**
  * Routing config — locales + localized pathnames.
@@ -18,8 +18,8 @@ import { LOCALE_COOKIE } from "@/lib/locale";
  * /supplier-invite/[token]) are intentionally NOT registered —
  * auto-generated, single-use, never indexed.
  */
-const locales = ["de", "en", "nl", "fr", "it", "es", "pl", "cs", "pt", "ro"] as const;
-type Loc = (typeof locales)[number];
+const locales = LOCALE_CODES;
+type Loc = LocaleCode;
 
 /**
  * Localized pathnames are authored for de/en/nl. New locales (fr/it/es/pl)

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -44,10 +44,15 @@ class CredentialsFlowError extends CredentialsSignin {
  * The language a Google signup was reading the site in, or null.
  *
  * Credentials signup posts its locale in the request body; an OAuth callback
- * has no body, so the only trace of the choice is the cookie next-intl set when
- * the visitor used the switcher. Absent for anyone who never touched it, which
- * is the honest answer — `resolveEmailLocale` then falls back to the company's
- * country rather than to a guess made here.
+ * has no body, so the cookie is the only thing carrying it. next-intl's
+ * middleware sets NEXT_LOCALE on every page request rather than only on an
+ * explicit switch (`GET /` answers `de`, `GET /en/pricing` answers `en`), so
+ * this reflects the language they were actually reading, not just the language
+ * they clicked. It is `SameSite=lax`, which is why it survives Google's
+ * top-level redirect back to the callback.
+ *
+ * Null only if no page was loaded first, which in practice means a direct hit
+ * on the callback URL; `resolveEmailLocale` then falls back to company.country.
  *
  * `cookies()` throws outside a request scope. The signIn callback always runs
  * inside one, so the catch is for the case that stops being true: a language
@@ -220,9 +225,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             // the address — no separate OTP step for OAuth signups.
             emailVerifiedAt: now,
             // /api/auth/register receives the locale in its POST body; an OAuth
-            // callback has no body to put it in, so the cookie next-intl
-            // already set is the only thing carrying it. Null when the visitor
-            // never touched the switcher, which resolveEmailLocale handles.
+            // callback has no body to put it in, so the cookie next-intl set
+            // while they browsed is the only thing carrying it.
             locale: await signupLocaleFromCookie(),
           })
           .onConflictDoNothing({ target: user.email })

--- a/lib/locale.test.ts
+++ b/lib/locale.test.ts
@@ -7,7 +7,8 @@
  */
 import { describe, expect, test } from "bun:test";
 import { routing } from "@/i18n/routing";
-import { isLocaleCode, LOCALE_COOKIE, LOCALES } from "./locale";
+import { EMAIL_LOCALES } from "@/lib/mail/locale";
+import { isLocaleCode, LOCALE_CODES, LOCALE_COOKIE, LOCALES } from "./locale";
 
 describe("isLocaleCode", () => {
   test("accepts every locale the switcher offers", () => {
@@ -39,20 +40,34 @@ describe("isLocaleCode", () => {
 });
 
 describe("locale sources agree", () => {
-  test("every switcher code is a locale the router serves", () => {
-    // lib/locale.ts says "every `code` must exist in i18n/routing.ts" in a
-    // comment. This is that comment as a test: a code that drifts out of
-    // routing would render a switcher entry that navigates to a 404.
-    const served: readonly string[] = routing.locales;
-    for (const { code } of LOCALES) {
-      expect(served).toContain(code);
+  test("the router serves exactly LOCALE_CODES, in that order", () => {
+    // routing.locales is now built from LOCALE_CODES, so this is a tripwire
+    // against someone re-introducing a second hardcoded list — which is what
+    // i18n/routing.ts carried before, agreeing with this one by luck.
+    expect(routing.locales).toEqual(LOCALE_CODES);
+  });
+
+  test("the switcher offers every code the router serves, no more", () => {
+    // Same set, different order: the switcher lists English first, routing
+    // lists the default locale first. Sorting is the point of the test.
+    const offered = LOCALES.map((l) => l.code).sort();
+    expect(offered).toEqual([...LOCALE_CODES].sort());
+  });
+
+  test("every switcher entry has a real label", () => {
+    // `satisfies Record<LocaleCode, string>` catches a missing label at
+    // compile time; this catches an empty or placeholder one.
+    for (const { code, label } of LOCALES) {
+      expect(label.trim().length).toBeGreaterThan(0);
+      expect(label).not.toBe(code);
     }
   });
 
-  test("the router serves nothing the switcher hides", () => {
-    const offered = LOCALES.map((l) => l.code);
-    for (const code of routing.locales) {
-      expect(offered).toContain(code);
+  test("email locales are a subset of the app's locales", () => {
+    // EMAIL_LOCALES is typed `satisfies readonly LocaleCode[]`, so this is the
+    // runtime half: mail copy can be narrower than the site, never wider.
+    for (const code of EMAIL_LOCALES) {
+      expect(isLocaleCode(code)).toBe(true);
     }
   });
 

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -17,43 +17,81 @@ export function pickLocalized<T>(
 }
 
 /**
- * Locales offered in the UI language switchers (public navbar + portal
- * sidebar), with their native endonym labels. Single source of truth so the
- * two switchers stay in sync; every `code` must exist in i18n/routing.ts.
+ * Every locale this app serves. THE source: `i18n/routing.ts` passes this list
+ * straight to `defineRouting`, so `routing.locales` and this constant cannot
+ * name different sets. `Locale` in lib/seo.ts is an alias of `LocaleCode`, not
+ * a second union.
+ *
+ * Order is routing order, default first. The switcher shows a different order;
+ * see LOCALE_LABELS.
+ *
+ * Adding one means: a code here, a label below (the compiler demands it), and
+ * a `messages/<code>.json`.
  */
-export const LOCALES = [
-  { code: "en", label: "English" },
-  { code: "de", label: "Deutsch" },
-  { code: "nl", label: "Nederlands" },
-  { code: "fr", label: "Français" },
-  { code: "it", label: "Italiano" },
-  { code: "es", label: "Español" },
-  { code: "pl", label: "Polski" },
-  { code: "cs", label: "Čeština" },
-  { code: "pt", label: "Português" },
-  { code: "ro", label: "Română" },
+export const LOCALE_CODES = [
+  "de",
+  "en",
+  "nl",
+  "fr",
+  "it",
+  "es",
+  "pl",
+  "cs",
+  "pt",
+  "ro",
 ] as const;
 
-export type LocaleCode = (typeof LOCALES)[number]["code"];
+export type LocaleCode = (typeof LOCALE_CODES)[number];
 
 /**
- * Narrows an untrusted string to a locale the app actually serves.
- *
- * The three auth routes each carried their own copy of
- * `LOCALES.some((l) => l.code === x) ? (x as LocaleCode) : fallback`, and each
- * copy needed the cast because `.some()` proves nothing to the compiler. A type
- * predicate proves it once and the casts go away.
+ * Native endonyms, in the order the switcher dropdown lists them — English
+ * first, which is why this is its own object and not a field on LOCALE_CODES.
+ * Membership lives in one place, presentation in another, and `satisfies`
+ * welds them: a code added to LOCALE_CODES without a label here fails to
+ * compile rather than rendering a blank dropdown row.
+ */
+const LOCALE_LABELS = {
+  en: "English",
+  de: "Deutsch",
+  nl: "Nederlands",
+  fr: "Français",
+  it: "Italiano",
+  es: "Español",
+  pl: "Polski",
+  cs: "Čeština",
+  pt: "Português",
+  ro: "Română",
+} as const satisfies Record<LocaleCode, string>;
+
+/**
+ * Locales offered in the UI language switchers (public navbar + portal
+ * sidebar), as `{ code, label }` in dropdown order.
+ */
+export const LOCALES: readonly { code: LocaleCode; label: string }[] = (
+  Object.keys(LOCALE_LABELS) as LocaleCode[]
+).map((code) => ({ code, label: LOCALE_LABELS[code] }));
+
+/**
+ * Narrows an untrusted string to a locale the app actually serves. The one
+ * guard: the three auth routes, the OAuth cookie read, `user.setLocale` and
+ * lib/seo.ts all go through it, each of which used to carry its own `.some()`
+ * or `.includes()` plus the cast that `.some()` forces.
  */
 export function isLocaleCode(value: string | null | undefined): value is LocaleCode {
-  return LOCALES.some((l) => l.code === value);
+  return LOCALE_CODES.some((code) => code === value);
 }
 
 /**
- * The cookie next-intl writes when a visitor switches language.
+ * The cookie next-intl writes to record which language a visitor is reading.
+ *
+ * The middleware sets it on every page request, not only when someone uses the
+ * switcher: `GET /` answers `NEXT_LOCALE=de` and `GET /en/pricing` answers
+ * `NEXT_LOCALE=en`, both `Path=/; SameSite=lax`. That is what makes it readable
+ * from the Google OAuth callback, which arrives as a top-level redirect and so
+ * carries lax cookies.
  *
  * "NEXT_LOCALE" is next-intl's own default; naming it here and passing it to
  * `localeCookie` in i18n/routing.ts makes the string one value rather than a
- * default on one side and a guess on the other. The OAuth signup path reads it
- * to seed `user.locale`, which is the only reason it has to be nameable at all.
+ * default on one side and a guess on the other.
  */
 export const LOCALE_COOKIE = "NEXT_LOCALE";

--- a/lib/mail/email-type-labels.ts
+++ b/lib/mail/email-type-labels.ts
@@ -8,10 +8,17 @@
  * de / en / nl only, matching the languages our email copy exists in.
  */
 import type { EmailCategory, UserConsentEmailTypeId } from "./email-types";
+import { EMAIL_LOCALES, type EmailLocale } from "./locale";
 
-export type PreferenceLocale = "de" | "en" | "nl";
+/**
+ * Alias of EmailLocale. The preference centre and the mail templates answer the
+ * same question — which of the three languages our email copy exists in — and
+ * used to declare the union twice, so a fourth language would have had to be
+ * added in two places to take effect in both.
+ */
+export type PreferenceLocale = EmailLocale;
 
-export const PREFERENCE_LOCALES: readonly PreferenceLocale[] = ["de", "en", "nl"];
+export const PREFERENCE_LOCALES: readonly PreferenceLocale[] = EMAIL_LOCALES;
 
 export function parsePreferenceLocale(raw: string | null | undefined): PreferenceLocale {
   return raw === "en" || raw === "nl" ? raw : "de";

--- a/lib/mail/locale.ts
+++ b/lib/mail/locale.ts
@@ -18,8 +18,17 @@
  *   3. "de" — the platform default (DE-canonical site, German target market;
  *      same nothing-known fallback the OTP emails use).
  */
+import type { LocaleCode } from "@/lib/locale";
 
-export type EmailLocale = "de" | "en" | "nl";
+/**
+ * The languages our email copy exists in, as a subset of the app's locales.
+ * Narrower than LocaleCode on purpose: it asserts "someone has written the mail
+ * in this", not "the site serves this". Typing it against LocaleCode means a
+ * language that is not a real app locale cannot be listed here.
+ */
+export const EMAIL_LOCALES = ["de", "en", "nl"] as const satisfies readonly LocaleCode[];
+
+export type EmailLocale = (typeof EMAIL_LOCALES)[number];
 
 const GERMAN_SPEAKING_COUNTRIES: ReadonlySet<string> = new Set(["DE", "AT", "CH", "LI"]);
 

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,9 +1,16 @@
 import { routing } from "@/i18n/routing";
+import { isLocaleCode, type LocaleCode } from "@/lib/locale";
 import { ogCard } from "./og-card";
 
 export const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.nisd2.eu";
 
-export type Locale = (typeof routing.locales)[number];
+/**
+ * Alias, not a second union. ~160 files import `Locale` from here, so the name
+ * stays; what it points at is `LocaleCode` in lib/locale.ts, which is also what
+ * `routing.locales` is built from. One set of codes, one type, two names for
+ * historical reasons.
+ */
+export type Locale = LocaleCode;
 
 /**
  * Resolves a canonical pathname (the key in routing.pathnames) to its
@@ -24,19 +31,12 @@ function localizedSlug(canonicalPath: string, locale: Locale): string {
  * honouring routing.pathnames. Used by sitemap, hreflang alternates,
  * and JSON-LD URL fields. Single source of truth for locale-aware URLs.
  */
-export function localizedAbsoluteUrl(
-  canonicalPath: string,
-  locale: Locale,
-): string {
+export function localizedAbsoluteUrl(canonicalPath: string, locale: Locale): string {
   const slug = localizedSlug(canonicalPath, locale);
   if (locale === routing.defaultLocale) {
     return slug === "/" ? baseUrl : `${baseUrl}${slug}`;
   }
   return slug === "/" ? `${baseUrl}/${locale}` : `${baseUrl}/${locale}${slug}`;
-}
-
-function isLocale(value: string): value is Locale {
-  return (routing.locales as readonly string[]).includes(value);
 }
 
 /**
@@ -116,7 +116,7 @@ export function pageAlternates(
   locales: readonly Locale[] = routing.locales,
 ) {
   const canonical = slug ? `/${slug}` : "/";
-  const safeLocale: Locale = isLocale(locale) ? locale : routing.defaultLocale;
+  const safeLocale: Locale = isLocaleCode(locale) ? locale : routing.defaultLocale;
 
   // A locale outside `locales` still resolves -- the route exists in all ten
   // and i18n/request.ts fills the namespace from English -- so what it serves
@@ -152,7 +152,7 @@ export function pageAlternates(
 /** Absolute URL for a page in a given locale. */
 export function pageUrl(slug: string, locale: string): string {
   const canonical = slug ? `/${slug}` : "/";
-  const safeLocale: Locale = isLocale(locale) ? locale : routing.defaultLocale;
+  const safeLocale: Locale = isLocaleCode(locale) ? locale : routing.defaultLocale;
   return localizedAbsoluteUrl(canonical, safeLocale);
 }
 
@@ -184,17 +184,14 @@ export function pageOg(args: {
   locale: string;
   title: string;
   description: string;
-  type?:
-    | "website"
-    | "article"
-    | "profile"
-    | "product.group"
-    | "book";
+  type?: "website" | "article" | "profile" | "product.group" | "book";
   image?: string;
   imageAlt?: string;
   twitterHandle?: string;
 }) {
-  const safeLocale: Locale = isLocale(args.locale) ? args.locale : routing.defaultLocale;
+  const safeLocale: Locale = isLocaleCode(args.locale)
+    ? args.locale
+    : routing.defaultLocale;
   const url = pageUrl(args.slug, safeLocale);
   const alternates: string[] = routing.locales
     .filter((l) => l !== safeLocale)
@@ -391,10 +388,7 @@ export function breadcrumbJsonLd(
 // Person byline (Simon / Cory) and the schema.org subtype variants
 // the docs categories need.
 
-import {
-  authorPersonSchema,
-  type DocsAuthor,
-} from "@/lib/content/authors";
+import { authorPersonSchema, type DocsAuthor } from "@/lib/content/authors";
 import type { DocsCategory } from "@/lib/content/content-types";
 
 const LOCALE_BCP47: Record<Locale, string> = {
@@ -552,7 +546,9 @@ export function buildTechArticleJsonLd(input: TechArticleInput): Record<string, 
   if (input.alternativeHeadline) node.alternativeHeadline = input.alternativeHeadline;
   if (input.abstract) node.abstract = input.abstract;
   if (input.image) {
-    const imageUrl = input.image.startsWith("http") ? input.image : `${baseUrl}${input.image}`;
+    const imageUrl = input.image.startsWith("http")
+      ? input.image
+      : `${baseUrl}${input.image}`;
     node.image = {
       "@type": "ImageObject",
       url: imageUrl,
@@ -642,10 +638,7 @@ export function buildSiteGraphJsonLd(_locale: Locale): Record<string, unknown> {
         ],
         knowsLanguage: [...routing.locales],
         areaServed: { "@type": "Place" as const, name: "European Union" },
-        sameAs: [
-          "https://www.linkedin.com/company/nisd2",
-          "https://github.com/NISD2",
-        ],
+        sameAs: ["https://www.linkedin.com/company/nisd2", "https://github.com/NISD2"],
         publishingPrinciples: `${baseUrl}/redaktion`,
         ethicsPolicy: `${baseUrl}/ethik`,
         correctionsPolicy: `${baseUrl}/corrections`,

--- a/packages/isms-schema/src/tables/organization.ts
+++ b/packages/isms-schema/src/tables/organization.ts
@@ -350,11 +350,17 @@ export const user = pgTable(
      */
     lastLoginAt: timestamp("last_login_at"),
     /**
-     * UI locale snapshot taken at registration (one of the app's locale codes,
-     * lib/locale.ts). Exists so emails sent OUTSIDE a request context (lifecycle
-     * crons) can pick a language; in-request emails keep using the request
-     * locale. NULL for OAuth signups and accounts predating the column; readers
-     * fall back to company.country, then "de" (lib/mail/locale.ts).
+     * Which language this account reads the platform in (one of the app's
+     * locale codes, lib/locale.ts). Exists so email sent OUTSIDE a request
+     * context (lifecycle crons, digests) can pick a language; in-request email
+     * keeps using the request locale.
+     *
+     * Written at registration, re-written every time the language switcher is
+     * used (user.setLocale), and seeded on OAuth signup from the NEXT_LOCALE
+     * cookie. NULL only for accounts predating the column — there is no
+     * backfill, because for those rows no record of the choice exists. Readers
+     * go through resolveEmailLocale, which falls back to company.country and
+     * then "de" (lib/mail/locale.ts).
      */
     locale: varchar("locale", { length: 10 }),
     /**

--- a/server/trpc/routers/user.test.ts
+++ b/server/trpc/routers/user.test.ts
@@ -59,7 +59,7 @@ describe("user.setLocale", () => {
     expect(await caller.setLocale({ locale: "en" })).toEqual({ persisted: false });
   });
 
-  test("signed in: writes the locale and stamps updatedAt", async () => {
+  test("signed in: writes the locale", async () => {
     const recorded: Recorded[] = [];
     const caller = callerWith({
       userId: "user-1",
@@ -69,13 +69,15 @@ describe("user.setLocale", () => {
     expect(await caller.setLocale({ locale: "en" })).toEqual({ persisted: true });
     expect(recorded).toHaveLength(1);
     expect(recorded[0].set.locale).toBe("en");
-    expect(recorded[0].set.updatedAt).toBeInstanceOf(Date);
   });
 
-  test("signed in: writes nothing but the locale and the timestamp", async () => {
-    // A future edit that widened the input into a `.set(input)` spread would
-    // let a caller write role, email or passwordHash through a public
-    // procedure. The column list is the guard, so assert on it directly.
+  test("signed in: writes the locale column and nothing else", async () => {
+    // Two things at once. A future edit that widened the input into a
+    // `.set(input)` spread would let a caller write role, email or
+    // passwordHash through a public procedure. And `updatedAt` staying out is
+    // deliberate: platform-admin's unsubscribe view orders by
+    // desc(user.updatedAt) to mean "recently unsubscribed", and a language
+    // switch bumping it would misdate that list.
     const recorded: Recorded[] = [];
     const caller = callerWith({
       userId: "user-1",
@@ -84,7 +86,7 @@ describe("user.setLocale", () => {
 
     await caller.setLocale({ locale: "nl" });
 
-    expect(Object.keys(recorded[0].set).sort()).toEqual(["locale", "updatedAt"]);
+    expect(Object.keys(recorded[0].set)).toEqual(["locale"]);
   });
 
   test("rejects a locale the app does not serve", async () => {

--- a/server/trpc/routers/user.ts
+++ b/server/trpc/routers/user.ts
@@ -57,9 +57,13 @@ export const userRouter = router({
     .mutation(async ({ ctx, input }) => {
       if (!ctx.userId) return { persisted: false };
 
+      // No updatedAt bump. dismissHint, the other incidental-preference write
+      // in this router, deliberately leaves it alone, and platform-admin's
+      // unsubscribe view orders by desc(user.updatedAt) as a stand-in for
+      // "recently unsubscribed" — a language switch is not that.
       await ctx.db
         .update(user)
-        .set({ locale: input.locale, updatedAt: new Date() })
+        .set({ locale: input.locale })
         .where(eq(user.id, ctx.userId));
 
       return { persisted: true };


### PR DESCRIPTION
Follow-up to #160. That PR made the language switch persist, but it left the locale plumbing spread across four places and shipped two comments describing behaviour that had stopped being true. This closes both halves.

## One source for the locale set

| Before | After |
|---|---|
| `i18n/routing.ts:21` and `lib/locale.ts` each hardcoded the same ten codes | `LOCALE_CODES` in `lib/locale.ts` is the list; routing passes it to `defineRouting` |
| `Locale` (seo, derived from `routing.locales`) and `LocaleCode` (locale) | `Locale` is an alias of `LocaleCode`. ~160 files import that name, so the name stays and only its target changed |
| `isLocaleCode` (lib/locale) **and** private `isLocale` (lib/seo, 3 uses) **and** an inline `(routing.locales as readonly string[]).includes(...)` in the EU tracker wiki page | all three go through `isLocaleCode`; two more casts gone |
| `EmailLocale` and `PreferenceLocale`, the same three-way union declared twice in `lib/mail/` | `PreferenceLocale` is an alias; `EMAIL_LOCALES` is `satisfies readonly LocaleCode[]`, so mail copy can be narrower than the site but can never name a language the site does not serve |

Switcher labels moved to `LOCALE_LABELS`, typed `as const satisfies Record<LocaleCode, string>`. Adding a code without a label is now a compile error rather than a blank dropdown row. Dropdown order (English first) and routing order (default first) are both preserved — they are deliberately different, which is why membership and presentation are separate objects.

## Three defects from #160

- **`user.locale`'s own doc was false.** It still read "UI locale snapshot taken at registration" and "NULL for OAuth signups"; #160 made both untrue.
- **`lib/auth/config.ts` described the cookie wrong.** It said the cookie records an explicit switch. next-intl's middleware sets `NEXT_LOCALE` on *every* page request — `GET /` answers `de`, `GET /en/pricing` answers `en` — so it records the language they were reading. The behaviour is better than #160 claimed; the comment was wrong.
- **`setLocale` no longer bumps `updatedAt`.** `platform-admin.ts:675` orders the unsubscribe view by `desc(user.updatedAt)` to mean "recently unsubscribed", so a language switch was misdating that list. `dismissHint`, the other incidental-preference write in the same router, already leaves `updatedAt` alone. A test pins the write to exactly one column.

## Deliberately not unified

The three-language narrowings in journey, wiki bundles and docs categories stay as they are. They assert "someone has written this content in this language", not "the site serves this language" — the distinction `HELP_LOCALES` in `lib/seo.ts` already argues for at length, and collapsing them would couple unrelated content decisions to the routing list.

## Verification

The risk in touching `routing.locales` is sitemap and hreflang, so that was checked directly rather than inferred:

- **hreflang/sitemap output byte-identical to `main`** — `routing.locales`, `defaultLocale`, `localePrefix`, `localeCookie`, `HELP_LOCALES`, and `pageAlternates` across the homepage, an EN page, an NL page, the narrowed-locale branch and the bogus-locale branch, plus `pageUrl`. Diffed as JSON between worktrees: no difference.
- **Switcher order and labels identical** to `main`, compared entry by entry.
- `bun run build` produces the same **1555 redirects and 70 static pages**.
- `typecheck` clean, `lint:ci` exit 0, `test:unit` **365 pass / 0 fail** (two new: email locales are a subset of app locales; every switcher entry has a real label).