### PR TITLE
fix(security): hardening pass from the 2026-09-10 audit

### DIFF
--- a/app/[locale]/(info)/risikobewertung/page.tsx
+++ b/app/[locale]/(info)/risikobewertung/page.tsx
@@ -1,13 +1,13 @@
+import { BookOpen } from "lucide-react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { BookOpen } from "lucide-react";
-import { Link } from "@/i18n/navigation";
+import { JsonLd } from "@/components/JsonLd";
 import { MarketingHero, Underline } from "@/components/marketing/MarketingHero";
 import { RiskAssessmentShell } from "@/components/risk-assessment/RiskAssessmentShell";
-import { JsonLd } from "@/components/JsonLd";
+import { Link } from "@/i18n/navigation";
+import { ogImages } from "@/lib/og-card";
 import { scoreMatrix } from "@/lib/risk-assessment/scoring";
 import { pageAlternates } from "@/lib/seo";
-import { ogImages } from "@/lib/og-card";
 
 // Canned example used both for SEO crawlers (the radar card renders something
 // useful before any JS runs) and as the "before you start" preview. Picked

--- a/app/[locale]/(info)/risikobewertung/page.tsx
+++ b/app/[locale]/(info)/risikobewertung/page.tsx
@@ -4,6 +4,7 @@ import { BookOpen } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { MarketingHero, Underline } from "@/components/marketing/MarketingHero";
 import { RiskAssessmentShell } from "@/components/risk-assessment/RiskAssessmentShell";
+import { JsonLd } from "@/components/JsonLd";
 import { scoreMatrix } from "@/lib/risk-assessment/scoring";
 import { pageAlternates } from "@/lib/seo";
 import { ogImages } from "@/lib/og-card";
@@ -44,34 +45,28 @@ export async function generateMetadata({
   };
 }
 
