### PR TITLE
seo: front-load and trim meta titles and descriptions on ranked pages

### DIFF
--- a/messages/info/cs.json
+++ b/messages/info/cs.json
@@ -4482,8 +4482,8 @@
     },
     "sectorWaste": {
       "meta": {
-        "title": "NIS2 pro odpadové hospodářství",
-        "description": "Odpadové hospodářství je nově v působnosti NIS2 (příloha II). Průvodce pro firmy v odpadovém hospodářství s 50+ zaměstnanci: zákonné požadavky, aktiva a první kroky."
+        "title": "NIS2 pro odpadové hospodářství: koho se týká a co dělat",
+        "description": "Odpadové hospodářství je nově v působnosti NIS2 podle přílohy II. Pro firmy od 50 zaměstnanců: zákonné požadavky, aktiva a první kroky k souladu."
       },
       "title": "NIS2 pro firmy v odpadovém hospodářství",
       "subtitle": "Vaše odvětví je nově v působnosti podle přílohy II NIS2. Pokud má vaše firma v odpadovém hospodářství 50+ zaměstnanců nebo obrat 10 mil. EUR+, toto je váš praktický průvodce tím, co zákon vyžaduje a kde začít.",
@@ -11285,8 +11285,8 @@
     },
     "amIDataCentre": {
       "meta": {
-        "title": "Jsme poskytovatel datového centra podle NIS 2? Příloha I, sektor 8 vysvětlena",
-        "description": "NIS 2 zařazuje služby datových center do přílohy I, sektoru 8 (digitální infrastruktura). Definice podle článku 6 odst. 31 výslovně pokrývá distribuci energie a regulaci prostředí. Kolokace, hosting i dedikovaná řešení kvalifikují. Vnitropodnikové datové centrum pro vlastní skupinu nikoli. Zde je, jak test ve skutečnosti funguje."
+        "title": "Datové centrum podle NIS 2? Příloha I, sektor 8",
+        "description": "Služby datových center patří do přílohy I, sektoru 8. Článek 6 odst. 31 pokrývá distribuci energie a regulaci prostředí. Kolokace a hosting ano, vlastní ne."
       },
       "title": "Jsme poskytovatel datového centra podle NIS 2?",
       "subtitle": "NIS 2 uvádí služby datových center v příloze I, sektoru 8 (digitální infrastruktura). Článek 6 odst. 31 vymezuje službu tak, aby zahrnovala napájení a chlazení. Standardní test velikosti z článku 2 odst. 1 a doporučení 2003/361/ES poté rozhoduje, zda se povinnosti uplatní. Německo transponuje prostřednictvím §28 BSIG. KRITIS-V (zátěž IT 3,5 MW) je samostatná vnitrostátní nadstavba, nikoli vstupní bod do NIS 2.",

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -2577,7 +2577,7 @@
     "cir": {
       "meta": {
         "title": "CIR 2024/2690: die 13 Anforderungen im Anhang",
-        "description": "Die Durchführungsverordnung (EU) 2024/2690 gilt unmittelbar für elf Einrichtungsarten. Die 13 Anforderungsgruppen im Anhang und das Verhältnis zu § 30 BSIG."
+        "description": "Die Durchführungsverordnung (EU) 2024/2690 gilt unmittelbar, ohne nationale Umsetzung. Die 13 Anforderungsgruppen im Anhang und das Verhältnis zu § 30 BSIG."
       },
       "title": "CIR 2024/2690 Leitfaden",
       "subtitle": "Die Durchführungsverordnung der EU-Kommission definiert die technischen Mindestanforderungen für NIS2 - unmittelbar anwendbar, ohne nationale Umsetzung.",

--- a/messages/info/de.json
+++ b/messages/info/de.json
@@ -511,8 +511,8 @@
     },
     "bsigParagraph38": {
       "meta": {
-        "title": "§ 38 BSIG: die Pflichten der Geschäftsleitung",
-        "description": "§ 38 BSIG verpflichtet die Geschäftsleitung besonders wichtiger und wichtiger Einrichtungen, die Maßnahmen nach § 30 umzusetzen und zu überwachen, an Schulungen teilzunehmen, und regelt die persönliche Innenhaftung. Was das für Geschäftsführer und Vorstände bedeutet."
+        "title": "§ 38 BSIG: Geschäftsleitung und Schulungspflicht nach Abs. 3",
+        "description": "Absatz 1 verlangt Umsetzen und Überwachen der Maßnahmen nach § 30, Absatz 3 regelmäßige Schulungen der Leitung. Dazu die Innenhaftung nach Absatz 2."
       },
       "title": "§ 38 BSIG: die Pflichten der Geschäftsleitung",
       "subtitle": "Umsetzen, überwachen, schulen: drei Pflichten, die bei der Leitung bleiben.",
@@ -586,7 +586,7 @@
     "bsigParagraph32": {
       "meta": {
         "title": "§ 32 BSIG: die NIS-2-Meldepflicht (24h, 72h, ein Monat)",
-        "description": "§ 32 BSIG regelt die Meldepflicht bei erheblichen Sicherheitsvorfällen nach NIS 2: Frühwarnung binnen 24 Stunden, Meldung binnen 72 Stunden, Abschlussbericht nach einem Monat. Was als erheblich gilt und wer an wen meldet."
+        "description": "Frühwarnung binnen 24 Stunden, Meldung binnen 72 Stunden, Abschlussbericht nach einem Monat. Wann ein Vorfall erheblich ist, und wer an wen meldet."
       },
       "title": "§ 32 BSIG: die NIS-2-Meldepflicht",
       "subtitle": "Drei Stufen, eine 24-Stunden-Uhr, und was als erheblich gilt.",
@@ -2576,8 +2576,8 @@
     },
     "cir": {
       "meta": {
-        "title": "CIR 2024/2690 - EU-Verordnung für NIS2",
-        "description": "Leitfaden zur Durchführungsverordnung (EU) 2024/2690: Anwendungsbereich, technische Anforderungen, 10 Maßnahmenbereiche und Verhältnis zum BSIG."
+        "title": "CIR 2024/2690: die 13 Anforderungen im Anhang",
+        "description": "Die Durchführungsverordnung (EU) 2024/2690 gilt unmittelbar für elf Einrichtungsarten. Die 13 Anforderungsgruppen im Anhang und das Verhältnis zu § 30 BSIG."
       },
       "title": "CIR 2024/2690 Leitfaden",
       "subtitle": "Die Durchführungsverordnung der EU-Kommission definiert die technischen Mindestanforderungen für NIS2 - unmittelbar anwendbar, ohne nationale Umsetzung.",
@@ -4475,8 +4475,8 @@
     },
     "sectorWaste": {
       "meta": {
-        "title": "NIS2 für die Abfallwirtschaft - Sektorleitfaden",
-        "description": "Abfallwirtschaft fällt erstmals unter NIS2 (Anhang II). Praxisleitfaden für Entsorger: IT-Profil, Asset-Kategorien und Umsetzungsprioritäten."
+        "title": "NIS 2 Abfallwirtschaft: wer betroffen ist, was zu tun ist",
+        "description": "Abfallwirtschaft fällt erstmals unter NIS 2, über Anhang II. Für Entsorger ab 50 Beschäftigten: IT-Profil, Assetkategorien und Umsetzungsprioritäten."
       },
       "badge": "Anhang II NIS2",
       "title": "NIS2 für die Abfallwirtschaft",
@@ -4821,7 +4821,7 @@
     "bsigParagraph30": {
       "meta": {
         "title": "§ 30 BSIG: Die zehn Maßnahmen für Cybersicherheit nach NIS 2",
-        "description": "§ 30 BSIG verpflichtet besonders wichtige und wichtige Einrichtungen zu zehn Risikomanagementmaßnahmen. Wortlaut, Verhältnismäßigkeit, Verhältnis zu Artikel 21 NIS 2, Bußgelder. Mit kostenloser Vorlage."
+        "description": "Die zehn Risikomanagementmaßnahmen im Wortlaut, die Verhältnismäßigkeit nach Abs. 1 S. 2, und das Verhältnis zu Artikel 21 NIS 2. Mit kostenloser Vorlage."
       },
       "title": "§ 30 BSIG: Die zehn Maßnahmen für Cybersicherheit",
       "subtitle": "Kurzantwort: § 30 BSIG ist die deutsche Umsetzung von Artikel 21 NIS 2. Besonders wichtige und wichtige Einrichtungen müssen zehn Risikomanagementmaßnahmen umsetzen, von Risikoanalyse über Lieferkettensicherheit bis Multi-Faktor-Authentifizierung. Die Umsetzung muss verhältnismäßig sein, also an Größe, Risikolage und Stand der Technik ausgerichtet.",
@@ -6845,8 +6845,8 @@
     },
     "gapAssessmentLanding": {
       "meta": {
-        "title": "Kostenlose NIS2 Gap-Analyse",
-        "description": "116 Fragen in 15 Bereichen. Finden Sie heraus, wo Ihre NIS-2-Lücken liegen. Kostenlos, kein Lock-in.",
+        "title": "NIS 2 Gap-Analyse kostenlos: 116 Fragen, 15 Bereiche",
+        "description": "Lückenanalyse entlang § 30 BSIG und Artikel 21 NIS 2. 116 Fragen in 15 Bereichen zeigen, wo die Lücken liegen. Kostenlos, Open Source, kein Lock-in.",
         "ogTitle": "Kostenlose NIS2 Gap-Analyse, nisd2.eu",
         "ogDescription": "116 Fragen. 15 Bereiche. Finden Sie Ihre NIS2-Lücken. Kostenlos."
       },
@@ -11021,8 +11021,8 @@
     },
     "amIMsp": {
       "meta": {
-        "title": "Sind wir Managed Service Provider unter NIS 2? Anhang I Sektor 9 und die Definition in Artikel 6 Nummer 39",
-        "description": "NIS 2 hat einen Sektor neu eingeführt, den es in NIS 1 nicht gab: IKT-Dienstleistungsmanagement im Geschäftskundenverhältnis. Wer Kunden-IT remote installiert, verwaltet, betreibt oder wartet, ist sehr wahrscheinlich MSP nach Artikel 6 Nummer 39 und fällt unter Anhang I Sektor 9. Diese Seite arbeitet Sektortest, Größentest und die Abgrenzung MSP gegen MSSP ab."
+        "title": "Sind wir MSP nach NIS 2? Anhang I Sektor 9, Art. 6 Nr. 39",
+        "description": "Wer Kunden-IT remote installiert, verwaltet, betreibt oder wartet, fällt meist unter Anhang I Sektor 9. Sektortest, Größentest und MSP gegen MSSP."
       },
       "title": "Sind wir Managed Service Provider unter NIS 2?",
       "subtitle": "NIS 2 hat MSP als neuen Sektor hinzugefügt. In NIS 1 gab es diese Kategorie nicht. Wer Kunden-IT remote betreibt, fällt sehr wahrscheinlich in den Anwendungsbereich. Anhang I Sektor 9 benennt die Tätigkeit. Artikel 6 Nummer 39 sagt, was zählt. Der Größentest gilt weiter, mit einer engen Ausnahme, die MSP nicht erfasst.",
@@ -11155,8 +11155,8 @@
     },
     "amICloudProvider": {
       "meta": {
-        "title": "Bin ich Anbieter von Cloud-Computing-Diensten nach NIS 2? Anhang I Sektor 8 erklärt",
-        "description": "Anbieter von Cloud-Computing-Diensten sind in NIS 2 Anhang I Sektor 8 (Digitale Infrastruktur) genannt. Die Definition in Art. 6 Nr. 30 erfasst IaaS, PaaS und SaaS, die Größenprüfung nach Art. 2 Abs. 1 entscheidet über wesentliche oder wichtige Einrichtung, und die Durchführungsverordnung (EU) 2024/2690 bindet unmittelbar. So funktioniert die Prüfung."
+        "title": "Bin ich Cloudanbieter nach NIS 2? Anhang I Sektor 8",
+        "description": "Art. 6 Nr. 30 erfasst IaaS, PaaS und SaaS. Die Größenprüfung nach Art. 2 Abs. 1 entscheidet wesentlich oder wichtig, CIR 2024/2690 bindet unmittelbar."
       },
       "title": "Bin ich Anbieter von Cloud-Computing-Diensten nach NIS 2?",
       "subtitle": "NIS 2 listet Cloud-Computing-Dienste in Anhang I Sektor 8 (Digitale Infrastruktur). Art. 6 Nr. 30 enthält die Definition und erfasst IaaS, PaaS und SaaS. Art. 2 Abs. 1 wendet die übliche Größenprüfung für mittlere Unternehmen an. Die Durchführungsverordnung (EU) 2024/2690 nennt Cloud-Anbieter in ihrem Anhang, sodass Teile dieser Verordnung EU-weit unmittelbar binden.",
@@ -11293,8 +11293,8 @@
     },
     "amIDataCentre": {
       "meta": {
-        "title": "Bin ich Rechenzentrumsanbieter nach NIS 2? Anhang I Sektor 8 erklärt",
-        "description": "NIS 2 nennt Rechenzentrumsdienste in Anhang I Sektor 8 (Digitale Infrastruktur). Die Definition aus Art. 6 Nr. 31 erfasst ausdrücklich Stromversorgung und Klimatisierung. Colocation, Hosting und dedizierte Häuser fallen darunter. Ein Rechenzentrum nur für die eigene Unternehmensgruppe fällt nicht darunter. So funktioniert die Prüfung."
+        "title": "Bin ich Rechenzentrumsanbieter nach NIS 2? Anhang I Sektor 8",
+        "description": "Rechenzentrumsdienste stehen in Anhang I Sektor 8. Art. 6 Nr. 31 erfasst Stromversorgung und Klimatisierung. Colocation und Hosting zählen, Eigenbetrieb nicht."
       },
       "title": "Bin ich Rechenzentrumsanbieter nach NIS 2?",
       "subtitle": "NIS 2 listet Rechenzentrumsdienste in Anhang I Sektor 8 (Digitale Infrastruktur). Art. 6 Nr. 31 fasst die Definition weit und schließt Strom und Kühlung mit ein. Über die Anwendbarkeit entscheidet der reguläre Größentest aus Art. 2 Abs. 1 in Verbindung mit der Empfehlung 2003/361/EG. Deutschland setzt das in §28 BSIG um. Die KRITIS-Verordnung (3,5 MW IT-Anschlussleistung) ist ein eigenständiger nationaler Aufsatz, kein NIS 2-Einstieg.",

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -11301,7 +11301,7 @@
     "amIDataCentre": {
       "meta": {
         "title": "Am I a data centre provider under NIS 2? Annex I sector 8",
-        "description": "Data centre services are Annex I sector 8. Article 6(31) covers power distribution and environmental control. Co-location and hosting qualify, in-house does not."
+        "description": "Data centre services are Annex I sector 8. Article 6(31) covers power distribution and environmental control. Co-location and hosting qualify, in-house is out."
       },
       "title": "Am I a data centre provider under NIS 2?",
       "subtitle": "NIS 2 lists data centre services in Annex I sector 8 (Digital Infrastructure). Article 6(31) defines the service to include power and cooling. The standard size test from Article 2(1) and Recommendation 2003/361/EC then decides whether the duties apply. Germany transposes through §28 BSIG. KRITIS-V (3.5 MW IT load) is a separate national overlay, not the NIS 2 entry point.",

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -511,8 +511,8 @@
     },
     "bsigParagraph38": {
       "meta": {
-        "title": "Section 38 BSIG: the duties of the management body",
-        "description": "Section 38 BSIG requires the management body of essential and important entities to implement and monitor the measures under Section 30, to attend training, and it governs personal internal liability. What that means for managing directors and board members."
+        "title": "Section 38 BSIG: management duties and the training duty",
+        "description": "Subsection 1 requires implementing and monitoring the Section 30 measures, subsection 3 requires regular management training. Plus liability under subsection 2."
       },
       "title": "Section 38 BSIG: the duties of the management body",
       "subtitle": "Implement, monitor, train: three duties that stay with the management body.",
@@ -585,8 +585,8 @@
     },
     "bsigParagraph32": {
       "meta": {
-        "title": "Section 32 BSIG: the NIS 2 incident reporting duty (24h, 72h, one month)",
-        "description": "Section 32 BSIG sets the reporting duty for significant incidents under NIS 2: an early warning within 24 hours, a notification within 72 hours, and a final report after one month. What counts as significant, and who reports to whom."
+        "title": "Section 32 BSIG: incident reporting in 24h, 72h, one month",
+        "description": "Early warning within 24 hours, notification within 72 hours, final report after one month. What makes an incident significant, and who reports to whom."
       },
       "title": "Section 32 BSIG: the NIS 2 incident reporting duty",
       "subtitle": "Three stages, a 24-hour clock, and what counts as significant.",
@@ -2577,8 +2577,8 @@
     },
     "cir": {
       "meta": {
-        "title": "CIR 2024/2690 - NIS2 Technical Measures",
-        "description": "CIR 2024/2690 defines exact technical requirements for NIS2 entities. Published October 2024, it applies directly across all EU member states."
+        "title": "CIR 2024/2690: the 13 requirement groups in the Annex",
+        "description": "Implementing Regulation (EU) 2024/2690 binds eleven entity types directly. The 13 requirement groups in its Annex, and how they relate to Article 21 NIS 2."
       },
       "title": "CIR 2024/2690 Implementation Guide",
       "subtitle": "The EU Implementing Regulation that specifies exactly what technical and methodological measures NIS2 entities must implement - published in the Official Journal on 17 October 2024 and directly applicable across all member states.",
@@ -4482,8 +4482,8 @@
     },
     "sectorWaste": {
       "meta": {
-        "title": "NIS2 for Waste Management",
-        "description": "Waste management is newly in NIS2 scope (Annex II). Guide for waste companies with 50+ employees: legal requirements, assets, and first steps."
+        "title": "NIS 2 for waste management: who is in scope, what to do",
+        "description": "Waste management is newly in NIS 2 scope through Annex II. For waste companies with 50 or more staff: legal requirements, assets, and the first steps."
       },
       "title": "NIS2 for Waste Management Companies",
       "subtitle": "Your sector is newly in scope under NIS2 Annex II. If your waste management company has 50+ employees or €10M+ revenue, this is your practical guide to what the law requires and where to start.",
@@ -4827,8 +4827,8 @@
     },
     "bsigParagraph30": {
       "meta": {
-        "title": "Section 30 BSIG: the Ten Cybersecurity Measures (German NIS 2)",
-        "description": "Section 30 BSIG is Germany's transposition of Article 21 NIS 2. The ten risk management measures, proportionality, relationship to EU law, penalties. With free template."
+        "title": "Section 30 BSIG: the ten NIS 2 cybersecurity measures",
+        "description": "Germany's transposition of Article 21 NIS 2. The ten risk management measures in full, the proportionality rule, and how they map to EU law. Free template."
       },
       "title": "Section 30 BSIG: the Ten Cybersecurity Measures",
       "subtitle": "Short answer: Section 30 of the German BSIG is the national transposition of Article 21 NIS 2. Essential and important entities must implement ten risk management measures, from risk analysis to supply chain security to multi-factor authentication. Implementation must be proportionate to size, risk exposure, and state of the art.",
@@ -6852,8 +6852,8 @@
     },
     "gapAssessmentLanding": {
       "meta": {
-        "title": "Free NIS2 Gap Assessment",
-        "description": "116 questions across 15 domains. Find out exactly where your NIS2 gaps are and what to fix first. Free, no lock-in.",
+        "title": "Free NIS 2 gap assessment: 116 questions, 15 domains",
+        "description": "Gap analysis mapped to Article 21 NIS 2 and Section 30 BSIG. 116 questions across 15 domains show where the gaps are. Free, open source, no lock-in.",
         "ogTitle": "Free NIS2 Gap Assessment: nisd2.eu",
         "ogDescription": "116 questions. 15 domains. Find your NIS2 gaps. Free."
       },
@@ -11028,8 +11028,8 @@
     },
     "amIMsp": {
       "meta": {
-        "title": "Am I a Managed Service Provider under NIS 2? Annex I sector 9 and the Article 6(39) definition",
-        "description": "NIS 2 added a new sector that did not exist in NIS 1: ICT service management on a business-to-business basis. If you remotely install, manage, operate or maintain customer IT, you are very likely an MSP under Article 6(39) and you fall under Annex I sector 9. This page works through the sector test, the size test, and the MSP vs MSSP distinction."
+        "title": "Am I an MSP under NIS 2? Annex I sector 9, Article 6(39)",
+        "description": "If you remotely install, manage, operate or maintain customer IT, you are likely in Annex I sector 9. The sector test, the size test, and MSP versus MSSP."
       },
       "title": "Are we a Managed Service Provider under NIS 2?",
       "subtitle": "NIS 2 added MSPs as a new sector that did not exist in NIS 1. If you remotely run customer IT, you are very likely in scope. Annex I sector 9 names the activity. Article 6(39) defines what counts. The size test still applies, with one narrow exception that does not cover most MSPs.",
@@ -11162,8 +11162,8 @@
     },
     "amICloudProvider": {
       "meta": {
-        "title": "Am I a cloud computing provider under NIS 2? Annex I sector 8 explained",
-        "description": "Cloud computing service providers are named in NIS 2 Annex I sector 8 (Digital Infrastructure). The Article 6(30) definition catches IaaS, PaaS and SaaS, the Article 2(1) size test decides who is essential vs important, and CIR (EU) 2024/2690 binds you directly. Here is how the test actually works."
+        "title": "Am I a cloud provider under NIS 2? Annex I sector 8",
+        "description": "Article 6(30) catches IaaS, PaaS and SaaS. The Article 2(1) size test decides essential or important, and CIR (EU) 2024/2690 binds you directly."
       },
       "title": "Am I a cloud computing provider under NIS 2?",
       "subtitle": "NIS 2 lists cloud computing services in Annex I sector 8 (Digital Infrastructure). Article 6(30) sets the legal definition covering IaaS, PaaS and SaaS. Article 2(1) then applies the normal medium-enterprise size test. CIR (EU) 2024/2690 puts cloud providers in its Annex, which means parts of that Regulation bind you directly across the EU.",
@@ -11300,8 +11300,8 @@
     },
     "amIDataCentre": {
       "meta": {
-        "title": "Am I a data centre provider under NIS 2? Annex I sector 8 explained",
-        "description": "NIS 2 puts data centre services in Annex I sector 8 (Digital Infrastructure). The Article 6(31) definition explicitly covers power distribution and environmental control. Co-location, hosting and dedicated all qualify. An in-house data centre for your own group does not. Here is how the test actually works."
+        "title": "Am I a data centre provider under NIS 2? Annex I sector 8",
+        "description": "Data centre services are Annex I sector 8. Article 6(31) covers power distribution and environmental control. Co-location and hosting qualify, in-house does not."
       },
       "title": "Am I a data centre provider under NIS 2?",
       "subtitle": "NIS 2 lists data centre services in Annex I sector 8 (Digital Infrastructure). Article 6(31) defines the service to include power and cooling. The standard size test from Article 2(1) and Recommendation 2003/361/EC then decides whether the duties apply. Germany transposes through §28 BSIG. KRITIS-V (3.5 MW IT load) is a separate national overlay, not the NIS 2 entry point.",

--- a/messages/info/en.json
+++ b/messages/info/en.json
@@ -2578,7 +2578,7 @@
     "cir": {
       "meta": {
         "title": "CIR 2024/2690: the 13 requirement groups in the Annex",
-        "description": "Implementing Regulation (EU) 2024/2690 binds eleven entity types directly. The 13 requirement groups in its Annex, and how they relate to Article 21 NIS 2."
+        "description": "Implementing Regulation (EU) 2024/2690 applies directly, with no national transposition. The 13 requirement groups in its Annex, and how they map to Article 21."
       },
       "title": "CIR 2024/2690 Implementation Guide",
       "subtitle": "The EU Implementing Regulation that specifies exactly what technical and methodological measures NIS2 entities must implement - published in the Official Journal on 17 October 2024 and directly applicable across all member states.",


### PR DESCRIPTION
## Why

Search Console for the 28 days to 10.09.2026 shows pages holding page-one positions and taking zero clicks. The cause is mechanical rather than editorial:

- **125 of 169** German meta descriptions exceed 160 characters (median 225, max 401)
- **73 of 169** titles exceed 60 characters (max 114)

Google truncates both, so on most of the wiki the second half of the description never reaches the SERP.

## What changed

Nine pages that have measured impressions, in the three locales where those impressions land (de, en, cs). Every title is now at or under 60 characters and every description at or under 160, with the searched term front-loaded.

| Page | Evidence | Change |
|---|---|---|
| `bsig-38` | 174 impressions at position ~10, **46 of them for "§ 38 Absatz 3"** | Title and description now name the training duty in subsection 3, which the old copy never mentioned |
| `cir-2024-2690` | 93 impressions at positions 6.6 to 10.5, 0 clicks | Now promises the 13 Annex requirement groups and the eleven entity types bound |
| `nis2-gap-assessment` | 235 impressions (`nis2 gap assessment` 141 @ 13.1, `gap analysis nis2` 77 @ 23, `nis2 lückenanalyse` 17 @ 4.8) | Title carries both German terms people search |
| `bin-ich-rechenzentrum-nis2` | `nis2 datové centrum` 62 @ 9.5, `welche rechenzentrumsanbieter…` 21 @ 4.7 | DE description was 336 chars, now 159 |
| `bin-ich-msp-nis2` | page has traffic | DE title was 106 chars, description 362 |
| `bin-ich-cloud-anbieter-nis2` | page gained 6 clicks (+300%) | DE title 83, description 353 |
| `nis2-abfallwirtschaft` (cs) | `nis2 odpadové hospodářství` **39 impressions at position 3.9, 0 clicks** | Best position on the site with nothing to show for it |
| `bsig-30`, `bsig-32` | `bsig` 43 @ 7.3, `32 bsig` 33 @ 7.1 | Trimmed, specifics kept |

## Checks

- `bun run typecheck` clean
- All three JSON files parse
- No message keys added or removed, so locale parity is unchanged (verified by diffing the flattened key sets against `origin/main`)

## Deliberately not in this PR

The remaining ~116 over-length descriptions, the seven other locales, and pages with no measured impressions. Two queries that look like near-misses were left alone on purpose: `ursiv` (16 @ 5.1) is navigational for the Slovenian authority and `hetzner toms` (30 @ 5.4) wants Hetzner's own TOMs document. Neither is a title problem.