-function JsonLd() {
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebApplication",
-    name: "NIS2 Risk Assessment",
-    description:
-      "Free self-assessment heuristic in the spirit of BSI Grundschutz 200-2 §8.2 Schutzbedarfsfeststellung. Classifies V/I/A protection-need per asset (normal/hoch/sehr hoch) and recommends an Absicherungsvariante.",
-    url: "https://www.nisd2.eu/risikobewertung",
-    applicationCategory: "BusinessApplication",
-    offers: {
-      "@type": "Offer",
-      price: "0",
-      priceCurrency: "EUR",
-    },
-    provider: {
-      "@type": "Organization",
-      name: "NIS2 Compliance Platform",
-      url: "https://www.nisd2.eu",
-    },
-  };
-
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-    />
-  );
-}
+// Audit F-7 (2026-09-10): see the note on the applicability page — rendered
+// through <JsonLd> so the "<" escaping is not something each page has to
+// remember.
+const applicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "NIS2 Risk Assessment",
+  description:
+    "Free self-assessment heuristic in the spirit of BSI Grundschutz 200-2 §8.2 Schutzbedarfsfeststellung. Classifies V/I/A protection-need per asset (normal/hoch/sehr hoch) and recommends an Absicherungsvariante.",
+  url: "https://www.nisd2.eu/risikobewertung",
+  applicationCategory: "BusinessApplication",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "EUR",
+  },
+  provider: {
+    "@type": "Organization",
+    name: "NIS2 Compliance Platform",
+    url: "https://www.nisd2.eu",
+  },
+};
 
 export default async function RiskAssessmentPage() {
   const t = await getTranslations("riskAssessment");
@@ -79,7 +74,7 @@ export default async function RiskAssessmentPage() {
 
   return (
     <div className="space-y-6">
-      <JsonLd />
+      <JsonLd data={applicationSchema} />
 
       <div className="space-y-3">
         <MarketingHero

--- a/app/[locale]/applicability/page.tsx
+++ b/app/[locale]/applicability/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { ApplicabilitySection } from "@/components/applicability/ApplicabilitySection";
+import { JsonLd } from "@/components/JsonLd";
 import { MarketingHero } from "@/components/marketing/MarketingHero";
 import { pageAlternates } from "@/lib/seo";
 import { ogImages } from "@/lib/og-card";
@@ -22,33 +23,29 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   };
 }
 
-function JsonLd() {
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebApplication",
-    name: "NIS2 Applicability Check",
-    description: "Free self-assessment tool to check if your company falls under NIS2 (EU 2022/2555) and the German BSIG 2025.",
-    url: "https://www.nisd2.eu/applicability",
-    applicationCategory: "BusinessApplication",
-    offers: {
-      "@type": "Offer",
-      price: "0",
-      priceCurrency: "EUR",
-    },
-    provider: {
-      "@type": "Organization",
-      name: "NIS2 Compliance Platform",
-      url: "https://www.nisd2.eu",
-    },
-  };
-
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-    />
-  );
-}
+// Audit F-7 (2026-09-10): rendered through <JsonLd>, whose safeStringify
+// escapes "<" (JSON.stringify does not), so a value containing "</script>"
+// cannot close the tag early. The data here is static, so this is not a live
+// XSS — it stops the next edit that interpolates a translation or a search
+// param from becoming one.
+const applicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "NIS2 Applicability Check",
+  description: "Free self-assessment tool to check if your company falls under NIS2 (EU 2022/2555) and the German BSIG 2025.",
+  url: "https://www.nisd2.eu/applicability",
+  applicationCategory: "BusinessApplication",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "EUR",
+  },
+  provider: {
+    "@type": "Organization",
+    name: "NIS2 Compliance Platform",
+    url: "https://www.nisd2.eu",
+  },
+};
 
 export default async function ApplicabilityPage({
   params,
@@ -68,7 +65,7 @@ export default async function ApplicabilityPage({
 
   return (
     <>
-      <JsonLd />
+      <JsonLd data={applicationSchema} />
 
       <div className="mb-8">
         <MarketingHero

--- a/app/[locale]/applicability/page.tsx
+++ b/app/[locale]/applicability/page.tsx
@@ -1,13 +1,17 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
-import { Link } from "@/i18n/navigation";
 import { ApplicabilitySection } from "@/components/applicability/ApplicabilitySection";
 import { JsonLd } from "@/components/JsonLd";
 import { MarketingHero } from "@/components/marketing/MarketingHero";
-import { pageAlternates } from "@/lib/seo";
+import { Link } from "@/i18n/navigation";
 import { ogImages } from "@/lib/og-card";
+import { pageAlternates } from "@/lib/seo";
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations("applicability");
   return {
@@ -32,7 +36,8 @@ const applicationSchema = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
   name: "NIS2 Applicability Check",
-  description: "Free self-assessment tool to check if your company falls under NIS2 (EU 2022/2555) and the German BSIG 2025.",
+  description:
+    "Free self-assessment tool to check if your company falls under NIS2 (EU 2022/2555) and the German BSIG 2025.",
   url: "https://www.nisd2.eu/applicability",
   applicationCategory: "BusinessApplication",
   offers: {
@@ -72,7 +77,10 @@ export default async function ApplicabilityPage({
           headline={tLookup("title")}
           subhead={tLookup.rich("subtitle", {
             link: (chunks) => (
-              <Link href={"/wiki/anwendungsbereich/nis2-einrichtungen" as never} className="underline hover:text-foreground">
+              <Link
+                href={"/wiki/anwendungsbereich/nis2-einrichtungen" as never}
+                className="underline hover:text-foreground"
+              >
                 {chunks}
               </Link>
             ),

--- a/app/api/dev/seed/route.ts
+++ b/app/api/dev/seed/route.ts
@@ -5,13 +5,20 @@ import { NextResponse } from "next/server";
  * POST /api/dev/seed — re-run the database seed script.
  *
  * Hardened:
- *   - Build-time gate: outside a development build the handler answers 404
- *     and never reaches the exec. Audit F-10 (2026-09-10) — this used to be
- *     a runtime `NODE_ENV === "production"` check, which is one typo in a
- *     deployment config away from being live. The tRPC dev router next door
- *     is excluded from the bundle the same way (server/trpc/router.ts).
- *   - drizzle/seed.ts also throws at module load in production, so the guard
- *     is two-deep.
+ *   - Answers 404 unless NODE_ENV is exactly "development". Audit F-10
+ *     (2026-09-10) inverted the old `=== "production"` test, which failed
+ *     open for every value that is neither: an unset NODE_ENV, "test",
+ *     "staging", a typo. Allow-listing the one environment that should reach
+ *     the exec fails closed instead.
+ *
+ *     Be precise about what this is: a runtime env read hoisted to module
+ *     scope, which a bundler MAY fold away but is not guaranteed to. The
+ *     route file still ships. It is the same shape as the tRPC dev-router
+ *     exclusion in server/trpc/router.ts, which is also a runtime read.
+ *     Treat both as hardened runtime checks, not as absence.
+ *   - drizzle/seed.ts also throws at module load in production, and the
+ *     runner image bakes NODE_ENV=production (Dockerfile), so the guard is
+ *     three-deep in anything actually shipped.
  *   - Does NOT echo stdout/stderr back to the caller. The seed script logs
  *     row counts and table names that would be useful to an attacker probing
  *     this surface; failures should be diagnosed from server logs only.

--- a/app/api/dev/seed/route.ts
+++ b/app/api/dev/seed/route.ts
@@ -1,5 +1,5 @@
+import { exec } from "node:child_process";
 import { NextResponse } from "next/server";
-import { exec } from "child_process";
 
 /**
  * POST /api/dev/seed — re-run the database seed script.

--- a/app/api/dev/seed/route.ts
+++ b/app/api/dev/seed/route.ts
@@ -5,16 +5,23 @@ import { exec } from "child_process";
  * POST /api/dev/seed — re-run the database seed script.
  *
  * Hardened:
- *   - Runtime NODE_ENV gate (defense in depth — drizzle/seed.ts also throws
- *     at module load in production).
+ *   - Build-time gate: outside a development build the handler answers 404
+ *     and never reaches the exec. Audit F-10 (2026-09-10) — this used to be
+ *     a runtime `NODE_ENV === "production"` check, which is one typo in a
+ *     deployment config away from being live. The tRPC dev router next door
+ *     is excluded from the bundle the same way (server/trpc/router.ts).
+ *   - drizzle/seed.ts also throws at module load in production, so the guard
+ *     is two-deep.
  *   - Does NOT echo stdout/stderr back to the caller. The seed script logs
  *     row counts and table names that would be useful to an attacker probing
  *     this surface; failures should be diagnosed from server logs only.
  *   - Fixed shell command with no input interpolation — no injection vector.
  */
+const isDev = process.env.NODE_ENV === "development";
+
 export async function POST() {
-  if (process.env.NODE_ENV === "production") {
-    return NextResponse.json({ error: "Dev only" }, { status: 403 });
+  if (!isDev) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
   try {

--- a/app/api/supplier-questionnaire/docx/route.ts
+++ b/app/api/supplier-questionnaire/docx/route.ts
@@ -7,7 +7,7 @@ import { AlignmentType, Document, HeadingLevel, Packer, Paragraph, TextRun } fro
 import { NextResponse } from "next/server";
 import { getClientIp } from "@/lib/client-ip";
 import { pickLocalized } from "@/lib/locale";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimitPublicRoute } from "@/lib/rate-limit";
 
 const VERSION = supplierQuestionnaire.version;
 const LAST_UPDATED = supplierQuestionnaire.lastUpdated;
@@ -345,7 +345,7 @@ function buildDoc(locale: Locale): Document {
 export async function GET(request: Request): Promise<Response> {
   // Audit F-1 (2026-09-10): unauthenticated document build, same reasoning as
   // the PDF sibling.
-  if (!rateLimit(`questionnaire:docx:${getClientIp(request.headers)}`, 10, 60_000)) {
+  if (!rateLimitPublicRoute("questionnaire:docx", getClientIp(request.headers), 10)) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 

--- a/app/api/supplier-questionnaire/docx/route.ts
+++ b/app/api/supplier-questionnaire/docx/route.ts
@@ -1,19 +1,12 @@
-import { NextResponse } from "next/server";
 import {
-  Document,
-  Packer,
-  Paragraph,
-  HeadingLevel,
-  TextRun,
-  AlignmentType,
-} from "docx";
-import {
-  supplierQuestionnaire,
   groupBySection,
   type SupplierField,
+  supplierQuestionnaire,
 } from "@nisd2/nis2-supply-chain-questionnaire-schema";
-import { pickLocalized } from "@/lib/locale";
+import { AlignmentType, Document, HeadingLevel, Packer, Paragraph, TextRun } from "docx";
+import { NextResponse } from "next/server";
 import { getClientIp } from "@/lib/client-ip";
+import { pickLocalized } from "@/lib/locale";
 import { rateLimit } from "@/lib/rate-limit";
 
 const VERSION = supplierQuestionnaire.version;
@@ -91,23 +84,27 @@ const SECTION_TITLES: Record<(typeof SECTION_ORDER)[number], Record<Locale, stri
   },
 };
 
-const STRINGS: Record<Locale, {
-  title: string;
-  subtitle: string;
-  meta: string;
-  intro: string;
-  source: string;
-  fieldType: string;
-  legalBasis: string;
-  required: string;
-  optional: string;
-  conditional: string;
-  license: string;
-  fieldsLabel: string;
-}> = {
+const STRINGS: Record<
+  Locale,
+  {
+    title: string;
+    subtitle: string;
+    meta: string;
+    intro: string;
+    source: string;
+    fieldType: string;
+    legalBasis: string;
+    required: string;
+    optional: string;
+    conditional: string;
+    license: string;
+    fieldsLabel: string;
+  }
+> = {
   de: {
     title: "NIS 2 Lieferanten-Fragebogen",
-    subtitle: "Offener, EU-verankerter Fragebogen für die Lieferantenbewertung unter NIS 2",
+    subtitle:
+      "Offener, EU-verankerter Fragebogen für die Lieferantenbewertung unter NIS 2",
     meta: `Version ${VERSION} - Stand ${LAST_UPDATED} - ${supplierQuestionnaire.fields.length} Felder in 6 Sektionen`,
     intro:
       "Jedes Feld ist an eine EU-rechtliche Primärquelle verankert: NIS 2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance, DSGVO Art. 28 oder den Cyber Resilience Act. Sektorspezifische Erweiterungen (TISAX, VDA ISA, BSI C5, KRITIS) ergänzen die Basis, ersetzen sie nicht.",
@@ -118,7 +115,8 @@ const STRINGS: Record<Locale, {
     required: "Pflichtfeld",
     optional: "Optional",
     conditional: "Bedingt",
-    license: "Lizenz: MIT (Schema) + CC BY 4.0 (Inhalt). Frei nutzbar, forkbar, anpassbar.",
+    license:
+      "Lizenz: MIT (Schema) + CC BY 4.0 (Inhalt). Frei nutzbar, forkbar, anpassbar.",
     fieldsLabel: "Felder",
   },
   en: {
@@ -150,12 +148,14 @@ const STRINGS: Record<Locale, {
     required: "Verplicht",
     optional: "Optioneel",
     conditional: "Voorwaardelijk",
-    license: "Licentie: MIT (schema) + CC BY 4.0 (inhoud). Vrij te gebruiken, te forken en aan te passen.",
+    license:
+      "Licentie: MIT (schema) + CC BY 4.0 (inhoud). Vrij te gebruiken, te forken en aan te passen.",
     fieldsLabel: "velden",
   },
   fr: {
     title: "Questionnaire fournisseur NIS 2",
-    subtitle: "Un questionnaire ouvert et ancré dans le droit de l'UE pour l'évaluation des fournisseurs au titre de NIS 2",
+    subtitle:
+      "Un questionnaire ouvert et ancré dans le droit de l'UE pour l'évaluation des fournisseurs au titre de NIS 2",
     meta: `Version ${VERSION} - Dernière mise à jour ${LAST_UPDATED} - ${supplierQuestionnaire.fields.length} champs répartis en 6 sections`,
     intro:
       "Chaque champ est ancré à une source primaire de niveau européen : NIS 2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance, GDPR Art. 28 ou le Cyber Resilience Act. Les compléments sectoriels (TISAX, VDA ISA, BSI C5, KRITIS) s'ajoutent à cette base.",
@@ -166,12 +166,14 @@ const STRINGS: Record<Locale, {
     required: "Obligatoire",
     optional: "Facultatif",
     conditional: "Conditionnel",
-    license: "Licence : MIT (schéma) + CC BY 4.0 (contenu). Libre d'utilisation, de fork et d'adaptation.",
+    license:
+      "Licence : MIT (schéma) + CC BY 4.0 (contenu). Libre d'utilisation, de fork et d'adaptation.",
     fieldsLabel: "champs",
   },
   it: {
     title: "Questionario per i fornitori NIS 2",
-    subtitle: "Un questionario aperto e ancorato al diritto dell'UE per la valutazione dei fornitori ai sensi di NIS 2",
+    subtitle:
+      "Un questionario aperto e ancorato al diritto dell'UE per la valutazione dei fornitori ai sensi di NIS 2",
     meta: `Versione ${VERSION} - Ultimo aggiornamento ${LAST_UPDATED} - ${supplierQuestionnaire.fields.length} campi in 6 sezioni`,
     intro:
       "Ogni campo è ancorato a una fonte primaria a livello UE: NIS 2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance, GDPR Art. 28 o il Cyber Resilience Act. Le integrazioni settoriali (TISAX, VDA ISA, BSI C5, KRITIS) si aggiungono a questa base.",
@@ -182,12 +184,14 @@ const STRINGS: Record<Locale, {
     required: "Obbligatorio",
     optional: "Facoltativo",
     conditional: "Condizionale",
-    license: "Licenza: MIT (schema) + CC BY 4.0 (contenuto). Libero di usare, forkare e adattare.",
+    license:
+      "Licenza: MIT (schema) + CC BY 4.0 (contenuto). Libero di usare, forkare e adattare.",
     fieldsLabel: "campi",
   },
   es: {
     title: "Cuestionario para proveedores NIS 2",
-    subtitle: "Un cuestionario abierto y anclado en el derecho de la UE para la evaluación de proveedores conforme a NIS 2",
+    subtitle:
+      "Un cuestionario abierto y anclado en el derecho de la UE para la evaluación de proveedores conforme a NIS 2",
     meta: `Versión ${VERSION} - Última actualización ${LAST_UPDATED} - ${supplierQuestionnaire.fields.length} campos en 6 secciones`,
     intro:
       "Cada campo está anclado a una fuente primaria de nivel europeo: NIS 2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance, GDPR Art. 28 o el Cyber Resilience Act. Los complementos sectoriales (TISAX, VDA ISA, BSI C5, KRITIS) se añaden a esta base.",
@@ -198,12 +202,14 @@ const STRINGS: Record<Locale, {
     required: "Obligatorio",
     optional: "Opcional",
     conditional: "Condicional",
-    license: "Licencia: MIT (esquema) + CC BY 4.0 (contenido). Libre para usar, bifurcar y adaptar.",
+    license:
+      "Licencia: MIT (esquema) + CC BY 4.0 (contenido). Libre para usar, bifurcar y adaptar.",
     fieldsLabel: "campos",
   },
   pl: {
     title: "Kwestionariusz dla dostawców NIS 2",
-    subtitle: "Otwarty, zakotwiczony w prawie UE kwestionariusz do oceny dostawców w ramach NIS 2",
+    subtitle:
+      "Otwarty, zakotwiczony w prawie UE kwestionariusz do oceny dostawców w ramach NIS 2",
     meta: `Wersja ${VERSION} - Ostatnia aktualizacja ${LAST_UPDATED} - ${supplierQuestionnaire.fields.length} pól w 6 sekcjach`,
     intro:
       "Każde pole jest zakotwiczone w pierwotnym źródle na poziomie UE: NIS 2 Art. 21(2), CIR 2024/2690, ENISA Technical Implementation Guidance, GDPR Art. 28 lub Cyber Resilience Act. Uzupełnienia sektorowe (TISAX, VDA ISA, BSI C5, KRITIS) są dodawane do tej podstawy.",
@@ -214,16 +220,23 @@ const STRINGS: Record<Locale, {
     required: "Wymagane",
     optional: "Opcjonalne",
     conditional: "Warunkowe",
-    license: "Licencja: MIT (schemat) + CC BY 4.0 (treść). Można swobodnie używać, forkować i adaptować.",
+    license:
+      "Licencja: MIT (schemat) + CC BY 4.0 (treść). Można swobodnie używać, forkować i adaptować.",
     fieldsLabel: "pól",
   },
 };
 
-function pickLocaleString(value: { en: string } & Record<string, string | undefined>, locale: Locale): string {
+function pickLocaleString(
+  value: { en: string } & Record<string, string | undefined>,
+  locale: Locale,
+): string {
   return pickLocalized(value, locale);
 }
 
-function pickRequiredLabel(field: SupplierField, strings: (typeof STRINGS)[Locale]): string {
+function pickRequiredLabel(
+  field: SupplierField,
+  strings: (typeof STRINGS)[Locale],
+): string {
   if (field.visibleWhen) return strings.conditional;
   return field.required ? strings.required : strings.optional;
 }

--- a/app/api/supplier-questionnaire/docx/route.ts
+++ b/app/api/supplier-questionnaire/docx/route.ts
@@ -13,6 +13,8 @@ import {
   type SupplierField,
 } from "@nisd2/nis2-supply-chain-questionnaire-schema";
 import { pickLocalized } from "@/lib/locale";
+import { getClientIp } from "@/lib/client-ip";
+import { rateLimit } from "@/lib/rate-limit";
 
 const VERSION = supplierQuestionnaire.version;
 const LAST_UPDATED = supplierQuestionnaire.lastUpdated;
@@ -328,6 +330,12 @@ function buildDoc(locale: Locale): Document {
 }
 
 export async function GET(request: Request): Promise<Response> {
+  // Audit F-1 (2026-09-10): unauthenticated document build, same reasoning as
+  // the PDF sibling.
+  if (!rateLimit(`questionnaire:docx:${getClientIp(request.headers)}`, 10, 60_000)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const url = new URL(request.url);
   const localeParam = url.searchParams.get("locale");
   const locale: Locale =

--- a/app/api/supplier-questionnaire/pdf/route.ts
+++ b/app/api/supplier-questionnaire/pdf/route.ts
@@ -1,11 +1,11 @@
 import { renderToBuffer } from "@react-pdf/renderer";
 import { NextResponse } from "next/server";
+import { getClientIp } from "@/lib/client-ip";
 import {
   QUESTIONNAIRE_LOCALES,
   type QuestionnaireLocale,
   SupplierQuestionnaireDocument,
 } from "@/lib/pdf/supplier-questionnaire";
-import { getClientIp } from "@/lib/client-ip";
 import { rateLimit } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";

--- a/app/api/supplier-questionnaire/pdf/route.ts
+++ b/app/api/supplier-questionnaire/pdf/route.ts
@@ -5,10 +5,20 @@ import {
   type QuestionnaireLocale,
   SupplierQuestionnaireDocument,
 } from "@/lib/pdf/supplier-questionnaire";
+import { getClientIp } from "@/lib/client-ip";
+import { rateLimit } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
 export async function GET(request: Request): Promise<Response> {
+  // Audit F-1 (2026-09-10): unauthenticated and CPU-bound. The response is
+  // cacheable, but only `locale` changes the output, so any unknown query
+  // parameter produces a fresh cache key and a fresh render. Every other
+  // export route in the app throttles; this one had nothing.
+  if (!rateLimit(`questionnaire:pdf:${getClientIp(request.headers)}`, 10, 60_000)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const url = new URL(request.url);
   const requested = url.searchParams.get("locale");
   const locale: QuestionnaireLocale =

--- a/app/api/supplier-questionnaire/pdf/route.ts
+++ b/app/api/supplier-questionnaire/pdf/route.ts
@@ -6,7 +6,7 @@ import {
   type QuestionnaireLocale,
   SupplierQuestionnaireDocument,
 } from "@/lib/pdf/supplier-questionnaire";
-import { rateLimit } from "@/lib/rate-limit";
+import { rateLimitPublicRoute } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
@@ -15,7 +15,7 @@ export async function GET(request: Request): Promise<Response> {
   // cacheable, but only `locale` changes the output, so any unknown query
   // parameter produces a fresh cache key and a fresh render. Every other
   // export route in the app throttles; this one had nothing.
-  if (!rateLimit(`questionnaire:pdf:${getClientIp(request.headers)}`, 10, 60_000)) {
+  if (!rateLimitPublicRoute("questionnaire:pdf", getClientIp(request.headers), 10)) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
 

--- a/components/compliance/FileUpload.tsx
+++ b/components/compliance/FileUpload.tsx
@@ -60,7 +60,7 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
       setUploading(true);
       try {
         // 1. Get presigned URL
-        const { uploadUrl, evidenceId } =
+        const { uploadUrl, evidenceId, contentType } =
           await createUploadUrl.mutateAsync({
             requirementStatusId,
             fileName: file.name,
@@ -68,12 +68,15 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
             fileSize: file.size,
           });
 
-        // 2. Upload directly to S3. SSE header must match server-signed value or S3 returns 403.
+        // 2. Upload directly to S3. Both the SSE header and Content-Type must
+        // match the server-signed values or S3 returns 403 — so send back the
+        // `contentType` the server signed, not `file.type`, which the server
+        // may have downgraded (audit F-4).
         const putRes = await fetch(uploadUrl, {
           method: "PUT",
           body: file,
           headers: {
-            "Content-Type": file.type || "application/octet-stream",
+            "Content-Type": contentType,
             "x-amz-server-side-encryption": "AES256",
           },
         });

--- a/components/compliance/FileUpload.tsx
+++ b/components/compliance/FileUpload.tsx
@@ -1,18 +1,13 @@
 "use client";
 
+import { Download, FileIcon, Loader2, Trash2 } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
-import { useTranslations, useLocale } from "next-intl";
-import { trpc } from "@/lib/trpc/client";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  FileIcon,
-  Loader2,
-  Trash2,
-  Download,
-} from "lucide-react";
-import { toast } from "sonner";
 import { exceedsUploadLimit, MAX_UPLOAD_MB } from "@/lib/storage/limits";
+import { trpc } from "@/lib/trpc/client";
 import { userFacingError } from "@/lib/trpc/error-message";
 import { formatFileSize } from "@/lib/utils";
 
@@ -37,7 +32,7 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
   const utils = trpc.useUtils();
   const { data: files, isLoading } = trpc.evidence.listByRequirementStatus.useQuery(
     { requirementStatusId },
-    { enabled: !!requirementStatusId }
+    { enabled: !!requirementStatusId },
   );
   const createUploadUrl = trpc.evidence.createUploadUrl.useMutation();
   const confirmUpload = trpc.evidence.confirmUpload.useMutation();
@@ -60,13 +55,12 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
       setUploading(true);
       try {
         // 1. Get presigned URL
-        const { uploadUrl, evidenceId, contentType } =
-          await createUploadUrl.mutateAsync({
-            requirementStatusId,
-            fileName: file.name,
-            fileType: file.type || "application/octet-stream",
-            fileSize: file.size,
-          });
+        const { uploadUrl, evidenceId, contentType } = await createUploadUrl.mutateAsync({
+          requirementStatusId,
+          fileName: file.name,
+          fileType: file.type || "application/octet-stream",
+          fileSize: file.size,
+        });
 
         // 2. Upload directly to S3. Both the SSE header and Content-Type must
         // match the server-signed values or S3 returns 403 — so send back the
@@ -82,7 +76,9 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
         });
         if (!putRes.ok) {
           const body = await putRes.text().catch(() => "");
-          throw new Error(`S3 upload failed: ${putRes.status} ${putRes.statusText} ${body.slice(0, 200)}`);
+          throw new Error(
+            `S3 upload failed: ${putRes.status} ${putRes.statusText} ${body.slice(0, 200)}`,
+          );
         }
 
         // 3. Compute hash + confirm
@@ -107,7 +103,7 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
         e.target.value = "";
       }
     },
-    [requirementStatusId, createUploadUrl, confirmUpload, utils, t]
+    [requirementStatusId, createUploadUrl, confirmUpload, utils, t],
   );
 
   const handleDelete = useCallback(
@@ -121,15 +117,13 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
         toast.error(t("deleteFailed"));
       }
     },
-    [deleteEvidence, utils, requirementStatusId, t]
+    [deleteEvidence, utils, requirementStatusId, t],
   );
 
   return (
     <div className="space-y-3">
       {/* Existing files */}
-      {isLoading && (
-        <p className="text-sm text-muted-foreground">{t("loading")}</p>
-      )}
+      {isLoading && <p className="text-sm text-muted-foreground">{t("loading")}</p>}
 
       {files && files.length > 0 && (
         <div className="space-y-2">
@@ -148,12 +142,7 @@ export function FileUpload({ requirementStatusId, disabled }: FileUploadProps) {
               </div>
 
               {f.downloadUrl && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  asChild
-                >
+                <Button variant="ghost" size="icon" className="h-7 w-7" asChild>
                   <a
                     href={f.downloadUrl}
                     target="_blank"

--- a/components/compliance/ProcurementItemRows.tsx
+++ b/components/compliance/ProcurementItemRows.tsx
@@ -1,19 +1,22 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
 import { Link } from "@/i18n/navigation";
 import { trpc } from "@/lib/trpc/client";
-import { PolicyItemsTable } from "./PolicyItemsTable";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { severityColor } from "./severity-colors";
 import type { supplier as supplierSchema } from "@/schema";
+import { PolicyItemsTable } from "./PolicyItemsTable";
+import { severityColor } from "./severity-colors";
 
 type SupplierRow = typeof supplierSchema.$inferSelect;
 
 type ClauseField = keyof Pick<
   SupplierRow,
-  "hasSecurityClauses" | "hasIncidentNotificationClause" | "hasAuditRights" | "hasSubcontractorFlowDown"
+  | "hasSecurityClauses"
+  | "hasIncidentNotificationClause"
+  | "hasAuditRights"
+  | "hasSubcontractorFlowDown"
 >;
 
 const CLAUSE_FIELDS: ReadonlyArray<ClauseField> = [
@@ -43,9 +46,7 @@ export function ProcurementItemRows() {
   const items = suppliers ?? [];
   const totalClauses = CLAUSE_FIELDS.length;
 
-  const completionCount = items.filter(
-    (s) => countClausesMet(s) === totalClauses,
-  ).length;
+  const completionCount = items.filter((s) => countClausesMet(s) === totalClauses).length;
 
   return (
     <PolicyItemsTable
@@ -57,10 +58,18 @@ export function ProcurementItemRows() {
       <table className="w-full text-sm">
         <thead>
           <tr className="bg-muted/50">
-            <th className="px-3 py-2 text-left font-medium text-muted-foreground">{t("supplier")}</th>
-            <th className="px-3 py-2 text-left font-medium text-muted-foreground">{t("riskLevel")}</th>
-            <th className="px-3 py-2 text-left font-medium text-muted-foreground">{t("clausesTitle")}</th>
-            <th className="px-3 py-2 text-left font-medium text-muted-foreground">{t("contractDates")}</th>
+            <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+              {t("supplier")}
+            </th>
+            <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+              {t("riskLevel")}
+            </th>
+            <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+              {t("clausesTitle")}
+            </th>
+            <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+              {t("contractDates")}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -79,7 +88,10 @@ export function ProcurementItemRows() {
                 </td>
                 <td className="px-3 py-2">
                   {s.riskLevel && (
-                    <Badge variant="outline" className={cn("text-[10px]", severityColor(s.riskLevel))}>
+                    <Badge
+                      variant="outline"
+                      className={cn("text-[10px]", severityColor(s.riskLevel))}
+                    >
                       {s.riskLevel}
                     </Badge>
                   )}
@@ -90,7 +102,11 @@ export function ProcurementItemRows() {
                       <div
                         className={cn(
                           "h-full rounded-full transition-all",
-                          pct === 100 ? "bg-emerald-500" : pct > 50 ? "bg-amber-500" : "bg-red-500",
+                          pct === 100
+                            ? "bg-emerald-500"
+                            : pct > 50
+                              ? "bg-amber-500"
+                              : "bg-red-500",
                         )}
                         style={{ width: `${pct}%` }}
                       />
@@ -103,7 +119,7 @@ export function ProcurementItemRows() {
                 <td className="px-3 py-2 text-xs text-muted-foreground">
                   {s.contractStartDate && s.contractEndDate
                     ? `${s.contractStartDate} - ${s.contractEndDate}`
-                    : s.contractStartDate ?? "-"}
+                    : (s.contractStartDate ?? "-")}
                 </td>
               </tr>
             );

--- a/components/compliance/ProcurementItemRows.tsx
+++ b/components/compliance/ProcurementItemRows.tsx
@@ -11,14 +11,25 @@ import type { supplier as supplierSchema } from "@/schema";
 
 type SupplierRow = typeof supplierSchema.$inferSelect;
 
-const CLAUSE_FIELDS: ReadonlyArray<keyof Pick<SupplierRow, "hasSecurityClauses" | "hasIncidentNotificationClause" | "hasAuditRights" | "hasSubcontractorFlowDown">> = [
+type ClauseField = keyof Pick<
+  SupplierRow,
+  "hasSecurityClauses" | "hasIncidentNotificationClause" | "hasAuditRights" | "hasSubcontractorFlowDown"
+>;
+
+const CLAUSE_FIELDS: ReadonlyArray<ClauseField> = [
   "hasSecurityClauses",
   "hasIncidentNotificationClause",
   "hasAuditRights",
   "hasSubcontractorFlowDown",
 ];
 
-function countClausesMet(s: SupplierRow): number {
+/**
+ * Takes only the columns it reads, not the whole row. `supplier.list` stopped
+ * returning `unsubscribeToken` (audit F-9) and a full-row parameter made that
+ * projection a type error here, which is the parameter being wrong rather
+ * than the projection.
+ */
+function countClausesMet(s: Pick<SupplierRow, ClauseField>): number {
   let count = 0;
   for (const f of CLAUSE_FIELDS) {
     if (s[f]) count++;

--- a/components/shared/SimpleFileUpload.tsx
+++ b/components/shared/SimpleFileUpload.tsx
@@ -1,8 +1,17 @@
+// biome-ignore-all lint/a11y/useSemanticElements: drop zone is a drag target, not a button
 "use client";
 
-import { useState, useRef } from "react";
+// On the suppression above: the drop zone near the bottom of this file is a
+// drag-and-drop target. A real <button> would still need the drop handlers,
+// and role/tabIndex/the Enter-Space handler already give it button semantics.
+// The rule reports on a JSX attribute, which cannot carry a targeted
+// suppression, hence the file-scoped one. Inherited from the lint backlog by
+// touching this file — the change here is the Content-Type fix (audit F-4),
+// not a rewrite of the widget. Worth doing properly on its own.
+
+import { FileText, Loader2, Upload, X } from "lucide-react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Upload, X, FileText, Loader2 } from "lucide-react";
 import { exceedsUploadLimit, MAX_UPLOAD_MB } from "@/lib/storage/limits";
 import { userFacingError } from "@/lib/trpc/error-message";
 import { cn } from "@/lib/utils";
@@ -13,7 +22,11 @@ interface SimpleFileUploadProps {
   /** Called when file is removed */
   onRemoved?: () => void;
   /** Get presigned upload URL — caller provides the tRPC mutation */
-  getUploadUrl: (file: { fileName: string; contentType: string; fileSize: number }) => Promise<{
+  getUploadUrl: (file: {
+    fileName: string;
+    contentType: string;
+    fileSize: number;
+  }) => Promise<{
     uploadUrl: string;
     fileKey: string;
     /**
@@ -72,9 +85,7 @@ export function SimpleFileUpload({
     // Caught here rather than at the presigner, which throws a bare Error the
     // client can only render as a generic failure.
     if (exceedsUploadLimit(file.size)) {
-      setError(
-        tooLargeText ? tooLargeText(MAX_UPLOAD_MB) : errorText,
-      );
+      setError(tooLargeText ? tooLargeText(MAX_UPLOAD_MB) : errorText);
       return;
     }
     setUploading(true);
@@ -95,7 +106,9 @@ export function SimpleFileUpload({
       });
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        throw new Error(`Upload failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`);
+        throw new Error(
+          `Upload failed: ${res.status} ${res.statusText} ${body.slice(0, 200)}`,
+        );
       }
       setFileName(file.name);
       setHasFile(true);
@@ -133,7 +146,12 @@ export function SimpleFileUpload({
           <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
           <span className="text-sm truncate flex-1">{fileName}</span>
           {!disabled && (
-            <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={handleRemove}>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={handleRemove}
+            >
               <X className="h-3 w-3 mr-1" />
               {removeText}
             </Button>

--- a/components/shared/SimpleFileUpload.tsx
+++ b/components/shared/SimpleFileUpload.tsx
@@ -16,6 +16,14 @@ interface SimpleFileUploadProps {
   getUploadUrl: (file: { fileName: string; contentType: string; fileSize: number }) => Promise<{
     uploadUrl: string;
     fileKey: string;
+    /**
+     * The content type the server actually signed into `uploadUrl`, when it
+     * differs from what we asked for. Content-Type is a signed header, so the
+     * PUT has to echo the signed value or S3 answers 403. Handlers that pin
+     * the type with a Zod regex sign exactly what they were given and can
+     * leave this unset (audit F-4).
+     */
+    contentType?: string;
   }>;
   /** Current file key (for edit mode) */
   currentFileKey?: string | null;
@@ -71,16 +79,17 @@ export function SimpleFileUpload({
     }
     setUploading(true);
     try {
-      const { uploadUrl, fileKey } = await getUploadUrl({
+      const requestedType = file.type || "application/octet-stream";
+      const { uploadUrl, fileKey, contentType } = await getUploadUrl({
         fileName: file.name,
-        contentType: file.type || "application/octet-stream",
+        contentType: requestedType,
         fileSize: file.size,
       });
       const res = await fetch(uploadUrl, {
         method: "PUT",
         body: file,
         headers: {
-          "Content-Type": file.type || "application/octet-stream",
+          "Content-Type": contentType ?? requestedType,
           "x-amz-server-side-encryption": "AES256",
         },
       });

--- a/components/supplier-portal/CertificationsSection.tsx
+++ b/components/supplier-portal/CertificationsSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Calendar, Plus, ShieldCheck, Trash2 } from "lucide-react";
 /**
  * Certifications section — embedded in the supplier portal as a section page.
  *
@@ -14,13 +15,12 @@
  */
 import { useState } from "react";
 import type { z } from "zod";
-import { useRouter } from "@/i18n/navigation";
-import { Plus, Trash2, Calendar, ShieldCheck } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { SimpleFileUpload } from "@/components/shared/SimpleFileUpload";
-import { trpc } from "@/lib/trpc/client";
-import { SchemaForm } from "@/lib/forms/schema-form";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "@/i18n/navigation";
 import type { FieldOverride } from "@/lib/forms/field-renderer";
+import { SchemaForm } from "@/lib/forms/schema-form";
+import { trpc } from "@/lib/trpc/client";
 import { companyCertificationCreateSchema } from "@/schema/validators";
 
 type CertCreateValues = z.infer<typeof companyCertificationCreateSchema>;
@@ -116,7 +116,17 @@ export function CertificationsSection({
               ...file,
               contentType: "application/pdf",
             });
-            return { uploadUrl: result.url, fileKey: result.key };
+            // ...and hand that same value back, because Content-Type is a
+            // signed header: the URL is signed for application/pdf, so a PUT
+            // sending the browser's octet-stream is a signature mismatch and
+            // a 403. That is the exact case the override above exists for,
+            // which it could not actually fix until the upload component
+            // grew this return channel.
+            return {
+              uploadUrl: result.url,
+              fileKey: result.key,
+              contentType: "application/pdf",
+            };
           }}
           onUploaded={(key) => field.onChange(key)}
           onRemoved={() => field.onChange("")}
@@ -182,8 +192,7 @@ export function CertificationsSection({
                 <ShieldCheck className="h-5 w-5 text-primary shrink-0" />
                 <div className="min-w-0">
                   <div className="font-medium text-sm truncate">
-                    {CERT_TYPES.find((t) => t.value === cert.type)?.label ??
-                      cert.type}
+                    {CERT_TYPES.find((t) => t.value === cert.type)?.label ?? cert.type}
                   </div>
                   <div className="text-xs text-muted-foreground inline-flex items-center gap-1">
                     <Calendar className="h-3 w-3" />

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -16,7 +16,6 @@ import { env } from "@/lib/env";
 import { isLocaleCode, LOCALE_COOKIE, type LocaleCode } from "@/lib/locale";
 import { newUserSignupEmail, sendMail, sendWelcomeEmail } from "@/lib/mail";
 import { resolveHints } from "@/lib/onboarding/hints";
-import { getAppUrl } from "@/lib/utils";
 import { company, user } from "@/schema";
 import { createDraftCompany } from "@/server/trpc/helpers/setup-helpers";
 
@@ -115,7 +114,7 @@ const providers: Provider[] = [
       const hash = dbUser?.passwordHash ?? DUMMY_HASH;
       const valid = await bcrypt.compare(password, hash);
 
-      if (!dbUser || !dbUser.passwordHash || !valid) return null;
+      if (!dbUser?.passwordHash || !valid) return null;
 
       // Block unverified email-password accounts. The signin UI handles this
       // specific error code by prompting the user to verify their email.

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,6 +1,7 @@
 import "@/lib/server-guard";
 import bcrypt from "bcryptjs";
 import { eq, sql } from "drizzle-orm";
+import type { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { cookies } from "next/headers";
 import type { Session } from "next-auth";
 import NextAuth, { CredentialsSignin } from "next-auth";
@@ -247,8 +248,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           });
           if (existing) {
             userId = existing.id;
-            const patch: Partial<typeof user.$inferInsert> = { updatedAt: now };
-            if (existing.passwordHash) patch.passwordHash = null;
+            // PgUpdateSetSource, not Partial<$inferInsert>: sessionVersion is
+            // set to an SQL expression below, which the insert-shape type
+            // does not admit.
+            const patch: PgUpdateSetSource<typeof user> = { updatedAt: now };
+            if (existing.passwordHash) {
+              patch.passwordHash = null;
+              // Audit F-5 (2026-09-10): removing the password is a credential
+              // change, so it invalidates outstanding sessions the same way a
+              // reset does (audit M-1). The jwt callback runs after this one
+              // and re-reads sessionVersion, so THIS sign-in is stamped with
+              // the incremented value and stays valid; only tokens issued
+              // before the change are rejected.
+              patch.sessionVersion = sql`${user.sessionVersion} + 1`;
+            }
             if (!existing.emailVerifiedAt) {
               patch.emailVerifiedAt = now;
               shouldProvision = true;

--- a/lib/cron/auth.ts
+++ b/lib/cron/auth.ts
@@ -29,8 +29,15 @@ export function verifyCronBearer(req: Request): boolean {
   const header = req.headers.get("authorization");
   if (!header?.startsWith("Bearer ")) return false;
 
-  const provided = header.slice("Bearer ".length);
-  if (provided.length !== secret.length) return false;
+  // Audit F-8 (2026-09-10): compare BYTE length, not JS string length. A
+  // token of equal character length but different UTF-8 byte length (any
+  // multi-byte character) passed the old string-length guard and then made
+  // timingSafeEqual throw RangeError, so the route answered 500 instead of
+  // 401 — a signal about the secret's byte length, and error-log noise on
+  // every scan.
+  const provided = Buffer.from(header.slice("Bearer ".length), "utf8");
+  const expected = Buffer.from(secret, "utf8");
+  if (provided.length !== expected.length) return false;
 
-  return timingSafeEqual(Buffer.from(provided), Buffer.from(secret));
+  return timingSafeEqual(provided, expected);
 }

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -5,7 +5,7 @@
  * spent, because that turns a memory fix into a fail-open.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { __resetRateLimitState, rateLimit } from "./rate-limit";
+import { __rateLimitInternals, __resetRateLimitState, rateLimit } from "./rate-limit";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -44,12 +44,25 @@ describe("rateLimit", () => {
     expect(rateLimit("victim", 1, 60_000)).toBe(false);
   });
 
-  test("sweeps windows that have fully expired", async () => {
-    for (let i = 0; i < 10_050; i++) rateLimit(`stale:${i}`, 1, 20);
+  test("the sweep reclaims windows that have fully expired", async () => {
+    for (let i = 0; i < 500; i++) rateLimit(`stale:${i}`, 1, 20);
+    expect(__rateLimitInternals.windowCount()).toBe(500);
+
     await sleep(60);
-    // One more call past the threshold triggers the sweep; the stale windows
-    // are all expired by now, so it reclaims them.
-    rateLimit("trigger", 1, 60_000);
-    expect(rateLimit("stale:0", 1, 20)).toBe(true);
+    __rateLimitInternals.forceSweep();
+
+    expect(__rateLimitInternals.windowCount()).toBe(0);
+  });
+
+  test("the sweep keeps windows that are still live", async () => {
+    for (let i = 0; i < 200; i++) rateLimit(`stale:${i}`, 1, 20);
+    for (let i = 0; i < 200; i++) rateLimit(`live:${i}`, 1, 60_000);
+
+    await sleep(60);
+    __rateLimitInternals.forceSweep();
+
+    // Only the short-window half has aged out.
+    expect(__rateLimitInternals.windowCount()).toBe(200);
+    expect(rateLimit("live:0", 1, 60_000)).toBe(false);
   });
 });

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Audit F-2 (2026-09-10): the limiter now deletes fully-expired windows so the
+ * Map cannot grow forever. These tests pin the part that would be dangerous to
+ * get wrong — the sweep must never hand a caller a budget they had already
+ * spent, because that turns a memory fix into a fail-open.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { __resetRateLimitState, rateLimit } from "./rate-limit";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+afterEach(() => {
+  __resetRateLimitState();
+});
+
+describe("rateLimit", () => {
+  test("allows up to the limit and denies past it", () => {
+    const results = Array.from({ length: 4 }, () => rateLimit("k", 3, 60_000));
+    expect(results).toEqual([true, true, true, false]);
+  });
+
+  test("keeps separate budgets per key", () => {
+    expect(rateLimit("a", 1, 60_000)).toBe(true);
+    expect(rateLimit("a", 1, 60_000)).toBe(false);
+    expect(rateLimit("b", 1, 60_000)).toBe(true);
+  });
+
+  test("lets the budget recover once the window has passed", async () => {
+    expect(rateLimit("k", 1, 30)).toBe(true);
+    expect(rateLimit("k", 1, 30)).toBe(false);
+    await sleep(60);
+    expect(rateLimit("k", 1, 30)).toBe(true);
+  });
+
+  test("does not reset a live window when other keys churn past the sweep threshold", () => {
+    expect(rateLimit("victim", 1, 60_000)).toBe(true);
+    expect(rateLimit("victim", 1, 60_000)).toBe(false);
+
+    // Push the Map well past SWEEP_THRESHOLD so the sweep actually runs.
+    for (let i = 0; i < 10_050; i++) rateLimit(`churn:${i}`, 1, 60_000);
+
+    // The victim's window is still inside its 60s window, so the sweep must
+    // have left it alone and the caller must still be denied.
+    expect(rateLimit("victim", 1, 60_000)).toBe(false);
+  });
+
+  test("sweeps windows that have fully expired", async () => {
+    for (let i = 0; i < 10_050; i++) rateLimit(`stale:${i}`, 1, 20);
+    await sleep(60);
+    // One more call past the threshold triggers the sweep; the stale windows
+    // are all expired by now, so it reclaims them.
+    rateLimit("trigger", 1, 60_000);
+    expect(rateLimit("stale:0", 1, 20)).toBe(true);
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -27,13 +27,34 @@ interface Window {
 const windows = new Map<string, Window>();
 
 /**
- * Sweep once the Map is bigger than this. Sized well above any plausible
- * concurrent-caller count so a normal instance never pays for the sweep.
+ * Only consider sweeping once the Map is bigger than this. Sized well above
+ * any plausible concurrent-caller count so a normal instance never sweeps.
  */
 const SWEEP_THRESHOLD = 10_000;
 
+/**
+ * And then at most this often.
+ *
+ * Both guards are needed, and the size one alone is a trap: the sweep is O(n)
+ * over the whole Map, so if the entries above the threshold are still LIVE it
+ * deletes nothing, the size never drops, and every subsequent call pays a
+ * full scan. Measured at 10.050 live windows that is 47 µs/call against
+ * 0,20 µs for the unswept map — a 237x regression, reachable by anyone able
+ * to put 10.001 distinct keys in play, which is the same "many distinct IPs"
+ * the eviction exists to survive. Time-throttling bounds the cost to one scan
+ * a minute no matter what the caller does.
+ *
+ * The trade is that between sweeps the Map holds at most a minute of unique
+ * keys rather than none, which is the point: bounded, not zero.
+ */
+const SWEEP_INTERVAL_MS = 60_000;
+
+/** Timestamp cursor for the throttle above. Mutable for the same reason `windows` is. */
+let lastSweptAt = 0;
+
 /** Drop every window whose newest timestamp has already aged out. */
 function sweepExpired(now: number): void {
+  lastSweptAt = now;
   for (const [key, window] of windows) {
     if (window.expiresAt <= now) windows.delete(key);
   }
@@ -46,7 +67,9 @@ export function rateLimit(key: string, limit: number, windowMs: number): boolean
   const now = Date.now();
   const cutoff = now - windowMs;
 
-  if (windows.size > SWEEP_THRESHOLD) sweepExpired(now);
+  if (windows.size > SWEEP_THRESHOLD && now - lastSweptAt >= SWEEP_INTERVAL_MS) {
+    sweepExpired(now);
+  }
 
   const existing = windows.get(key);
   const recent = existing ? existing.timestamps.filter((t) => t > cutoff) : [];
@@ -71,4 +94,16 @@ export function rateLimit(key: string, limit: number, windowMs: number): boolean
 /** Test seam: drop all state. Not used in application code. */
 export function __resetRateLimitState(): void {
   windows.clear();
+  lastSweptAt = 0;
 }
+
+/**
+ * Test seam: how many windows are being held, and a way to run the sweep
+ * without waiting out SWEEP_INTERVAL_MS. Not used in application code — the
+ * sweep is what keeps the Map bounded and what must never drop a live window,
+ * so it is worth testing directly rather than through a minute-long wait.
+ */
+export const __rateLimitInternals = {
+  windowCount: () => windows.size,
+  forceSweep: () => sweepExpired(Date.now()),
+};

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,8 +1,46 @@
-const windows = new Map<string, number[]>();
+/**
+ * In-memory sliding-window rate limiter.
+ *
+ * Audit M-2 (2026-06-10) / F-2 (2026-09-10): the previous version pruned the
+ * timestamps inside an entry but never removed the entry itself, so every
+ * distinct key was a permanent Map entry for the life of the process. Keys
+ * embed the client IP (`applicability:search:${ip}`, `supplier-access:read:${ip}`,
+ * …), so the Map grew with every new caller and never shrank.
+ *
+ * Two changes, both of which only ever DELETE windows that have fully expired:
+ * an entry whose timestamps have all aged out is indistinguishable from one
+ * that was never created, so dropping it cannot hand anyone a fresh budget
+ * they did not already have.
+ *
+ * Still per-process, so a redeploy resets every budget and a second replica
+ * would double every limit. Moving the window to Postgres with a `reset_at`
+ * TTL — the shape `email_otp` already uses — is the real fix and wants its
+ * own change.
+ */
+
+interface Window {
+  timestamps: number[];
+  /** When the last timestamp in this window ages out. */
+  expiresAt: number;
+}
+
+const windows = new Map<string, Window>();
 
 /**
- * In-memory sliding window rate limiter.
- * Returns `true` if the request is allowed, `false` if rate-limited.
+ * Sweep once the Map is bigger than this. Sized well above any plausible
+ * concurrent-caller count so a normal instance never pays for the sweep.
+ */
+const SWEEP_THRESHOLD = 10_000;
+
+/** Drop every window whose newest timestamp has already aged out. */
+function sweepExpired(now: number): void {
+  for (const [key, window] of windows) {
+    if (window.expiresAt <= now) windows.delete(key);
+  }
+}
+
+/**
+ * Returns `true` if the request is allowed, `false` if it is rate-limited.
  */
 export function rateLimit(
   key: string,
@@ -12,15 +50,31 @@ export function rateLimit(
   const now = Date.now();
   const cutoff = now - windowMs;
 
-  const timestamps = windows.get(key) ?? [];
-  const recent = timestamps.filter((t) => t > cutoff);
+  if (windows.size > SWEEP_THRESHOLD) sweepExpired(now);
+
+  const existing = windows.get(key);
+  const recent = existing
+    ? existing.timestamps.filter((t) => t > cutoff)
+    : [];
 
   if (recent.length >= limit) {
-    windows.set(key, recent);
+    // expiresAt tracks the NEWEST timestamp, not the oldest: the window is
+    // only safe to sweep once every timestamp in it has aged out. Keying it
+    // off the oldest would let the sweep drop a window that still holds live
+    // hits, which is precisely the fail-open this change exists to avoid.
+    const newest = recent[recent.length - 1] ?? now;
+    windows.set(key, { timestamps: recent, expiresAt: newest + windowMs });
     return false;
   }
 
-  recent.push(now);
-  windows.set(key, recent);
+  windows.set(key, {
+    timestamps: [...recent, now],
+    expiresAt: now + windowMs,
+  });
   return true;
+}
+
+/** Test seam: drop all state. Not used in application code. */
+export function __resetRateLimitState(): void {
+  windows.clear();
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -18,13 +18,14 @@
  * own change.
  */
 
-interface Window {
+/** Named RateWindow, not Window, so it cannot shadow the DOM global. */
+interface RateWindow {
   timestamps: number[];
   /** When the last timestamp in this window ages out. */
   expiresAt: number;
 }
 
-const windows = new Map<string, Window>();
+const windows = new Map<string, RateWindow>();
 
 /**
  * Only consider sweeping once the Map is bigger than this. Sized well above
@@ -55,8 +56,8 @@ let lastSweptAt = 0;
 /** Drop every window whose newest timestamp has already aged out. */
 function sweepExpired(now: number): void {
   lastSweptAt = now;
-  for (const [key, window] of windows) {
-    if (window.expiresAt <= now) windows.delete(key);
+  for (const [key, entry] of windows) {
+    if (entry.expiresAt <= now) windows.delete(key);
   }
 }
 
@@ -89,6 +90,31 @@ export function rateLimit(key: string, limit: number, windowMs: number): boolean
     expiresAt: now + windowMs,
   });
   return true;
+}
+
+/**
+ * Per-IP limit for an unauthenticated route, with a sane answer for the
+ * deployments that cannot report an IP.
+ *
+ * `getClientIp` returns the literal "unknown" when neither `x-real-ip` nor
+ * `x-forwarded-for` is present, which is every self-hosted instance started
+ * without the optional Caddy proxy profile. Keying on that string would put
+ * every visitor to such an instance in ONE bucket, so the eleventh download
+ * of the day from anybody 429s. Those callers get their own, much larger
+ * shared budget instead: still a ceiling on the CPU an anonymous crowd can
+ * burn, without pretending a whole instance is one person.
+ *
+ * Deployments behind Traefik or Caddy always have the header, so they get the
+ * real per-IP limit.
+ */
+export function rateLimitPublicRoute(
+  name: string,
+  ip: string,
+  perIpPerMinute: number,
+): boolean {
+  return ip === "unknown"
+    ? rateLimit(`${name}:no-client-ip`, perIpPerMinute * 12, 60_000)
+    : rateLimit(`${name}:${ip}`, perIpPerMinute, 60_000);
 }
 
 /** Test seam: drop all state. Not used in application code. */

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -42,20 +42,14 @@ function sweepExpired(now: number): void {
 /**
  * Returns `true` if the request is allowed, `false` if it is rate-limited.
  */
-export function rateLimit(
-  key: string,
-  limit: number,
-  windowMs: number,
-): boolean {
+export function rateLimit(key: string, limit: number, windowMs: number): boolean {
   const now = Date.now();
   const cutoff = now - windowMs;
 
   if (windows.size > SWEEP_THRESHOLD) sweepExpired(now);
 
   const existing = windows.get(key);
-  const recent = existing
-    ? existing.timestamps.filter((t) => t > cutoff)
-    : [];
+  const recent = existing ? existing.timestamps.filter((t) => t > cutoff) : [];
 
   if (recent.length >= limit) {
     // expiresAt tracks the NEWEST timestamp, not the oldest: the window is

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,7 +1,7 @@
-export { s3, BUCKET } from "./s3-client";
-export { createPresignedPut, createPresignedGet, deleteObject } from "./presign";
 export {
-  sanitizeFilename,
-  normalizeContentType,
   FALLBACK_CONTENT_TYPE,
+  normalizeContentType,
+  sanitizeFilename,
 } from "./object-key";
+export { createPresignedGet, createPresignedPut, deleteObject } from "./presign";
+export { BUCKET, s3 } from "./s3-client";

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,2 +1,7 @@
 export { s3, BUCKET } from "./s3-client";
 export { createPresignedPut, createPresignedGet, deleteObject } from "./presign";
+export {
+  sanitizeFilename,
+  normalizeContentType,
+  FALLBACK_CONTENT_TYPE,
+} from "./object-key";

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,7 +1,3 @@
-export {
-  FALLBACK_CONTENT_TYPE,
-  normalizeContentType,
-  sanitizeFilename,
-} from "./object-key";
+export { normalizeContentType, sanitizeFilename } from "./object-key";
 export { createPresignedGet, createPresignedPut, deleteObject } from "./presign";
 export { BUCKET, s3 } from "./s3-client";

--- a/lib/storage/object-key.ts
+++ b/lib/storage/object-key.ts
@@ -1,0 +1,63 @@
+/**
+ * Object-key and content-type hygiene for everything that gets a presigned PUT.
+ *
+ * Audit F-4 (2026-09-10). Four upload paths sign keys into the same bucket:
+ * evidence, training certificates, supplier logos and supplier certifications.
+ * Two of them sanitized the caller's filename and pinned the content type; two
+ * spliced `input.fileName` straight into the key and passed `fileType` through
+ * as whatever the client claimed. This module is the one copy, so they cannot
+ * drift apart again.
+ */
+
+/**
+ * Reduce a caller-supplied filename to the character set an object key can
+ * carry without surprises. Anything outside `[A-Za-z0-9._-]` becomes `_`,
+ * which also removes the `/` and `..` sequences that would otherwise decide
+ * where the object lands — S3 treats keys as opaque strings, but the
+ * S3-compatible servers a self-hoster may point at do not all agree on that.
+ */
+export function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 200);
+}
+
+/**
+ * Content types an evidence or certificate upload may keep.
+ *
+ * Mirrors the `accept` list on the evidence uploader
+ * (`components/compliance/FileUpload.tsx`) plus the certificate PDF.
+ */
+const STORABLE_CONTENT_TYPES = new Set([
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "text/plain",
+  "text/csv",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/** What an unrecognised type becomes: bytes, and never a document a browser renders. */
+export const FALLBACK_CONTENT_TYPE = "application/octet-stream";
+
+/**
+ * Pin the content type an object is stored with.
+ *
+ * The stored type is what a presigned GET later serves, and the evidence list
+ * opens that URL with `target="_blank"`. A caller who claimed `text/html` or
+ * `image/svg+xml` therefore got a page rendered on the storage origin, which
+ * under the bundled Caddy config is a sibling hostname of the app.
+ *
+ * Unrecognised types are downgraded rather than rejected. Rejecting would
+ * break real uploads: browsers disagree about the type of a `.csv` and send an
+ * empty string or `application/octet-stream` for anything the OS cannot place.
+ * Downgrading keeps every upload the UI accepts working and still means no
+ * caller can choose a type a browser will execute.
+ */
+export function normalizeContentType(contentType: string): string {
+  const bare = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return STORABLE_CONTENT_TYPES.has(bare) ? bare : FALLBACK_CONTENT_TYPE;
+}

--- a/lib/storage/object-key.ts
+++ b/lib/storage/object-key.ts
@@ -11,20 +11,33 @@
 
 /**
  * Reduce a caller-supplied filename to the character set an object key can
- * carry without surprises. Anything outside `[A-Za-z0-9._-]` becomes `_`,
- * which also removes the `/` and `..` sequences that would otherwise decide
- * where the object lands — S3 treats keys as opaque strings, but the
- * S3-compatible servers a self-hoster may point at do not all agree on that.
+ * carry without surprises. Anything outside `[A-Za-z0-9._-]` becomes `_`.
+ *
+ * What that guarantees, exactly: no path SEPARATORS. `.` is in the allowed
+ * set, so `..` survives verbatim — `sanitizeFilename("../../etc/passwd")` is
+ * `".._.._etc_passwd"`. Traversal is defeated because the slashes are gone,
+ * not because the dots are. So this is safe for a whole filename and NOT
+ * safe for a path segment that something later joins with "/". S3 treats
+ * keys as opaque strings anyway, but the S3-compatible servers a self-hoster
+ * may point at do not all agree on that, which is why the separators go.
  */
 export function sanitizeFilename(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 200);
 }
 
 /**
- * Content types an evidence or certificate upload may keep.
+ * Content types an object may be STORED under as-is.
  *
- * Mirrors the `accept` list on the evidence uploader
- * (`components/compliance/FileUpload.tsx`) plus the certificate PDF.
+ * Not a mirror of any uploader's `accept` list, and deliberately not a
+ * validation allowlist — nothing is rejected for missing from this set, and
+ * the row's own `fileType` column still records what the browser reported.
+ * The only question here is what Content-Type the object carries in the
+ * bucket, i.e. what a browser would be invited to do with the bytes if it
+ * ever reached them directly. Formats a browser executes (text/html,
+ * image/svg+xml, application/xhtml+xml) are absent on purpose and everything
+ * unrecognised lands on the same safe default, so adding a format to an
+ * uploader's `accept` without touching this set costs a less specific stored
+ * type and nothing else.
  */
 const STORABLE_CONTENT_TYPES = new Set([
   "application/pdf",
@@ -41,7 +54,7 @@ const STORABLE_CONTENT_TYPES = new Set([
 ]);
 
 /** What an unrecognised type becomes: bytes, and never a document a browser renders. */
-export const FALLBACK_CONTENT_TYPE = "application/octet-stream";
+const FALLBACK_CONTENT_TYPE = "application/octet-stream";
 
 /**
  * Pin the content type an object is stored with.

--- a/lib/storage/presign.ts
+++ b/lib/storage/presign.ts
@@ -1,12 +1,12 @@
 import "@/lib/server-guard";
 import {
-  PutObjectCommand,
-  GetObjectCommand,
   DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { s3, s3Signer, BUCKET } from "./s3-client";
 import { MAX_UPLOAD_BYTES } from "./limits";
+import { BUCKET, s3, s3Signer } from "./s3-client";
 
 /** Generate a presigned PUT URL for direct client upload (15 min expiry) */
 export async function createPresignedPut(
@@ -27,11 +27,26 @@ export async function createPresignedPut(
   return getSignedUrl(s3Signer, command, { expiresIn: 900 });
 }
 
-/** Generate a presigned GET URL for file download (1 hour expiry) */
+/**
+ * Generate a presigned GET URL for file download (1 hour expiry).
+ *
+ * Audit F-4 (2026-09-10): the response is forced to `attachment`. Pinning the
+ * content type at upload time only helps objects uploaded after that change —
+ * everything already in the bucket still carries whatever type the client
+ * claimed when it was stored, and the evidence list opens these URLs with
+ * `target="_blank"`. Overriding the disposition here covers the objects
+ * already written, the ones written from here on, and any future presign
+ * site that forgets, because it is the one door they all leave through.
+ *
+ * Every caller today is a download control, so this matches what the UI
+ * already promises. If something ever needs to render an object inline, give
+ * it its own presigner rather than widening this one.
+ */
 export async function createPresignedGet(key: string): Promise<string> {
   const command = new GetObjectCommand({
     Bucket: BUCKET,
     Key: key,
+    ResponseContentDisposition: "attachment",
   });
   return getSignedUrl(s3Signer, command, { expiresIn: 3600 });
 }

--- a/server/trpc/routers/evidence.ts
+++ b/server/trpc/routers/evidence.ts
@@ -9,6 +9,7 @@ import {
   normalizeContentType,
   sanitizeFilename,
 } from "@/lib/storage";
+import { MAX_UPLOAD_BYTES } from "@/lib/storage/limits";
 import { companyAssessment, companyRequirementStatus, evidence } from "@/schema";
 import { enforceAssignment, verifyAssessmentOwnership } from "../guards";
 import { companyProcedure, router } from "../init";
@@ -21,11 +22,11 @@ export const evidenceRouter = router({
         requirementStatusId: z.string().uuid(),
         fileName: z.string().min(1).max(500),
         fileType: z.string().min(1).max(100),
-        fileSize: z
-          .number()
-          .int()
-          .positive()
-          .max(50 * 1024 * 1024),
+        // MAX_UPLOAD_BYTES, not a literal: the browser pre-checks the same
+        // constant via exceedsUploadLimit, and a router that disagrees with
+        // it turns a clear "too large" into the opaque failure limits.ts was
+        // written to prevent.
+        fileSize: z.number().int().positive().max(MAX_UPLOAD_BYTES),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -53,6 +54,15 @@ export const evidenceRouter = router({
       // Neither is trusted raw — the supplier-portal upload paths have always
       // done both, this one did neither. `fileName` is still stored verbatim
       // on the row, so the download keeps the name the user recognises.
+      //
+      // The row keeps the type the browser reported and only the OBJECT is
+      // stored under the normalized one. These are two different questions:
+      // `evidence.fileType` is a description of the artifact and feeds the
+      // Prüfordner evidence register (lib/pdf/load-report-data.ts), where
+      // "application/octet-stream" for every .odt or .zip would be a worse
+      // answer than the truth. What a browser is allowed to DO with the bytes
+      // is decided by the stored Content-Type and the attachment disposition
+      // on the way out, not by this column.
       const storedType = normalizeContentType(input.fileType);
       const storageKey = `evidence/${ctx.companyId}/${input.requirementStatusId}/${randomUUID()}-${sanitizeFilename(input.fileName)}`;
 
@@ -62,7 +72,7 @@ export const evidenceRouter = router({
         .values({
           requirementStatusId: input.requirementStatusId,
           fileName: input.fileName,
-          fileType: storedType,
+          fileType: input.fileType,
           fileSize: input.fileSize,
           storageKey,
           uploadedBy: ctx.userId,

--- a/server/trpc/routers/evidence.ts
+++ b/server/trpc/routers/evidence.ts
@@ -1,17 +1,17 @@
-import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
 import { TRPCError } from "@trpc/server";
-import { router, companyProcedure } from "../init";
-import { evidence, companyRequirementStatus, companyAssessment } from "@/schema";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 import {
-  createPresignedPut,
   createPresignedGet,
+  createPresignedPut,
   deleteObject,
   normalizeContentType,
   sanitizeFilename,
 } from "@/lib/storage";
+import { companyAssessment, companyRequirementStatus, evidence } from "@/schema";
 import { enforceAssignment, verifyAssessmentOwnership } from "../guards";
-import { randomUUID } from "crypto";
+import { companyProcedure, router } from "../init";
 
 export const evidenceRouter = router({
   /** Request a presigned upload URL and create a draft evidence record */
@@ -21,8 +21,12 @@ export const evidenceRouter = router({
         requirementStatusId: z.string().uuid(),
         fileName: z.string().min(1).max(500),
         fileType: z.string().min(1).max(100),
-        fileSize: z.number().int().positive().max(50 * 1024 * 1024),
-      })
+        fileSize: z
+          .number()
+          .int()
+          .positive()
+          .max(50 * 1024 * 1024),
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       // Enforce assignment before allowing upload
@@ -31,7 +35,10 @@ export const evidenceRouter = router({
         with: { requirement: { columns: { id: true, categoryId: true } } },
       });
       if (!statusRow) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Requirement status not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Requirement status not found",
+        });
       }
       await verifyAssessmentOwnership(ctx.db, statusRow.assessmentId, ctx.companyId);
       await enforceAssignment(ctx.db, {
@@ -77,7 +84,7 @@ export const evidenceRouter = router({
       z.object({
         evidenceId: z.string().uuid(),
         contentHash: z.string().length(64).optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const row = await ctx.db.query.evidence.findFirst({
@@ -92,7 +99,10 @@ export const evidenceRouter = router({
         with: { requirement: { columns: { id: true, categoryId: true } } },
       });
       if (!statusRow) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Requirement status not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Requirement status not found",
+        });
       }
       await verifyAssessmentOwnership(ctx.db, statusRow.assessmentId, ctx.companyId);
       await enforceAssignment(ctx.db, {
@@ -108,12 +118,7 @@ export const evidenceRouter = router({
           status: "in_review",
           contentHash: input.contentHash ?? null,
         })
-        .where(
-          and(
-            eq(evidence.id, input.evidenceId),
-            eq(evidence.status, "draft"),
-          )
-        )
+        .where(and(eq(evidence.id, input.evidenceId), eq(evidence.status, "draft")))
         .returning();
 
       return updated;
@@ -132,7 +137,12 @@ export const evidenceRouter = router({
       const [owned] = await ctx.db
         .select({ id: companyAssessment.id })
         .from(companyAssessment)
-        .where(and(eq(companyAssessment.id, statusRow.assessmentId), eq(companyAssessment.companyId, ctx.companyId)))
+        .where(
+          and(
+            eq(companyAssessment.id, statusRow.assessmentId),
+            eq(companyAssessment.companyId, ctx.companyId),
+          ),
+        )
         .limit(1);
       if (!owned) return [];
 
@@ -145,10 +155,8 @@ export const evidenceRouter = router({
         rows.map(async (row) => ({
           ...row,
           downloadUrl:
-            row.status !== "draft"
-              ? await createPresignedGet(row.storageKey)
-              : null,
-        }))
+            row.status !== "draft" ? await createPresignedGet(row.storageKey) : null,
+        })),
       );
     }),
 
@@ -170,7 +178,12 @@ export const evidenceRouter = router({
       const [owned] = await ctx.db
         .select({ id: companyAssessment.id })
         .from(companyAssessment)
-        .where(and(eq(companyAssessment.id, statusRow.assessmentId), eq(companyAssessment.companyId, ctx.companyId)))
+        .where(
+          and(
+            eq(companyAssessment.id, statusRow.assessmentId),
+            eq(companyAssessment.companyId, ctx.companyId),
+          ),
+        )
         .limit(1);
       if (!owned) return null;
 
@@ -193,7 +206,10 @@ export const evidenceRouter = router({
         with: { requirement: { columns: { id: true, categoryId: true } } },
       });
       if (!statusRow) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Requirement status not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Requirement status not found",
+        });
       }
 
       await verifyAssessmentOwnership(ctx.db, statusRow.assessmentId, ctx.companyId);

--- a/server/trpc/routers/evidence.ts
+++ b/server/trpc/routers/evidence.ts
@@ -3,7 +3,13 @@ import { eq, and } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { router, companyProcedure } from "../init";
 import { evidence, companyRequirementStatus, companyAssessment } from "@/schema";
-import { createPresignedPut, createPresignedGet, deleteObject } from "@/lib/storage";
+import {
+  createPresignedPut,
+  createPresignedGet,
+  deleteObject,
+  normalizeContentType,
+  sanitizeFilename,
+} from "@/lib/storage";
 import { enforceAssignment, verifyAssessmentOwnership } from "../guards";
 import { randomUUID } from "crypto";
 
@@ -35,7 +41,13 @@ export const evidenceRouter = router({
         categoryId: statusRow.requirement.categoryId,
       });
 
-      const storageKey = `evidence/${ctx.companyId}/${input.requirementStatusId}/${randomUUID()}-${input.fileName}`;
+      // Audit F-4 (2026-09-10): the caller's filename decides part of the key
+      // and the caller's fileType decides what a later presigned GET serves.
+      // Neither is trusted raw — the supplier-portal upload paths have always
+      // done both, this one did neither. `fileName` is still stored verbatim
+      // on the row, so the download keeps the name the user recognises.
+      const storedType = normalizeContentType(input.fileType);
+      const storageKey = `evidence/${ctx.companyId}/${input.requirementStatusId}/${randomUUID()}-${sanitizeFilename(input.fileName)}`;
 
       // Create draft evidence record
       const [row] = await ctx.db
@@ -43,7 +55,7 @@ export const evidenceRouter = router({
         .values({
           requirementStatusId: input.requirementStatusId,
           fileName: input.fileName,
-          fileType: input.fileType,
+          fileType: storedType,
           fileSize: input.fileSize,
           storageKey,
           uploadedBy: ctx.userId,
@@ -51,9 +63,12 @@ export const evidenceRouter = router({
         })
         .returning();
 
-      const uploadUrl = await createPresignedPut(storageKey, input.fileType, input.fileSize);
+      const uploadUrl = await createPresignedPut(storageKey, storedType, input.fileSize);
 
-      return { uploadUrl, storageKey, evidenceId: row.id };
+      // `contentType` is signed into `uploadUrl`, so the PUT has to send this
+      // exact value back or S3 answers 403. The caller must not reuse
+      // `file.type` here — it may be the value we just downgraded.
+      return { uploadUrl, storageKey, evidenceId: row.id, contentType: storedType };
     }),
 
   /** Confirm upload completed — transition from draft to in_review */

--- a/server/trpc/routers/supplier-portal/certification.ts
+++ b/server/trpc/routers/supplier-portal/certification.ts
@@ -10,6 +10,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
+import { MAX_UPLOAD_BYTES } from "@/lib/storage/limits";
 import { sanitizeFilename } from "@/lib/storage/object-key";
 import { createPresignedPut } from "@/lib/storage/presign";
 import { companyCertification } from "@/schema";
@@ -86,11 +87,7 @@ export const companyCertificationRouter = router({
           .min(1)
           .max(100)
           .regex(/^application\/pdf$/, "PDF only"),
-        fileSize: z
-          .number()
-          .int()
-          .positive()
-          .max(50 * 1024 * 1024),
+        fileSize: z.number().int().positive().max(MAX_UPLOAD_BYTES),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/server/trpc/routers/supplier-portal/certification.ts
+++ b/server/trpc/routers/supplier-portal/certification.ts
@@ -6,15 +6,16 @@
  * in the company_certification table for indexing. Used by the supplier portal
  * today; reusable by the entity portal in the future.
  */
-import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+
 import { TRPCError } from "@trpc/server";
-import { router, companyProcedure } from "../../init";
-import { insertRow } from "../../typed";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { sanitizeFilename } from "@/lib/storage/object-key";
+import { createPresignedPut } from "@/lib/storage/presign";
 import { companyCertification } from "@/schema";
 import { companyCertificationCreateSchema } from "@/schema/validators";
-import { createPresignedPut } from "@/lib/storage/presign";
-import { sanitizeFilename } from "@/lib/storage/object-key";
+import { companyProcedure, router } from "../../init";
+import { insertRow } from "../../typed";
 
 export const companyCertificationRouter = router({
   /** List all certifications I own. */
@@ -85,7 +86,11 @@ export const companyCertificationRouter = router({
           .min(1)
           .max(100)
           .regex(/^application\/pdf$/, "PDF only"),
-        fileSize: z.number().int().positive().max(50 * 1024 * 1024),
+        fileSize: z
+          .number()
+          .int()
+          .positive()
+          .max(50 * 1024 * 1024),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -94,5 +99,4 @@ export const companyCertificationRouter = router({
       const url = await createPresignedPut(key, input.contentType, input.fileSize);
       return { url, key };
     }),
-
 });

--- a/server/trpc/routers/supplier-portal/certification.ts
+++ b/server/trpc/routers/supplier-portal/certification.ts
@@ -14,11 +14,7 @@ import { insertRow } from "../../typed";
 import { companyCertification } from "@/schema";
 import { companyCertificationCreateSchema } from "@/schema/validators";
 import { createPresignedPut } from "@/lib/storage/presign";
-
-/** Strip path-traversal characters from a filename before using it in an S3 key. */
-function sanitizeFilename(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 200);
-}
+import { sanitizeFilename } from "@/lib/storage/object-key";
 
 export const companyCertificationRouter = router({
   /** List all certifications I own. */

--- a/server/trpc/routers/supplier-portal/profile.ts
+++ b/server/trpc/routers/supplier-portal/profile.ts
@@ -25,11 +25,7 @@ import { company } from "@/schema";
 import { securityProfileUpdateSchema } from "@/schema/validators";
 import { normalizeDomain } from "./helpers";
 import { createPresignedPut } from "@/lib/storage/presign";
-
-/** Strip any path-traversal characters from a filename before using it in an S3 key. */
-function sanitizeFilename(name: string): string {
-  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 200);
-}
+import { sanitizeFilename } from "@/lib/storage/object-key";
 
 /**
  * Shape of the supplier-portal subset of the company row, projected by `get`.

--- a/server/trpc/routers/supplier-portal/profile.ts
+++ b/server/trpc/routers/supplier-portal/profile.ts
@@ -16,16 +16,17 @@
  * logoStorageKey is set via the dedicated `setLogo` mutation which validates
  * the S3 key prefix.
  */
-import { eq } from "drizzle-orm";
+
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { router, companyProcedure } from "../../init";
-import { updateRow } from "../../typed";
+import { sanitizeFilename } from "@/lib/storage/object-key";
+import { createPresignedPut } from "@/lib/storage/presign";
 import { company } from "@/schema";
 import { securityProfileUpdateSchema } from "@/schema/validators";
+import { companyProcedure, router } from "../../init";
+import { updateRow } from "../../typed";
 import { normalizeDomain } from "./helpers";
-import { createPresignedPut } from "@/lib/storage/presign";
-import { sanitizeFilename } from "@/lib/storage/object-key";
 
 /**
  * Shape of the supplier-portal subset of the company row, projected by `get`.
@@ -105,9 +106,7 @@ export const supplierProfileRouter = router({
     .input(securityProfileUpdateSchema)
     .mutation(async ({ ctx, input }) => {
       const normalizedDomain =
-        input.primaryDomain != null
-          ? normalizeDomain(input.primaryDomain)
-          : undefined;
+        input.primaryDomain != null ? normalizeDomain(input.primaryDomain) : undefined;
 
       const [row] = await ctx.db
         .update(company)
@@ -136,7 +135,11 @@ export const supplierProfileRouter = router({
           .min(1)
           .max(100)
           .regex(/^image\/(png|jpeg|jpg|webp|svg\+xml)$/),
-        fileSize: z.number().int().positive().max(5 * 1024 * 1024),
+        fileSize: z
+          .number()
+          .int()
+          .positive()
+          .max(5 * 1024 * 1024),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/server/trpc/routers/supplier-portal/profile.ts
+++ b/server/trpc/routers/supplier-portal/profile.ts
@@ -130,11 +130,19 @@ export const supplierProfileRouter = router({
     .input(
       z.object({
         fileName: z.string().min(1).max(500),
+        // Raster only. SVG is a document: it carries <script>, and the store
+        // serves it back with whatever type it was uploaded under, on an
+        // origin the self-host Caddyfile makes a sibling of the app domain.
+        // Audit F-4 pinned the content type on the other three upload paths
+        // and this one was missed, because its regex looked like a guard
+        // while admitting the one executable format in the list. Nothing
+        // renders logoStorageKey today, so this closed a latent hole rather
+        // than a live one.
         contentType: z
           .string()
           .min(1)
           .max(100)
-          .regex(/^image\/(png|jpeg|jpg|webp|svg\+xml)$/),
+          .regex(/^image\/(png|jpeg|jpg|webp)$/),
         fileSize: z
           .number()
           .int()

--- a/server/trpc/routers/supplier-portal/relationship.ts
+++ b/server/trpc/routers/supplier-portal/relationship.ts
@@ -8,18 +8,19 @@
  *
  * Rows owned by THIS supplier are identified by supplierCompanyId = ctx.companyId.
  */
-import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
+
 import { TRPCError } from "@trpc/server";
-import { router, companyProcedure } from "../../init";
-import { insertRow, updateRow } from "../../typed";
-import { supplier, company } from "@/schema";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { company, supplier } from "@/schema";
 import {
-  supplierInviteCustomerSchema,
   relationshipClausesUpdateSchema,
+  supplierInviteCustomerSchema,
 } from "@/schema/validators";
-import { generateOpaqueToken } from "./helpers";
+import { companyProcedure, router } from "../../init";
+import { insertRow, updateRow } from "../../typed";
 import { notifyCustomerAdded } from "./broadcast";
+import { generateOpaqueToken } from "./helpers";
 
 /**
  * Guard: only companies that have opted into the supplier portal
@@ -44,8 +45,13 @@ async function requireSupplierRole(
 export const supplierRelationshipRouter = router({
   /** List all customers (supplier rows) where I'm the supplier-side party. */
   listMyCustomers: companyProcedure.query(async ({ ctx }) => {
+    // Audit F-9 (2026-09-10): no `unsubscribeToken`. It is the bearer
+    // credential for /supplier-access/{token}, one per customer, and this
+    // list renders customer name and status. `invite` and `resend` build the
+    // link from a targeted read, which is where the token belongs.
     return ctx.db.query.supplier.findMany({
       where: eq(supplier.supplierCompanyId, ctx.companyId),
+      columns: { unsubscribeToken: false },
       orderBy: [desc(supplier.createdAt)],
     });
   }),
@@ -114,7 +120,11 @@ export const supplierRelationshipRouter = router({
       return inserted;
     }),
 
-  /** Get a single relationship — returns the supplier row INCLUDING per-customer contract clauses. */
+  /**
+   * Get a single relationship — returns the supplier row INCLUDING
+   * per-customer contract clauses, but not the access token (audit F-9): the
+   * detail view renders clauses and SLA, and the token is a credential.
+   */
   get: companyProcedure
     .input(z.object({ id: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
@@ -123,6 +133,7 @@ export const supplierRelationshipRouter = router({
           eq(supplier.id, input.id),
           eq(supplier.supplierCompanyId, ctx.companyId),
         ),
+        columns: { unsubscribeToken: false },
       });
       if (!row) throw new TRPCError({ code: "NOT_FOUND" });
       return row;
@@ -143,12 +154,7 @@ export const supplierRelationshipRouter = router({
       const [row] = await ctx.db
         .update(supplier)
         .set(updateRow(supplier, { ...clauses, updatedAt: new Date() }))
-        .where(
-          and(
-            eq(supplier.id, id),
-            eq(supplier.supplierCompanyId, ctx.companyId),
-          ),
-        )
+        .where(and(eq(supplier.id, id), eq(supplier.supplierCompanyId, ctx.companyId)))
         .returning();
       if (!row) throw new TRPCError({ code: "NOT_FOUND" });
       return row;
@@ -167,10 +173,7 @@ export const supplierRelationshipRouter = router({
           }),
         )
         .where(
-          and(
-            eq(supplier.id, input.id),
-            eq(supplier.supplierCompanyId, ctx.companyId),
-          ),
+          and(eq(supplier.id, input.id), eq(supplier.supplierCompanyId, ctx.companyId)),
         )
         .returning();
       if (!row) throw new TRPCError({ code: "NOT_FOUND" });

--- a/server/trpc/routers/supplier.ts
+++ b/server/trpc/routers/supplier.ts
@@ -10,13 +10,17 @@
  * etc.) live under server/trpc/routers/supplier-portal/ and write to the same
  * table from the supplier perspective via supplierCompanyId.
  */
+
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
-import { router, companyProcedure } from "../init";
-import { recheckModuleRequirements, invalidateModuleSignOffs } from "@/lib/compliance/module-recheck";
-import { insertRow, updateRow } from "../typed";
+import {
+  invalidateModuleSignOffs,
+  recheckModuleRequirements,
+} from "@/lib/compliance/module-recheck";
 import { supplier } from "@/schema";
 import { supplierInsertSchema, supplierUpdateSchema } from "@/schema/validators";
+import { companyProcedure, router } from "../init";
+import { insertRow, updateRow } from "../typed";
 
 export const supplierRouter = router({
   list: companyProcedure.query(async ({ ctx }) => {
@@ -62,7 +66,9 @@ export const supplierRouter = router({
         .insert(supplier)
         .values(insertRow(supplier, values))
         .returning();
-      invalidateModuleSignOffs(ctx.db, ctx.companyId, "supplier", ctx.userId).catch((err) => console.error("[background] supplier recheck:", err));
+      invalidateModuleSignOffs(ctx.db, ctx.companyId, "supplier", ctx.userId).catch(
+        (err) => console.error("[background] supplier recheck:", err),
+      );
       return row;
     }),
 
@@ -74,14 +80,11 @@ export const supplierRouter = router({
       const [row] = await ctx.db
         .update(supplier)
         .set(updateRow(supplier, updates))
-        .where(
-          and(
-            eq(supplier.id, id),
-            eq(supplier.customerCompanyId, ctx.companyId),
-          ),
-        )
+        .where(and(eq(supplier.id, id), eq(supplier.customerCompanyId, ctx.companyId)))
         .returning();
-      invalidateModuleSignOffs(ctx.db, ctx.companyId, "supplier", ctx.userId).catch((err) => console.error("[background] supplier recheck:", err));
+      invalidateModuleSignOffs(ctx.db, ctx.companyId, "supplier", ctx.userId).catch(
+        (err) => console.error("[background] supplier recheck:", err),
+      );
       return row;
     }),
 
@@ -91,12 +94,11 @@ export const supplierRouter = router({
       await ctx.db
         .delete(supplier)
         .where(
-          and(
-            eq(supplier.id, input.id),
-            eq(supplier.customerCompanyId, ctx.companyId),
-          ),
+          and(eq(supplier.id, input.id), eq(supplier.customerCompanyId, ctx.companyId)),
         );
-      recheckModuleRequirements(ctx.db, ctx.companyId, "supplier", ctx.userId).catch((err) => console.error("[background] supplier:", err));
+      recheckModuleRequirements(ctx.db, ctx.companyId, "supplier", ctx.userId).catch(
+        (err) => console.error("[background] supplier:", err),
+      );
       return { deleted: true };
     }),
 });

--- a/server/trpc/routers/supplier.ts
+++ b/server/trpc/routers/supplier.ts
@@ -25,8 +25,19 @@ export const supplierRouter = router({
     // Direction-B rows where a supplier accepted our magic-link invite
     // (token set, supplierCompanyId set). Both are legitimate "my suppliers"
     // entries from the entity's perspective.
+    //
+    // Audit F-9 (2026-09-10): `unsubscribeToken` is excluded. Despite the
+    // legacy column name it is the supplier portal's bearer credential —
+    // 64 hex chars, and holding it grants the full customer view at
+    // /supplier-access/{token} with no account. It is the caller's own
+    // credential so this was never a cross-tenant leak, but a list payload
+    // that renders name, risk level and status has no use for it, and every
+    // other surface in the codebase already projects around this column
+    // (schema/validators.ts omits it, mass-assignment.test.ts asserts it,
+    // SuppliersPage hides it, export-demo-ordner projects it out).
     return ctx.db.query.supplier.findMany({
       where: eq(supplier.customerCompanyId, ctx.companyId),
+      columns: { unsubscribeToken: false },
       orderBy: [desc(supplier.updatedAt)],
     });
   }),

--- a/server/trpc/routers/training.ts
+++ b/server/trpc/routers/training.ts
@@ -1,17 +1,20 @@
-import { z } from "zod";
-import { eq, and, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { router, companyProcedure } from "../init";
-import { recheckModuleRequirements, invalidateModuleSignOffs } from "@/lib/compliance/module-recheck";
-import { trainingRecord } from "@/schema";
-import { trainingInsertSchema, trainingUpdateSchema } from "@/schema/validators";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
 import {
-  createPresignedPut,
+  invalidateModuleSignOffs,
+  recheckModuleRequirements,
+} from "@/lib/compliance/module-recheck";
+import {
   createPresignedGet,
+  createPresignedPut,
   normalizeContentType,
   sanitizeFilename,
 } from "@/lib/storage";
 import { MAX_UPLOAD_BYTES } from "@/lib/storage/limits";
+import { trainingRecord } from "@/schema";
+import { trainingInsertSchema, trainingUpdateSchema } from "@/schema/validators";
+import { companyProcedure, router } from "../init";
 
 /**
  * batchCreate writes one training_record row per participant, so its input
@@ -30,7 +33,12 @@ const participantColumns = {
 } as const;
 
 const batchCreateSchema = z.object({
-  training: trainingInsertSchema.omit({ ...participantColumns, id: true, companyId: true, createdAt: true }),
+  training: trainingInsertSchema.omit({
+    ...participantColumns,
+    id: true,
+    companyId: true,
+    createdAt: true,
+  }),
   participants: z.array(trainingInsertSchema.pick(participantColumns)).min(1),
 });
 
@@ -50,7 +58,12 @@ export const trainingRouter = router({
         .insert(trainingRecord)
         .values({ ...input, companyId: ctx.companyId })
         .returning();
-      invalidateModuleSignOffs(ctx.db, ctx.companyId, "training_record", ctx.userId).catch((err) => console.error("[background] training_record recheck:", err));
+      invalidateModuleSignOffs(
+        ctx.db,
+        ctx.companyId,
+        "training_record",
+        ctx.userId,
+      ).catch((err) => console.error("[background] training_record recheck:", err));
       return row;
     }),
 
@@ -67,7 +80,12 @@ export const trainingRouter = router({
           })),
         )
         .returning();
-      invalidateModuleSignOffs(ctx.db, ctx.companyId, "training_record", ctx.userId).catch((err) => console.error("[background] training_record recheck:", err));
+      invalidateModuleSignOffs(
+        ctx.db,
+        ctx.companyId,
+        "training_record",
+        ctx.userId,
+      ).catch((err) => console.error("[background] training_record recheck:", err));
       return rows;
     }),
 
@@ -78,9 +96,16 @@ export const trainingRouter = router({
       const [row] = await ctx.db
         .update(trainingRecord)
         .set(data)
-        .where(and(eq(trainingRecord.id, id), eq(trainingRecord.companyId, ctx.companyId)))
+        .where(
+          and(eq(trainingRecord.id, id), eq(trainingRecord.companyId, ctx.companyId)),
+        )
         .returning();
-      invalidateModuleSignOffs(ctx.db, ctx.companyId, "training_record", ctx.userId).catch((err) => console.error("[background] training_record recheck:", err));
+      invalidateModuleSignOffs(
+        ctx.db,
+        ctx.companyId,
+        "training_record",
+        ctx.userId,
+      ).catch((err) => console.error("[background] training_record recheck:", err));
       return row;
     }),
 
@@ -89,8 +114,18 @@ export const trainingRouter = router({
     .mutation(async ({ ctx, input }) => {
       await ctx.db
         .delete(trainingRecord)
-        .where(and(eq(trainingRecord.id, input.id), eq(trainingRecord.companyId, ctx.companyId)));
-      recheckModuleRequirements(ctx.db, ctx.companyId, "training_record", ctx.userId).catch((err) => console.error("[background] training:", err));
+        .where(
+          and(
+            eq(trainingRecord.id, input.id),
+            eq(trainingRecord.companyId, ctx.companyId),
+          ),
+        );
+      recheckModuleRequirements(
+        ctx.db,
+        ctx.companyId,
+        "training_record",
+        ctx.userId,
+      ).catch((err) => console.error("[background] training:", err));
       return { deleted: true };
     }),
 
@@ -138,7 +173,10 @@ export const trainingRouter = router({
         columns: { certificateFileKey: true },
       });
       if (!row?.certificateFileKey) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "No certificate on this record" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No certificate on this record",
+        });
       }
       return { downloadUrl: await createPresignedGet(row.certificateFileKey) };
     }),

--- a/server/trpc/routers/training.ts
+++ b/server/trpc/routers/training.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 import { eq, and, desc } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
 import { router, companyProcedure } from "../init";
 import { recheckModuleRequirements, invalidateModuleSignOffs } from "@/lib/compliance/module-recheck";
 import { trainingRecord } from "@/schema";
 import { trainingInsertSchema, trainingUpdateSchema } from "@/schema/validators";
-import { createPresignedPut, createPresignedGet } from "@/lib/storage";
+import {
+  createPresignedPut,
+  createPresignedGet,
+  normalizeContentType,
+  sanitizeFilename,
+} from "@/lib/storage";
 import { MAX_UPLOAD_BYTES } from "@/lib/storage/limits";
 
 /**
@@ -101,17 +107,39 @@ export const trainingRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const key = `companies/${ctx.companyId}/training-certs/${crypto.randomUUID()}-${input.fileName}`;
-      const uploadUrl = await createPresignedPut(key, input.contentType, input.fileSize);
-      return { uploadUrl, fileKey: key };
+      // Audit F-4 (2026-09-10): same treatment as evidence.createUploadUrl —
+      // the filename does not get to shape the key, and the caller does not
+      // get to choose a content type a browser will render. `contentType` is
+      // returned because it is signed into the URL and the PUT must echo it.
+      const storedType = normalizeContentType(input.contentType);
+      const key = `companies/${ctx.companyId}/training-certs/${crypto.randomUUID()}-${sanitizeFilename(input.fileName)}`;
+      const uploadUrl = await createPresignedPut(key, storedType, input.fileSize);
+      return { uploadUrl, fileKey: key, contentType: storedType };
     }),
 
+  /**
+   * Presigned GET for a training record's certificate.
+   *
+   * Audit F-6 (2026-09-10): this used to take the object key from the caller
+   * and admit it on a `startsWith("companies/<companyId>/")` prefix test. The
+   * prefix did hold the tenant boundary, but it let a caller name any object
+   * under their company's prefix, including keys no training_record points
+   * at. Every other download path in the codebase resolves the key from a row
+   * it has already checked ownership of; this one now does too.
+   */
   getCertificateDownloadUrl: companyProcedure
-    .input(z.object({ fileKey: z.string() }))
+    .input(z.object({ trainingRecordId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      if (!input.fileKey.startsWith(`companies/${ctx.companyId}/`)) {
-        throw new Error("Access denied");
+      const row = await ctx.db.query.trainingRecord.findFirst({
+        where: and(
+          eq(trainingRecord.id, input.trainingRecordId),
+          eq(trainingRecord.companyId, ctx.companyId),
+        ),
+        columns: { certificateFileKey: true },
+      });
+      if (!row?.certificateFileKey) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "No certificate on this record" });
       }
-      return { downloadUrl: await createPresignedGet(input.fileKey) };
+      return { downloadUrl: await createPresignedGet(row.certificateFileKey) };
     }),
 });


### PR DESCRIPTION
A security audit on 2026-09-10 turned up eleven findings; this fixes nine of
them. **No critical, no high** — the previous audit's critical and high fixes
all held on re-check, so this is a hardening pass plus two items carried over
from June. A review of the branch then found four more things, fixed here too.

## The audit findings

| ID | Area | Fix |
|---|---|---|
| F-1 | `/api/supplier-questionnaire/{pdf,docx}` | Rate-limit two unauthenticated, CPU-bound document builders. Every other export route already did. Instances that report no client IP get a separate, larger shared budget rather than one collapsed bucket. |
| F-2 | `lib/rate-limit.ts` | Sweep fully-expired windows so the key Map stops growing forever, throttled so the sweep cannot become an O(n)-per-call cost of its own. |
| F-4 | all four upload paths | Sanitize the filename before it reaches the object key, and pin the content type the object is stored under. Unrecognised types are downgraded, never rejected, so nothing the UI accepts starts failing. Downloads are additionally forced to `attachment`, which covers objects uploaded before this change. |
| F-5 | `lib/auth/config.ts` | A Google sign-in that removes an account's password now bumps `sessionVersion`, matching the password-reset path. |
| F-6 | `training.getCertificateDownloadUrl` | Resolve the object key from a row whose ownership is checked, instead of taking it from the caller. |
| F-7 | two JSON-LD blocks | Render through `<JsonLd>`, which escapes `<`. Data is static, so nothing was exploitable; this keeps the next edit safe. |
| F-8 | `lib/cron/auth.ts` | Compare byte length, not string length, so a multi-byte token returns 401 instead of throwing a 500. |
| F-9 | supplier rows | Keep the portal bearer token out of the three list/detail payloads that were returning it. Caller's own credential, so never a cross-tenant issue — it just has no business in a list of names and statuses. |
| F-10 | `/api/dev/seed` | Allow-list the one environment that may reach the exec, instead of deny-listing production and failing open for everything else. |

## What review caught

Worth calling out, because two were defects introduced by this branch rather
than pre-existing:

- The **rate-limit sweep was O(n) on every call** when the Map sat above the
  threshold with live entries — 47 µs/call against 0,20 µs before, a 237x
  regression trading a slow memory leak for a CPU amplifier. Throttled.
- **Normalizing the stored content type corrupted the audit deliverable**: the
  evidence row's `fileType` feeds the Prüfordner evidence register, so a `.odt`
  was about to be described to a Prüfer as `application/octet-stream`. The row
  now keeps what the browser reported; only the object is stored under the
  normalized type.
- The **supplier-logo presign was the one upload path F-4 missed**, and its
  regex admitted `image/svg+xml`.
- **F-9 missed two of its own siblings** in the relationship router.

## Verification

`typecheck` clean · `test:unit` 371 pass, 0 fail (6 new) · `lint:ci` clean ·
`next build` succeeds · all 8 CI checks green including e2e.

## Deliberately not in here

- Nonce-based CSP. Its own piece of work.
- The `@auth/core` bump for GHSA-x445-f3h2-j279 — the one production-reachable
  dependency advisory. Bumping a beta auth library belongs in a change where
  breaking sign-in is the only thing being watched. Worth doing next.
- Moving the rate-limit window to Postgres, which is the real fix for F-2.
- The account-owner notification when a Google sign-in removes a password.