### PR TITLE
chore(i18n): drop the dead landing.regLine key

### DIFF
--- a/messages/landing/cs.json
+++ b/messages/landing/cs.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Zdarma · Bez vendor lock-inu",
     "subtitle": "Bezplatná platforma pro regulované firmy a jejich dodavatele k zavedení NIS2: sebehodnocení, šablony a školení vedení. <os>Open source</os>, bez vendor lock-inu.",
     "productLine": "Bezplatná shoda s NIS2 a informace pro regulované firmy a jejich dodavatele.",
-    "regLine": "Směrnice NIS2 (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Dostali jste od zákazníka dotazník k NIS2? Přejděte do portálu pro dodavatele.",
     "trust1": "Open source, bez vendor lock-inu",
     "trust2": "Hostováno v Německu, v souladu s GDPR",

--- a/messages/landing/de.json
+++ b/messages/landing/de.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open Source · Kostenlos · Kein Lock-in",
     "subtitle": "Die kostenlose Plattform, mit der regulierte Unternehmen und ihre Lieferanten NIS2 umsetzen: mit Selbsteinschätzung, Vorlagen und Schulung für die Geschäftsführung. <os>Open Source</os>, kein Lock-in.",
     "productLine": "Kostenlose NIS2-Compliance und Informationen für regulierte Unternehmen und ihre Lieferanten.",
-    "regLine": "NIS2-Richtlinie (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Haben Sie einen NIS2-Fragebogen von einem Kunden erhalten? Zum Lieferantenportal.",
     "trust1": "Open Source, kein Lock-in",
     "trust2": "Gehostet in Deutschland, DSGVO-konform",

--- a/messages/landing/en.json
+++ b/messages/landing/en.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Free · No lock-in",
     "subtitle": "The free platform for regulated companies and their suppliers to implement NIS2: self-assessment, templates, and management training. <os>Open source</os>, no lock-in.",
     "productLine": "Free NIS2 compliance and information for regulated companies and their suppliers.",
-    "regLine": "NIS2 Directive (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Received a NIS2 questionnaire from a customer? Go to the supplier portal.",
     "trust1": "Open source, no lock-in",
     "trust2": "Hosted in Germany, GDPR-compliant",

--- a/messages/landing/es.json
+++ b/messages/landing/es.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Gratis · Sin lock-in",
     "subtitle": "La plataforma gratuita para que las empresas reguladas y sus proveedores implementen NIS2: autoevaluación, plantillas y formación para la dirección. <os>Open source</os>, sin lock-in.",
     "productLine": "Cumplimiento e información sobre NIS2 gratuitos para empresas reguladas y sus proveedores.",
-    "regLine": "Directiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "¿Ha recibido un cuestionario NIS2 de un cliente? Vaya al portal de proveedores.",
     "trust1": "Open source, sin lock-in",
     "trust2": "Alojada en Alemania, conforme con el GDPR",

--- a/messages/landing/fr.json
+++ b/messages/landing/fr.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Gratuit · Sans lock-in",
     "subtitle": "La plateforme gratuite permettant aux entreprises réglementées et à leurs fournisseurs de mettre en œuvre NIS2 : auto-évaluation, modèles et formation de la direction. <os>Open source</os>, sans lock-in.",
     "productLine": "Conformité et information NIS2 gratuites pour les entreprises réglementées et leurs fournisseurs.",
-    "regLine": "Directive NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Vous avez reçu un questionnaire NIS2 de la part d'un client ? Accédez au portail fournisseur.",
     "trust1": "Open source, sans lock-in",
     "trust2": "Hébergée en Allemagne, conforme au GDPR",

--- a/messages/landing/it.json
+++ b/messages/landing/it.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Gratuita · Nessun lock-in",
     "subtitle": "La piattaforma gratuita con cui le aziende regolamentate e i loro fornitori implementano NIS2: autovalutazione, modelli e formazione per la direzione. <os>Open source</os>, nessun lock-in.",
     "productLine": "Conformità NIS2 e informazioni gratuite per le aziende regolamentate e i loro fornitori.",
-    "regLine": "Direttiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Hai ricevuto un questionario NIS2 da un cliente? Vai al portale fornitori.",
     "trust1": "Open source, nessun lock-in",
     "trust2": "In hosting in Germania, conforme al GDPR",

--- a/messages/landing/nl.json
+++ b/messages/landing/nl.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Gratis · Geen lock-in",
     "subtitle": "Het gratis platform waarmee gereguleerde bedrijven en hun leveranciers NIS2 implementeren: met zelfbeoordeling, sjablonen en bestuurstraining. <os>Open source</os>, geen lock-in.",
     "productLine": "Gratis NIS2-compliance en informatie voor gereguleerde bedrijven en hun leveranciers.",
-    "regLine": "NIS2-richtlijn (EU) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Hebt u een NIS2-vragenlijst van een klant ontvangen? Naar het leveranciersportaal.",
     "trust1": "Open source, geen lock-in",
     "trust2": "Gehost in Duitsland, AVG-conform",

--- a/messages/landing/pl.json
+++ b/messages/landing/pl.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Darmowe · Kein Lock-in",
     "subtitle": "Darmowa platforma dla regulowanych firm i ich dostawców do wdrożenia NIS2: samoocena, szablony i szkolenia dla kierownictwa. <os>Open source</os>, bez lock-inu.",
     "productLine": "Darmowa zgodność z NIS2 i informacje dla regulowanych firm oraz ich dostawców.",
-    "regLine": "Dyrektywa NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Otrzymałeś kwestionariusz NIS2 od klienta? Przejdź do portalu dostawców.",
     "trust1": "Open source, kein Lock-in",
     "trust2": "Hostowane w Niemczech, zgodne z GDPR",

--- a/messages/landing/pt.json
+++ b/messages/landing/pt.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open source · Gratuito · Sem lock-in",
     "subtitle": "A plataforma gratuita para empresas reguladas e os seus fornecedores implementarem a NIS2: autoavaliação, modelos e formação para a direção. <os>Open source</os>, sem lock-in.",
     "productLine": "Conformidade NIS2 e informação gratuitas para empresas reguladas e os seus fornecedores.",
-    "regLine": "Diretiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Recebeu um questionário NIS2 de um cliente? Aceda ao portal de fornecedores.",
     "trust1": "Open source, sem lock-in",
     "trust2": "Alojada na Alemanha, em conformidade com o GDPR",

--- a/messages/landing/ro.json
+++ b/messages/landing/ro.json
@@ -4,7 +4,6 @@
     "eyebrow": "Open Source · Gratuit · Kein Lock-in",
     "subtitle": "Platforma gratuită prin care companiile reglementate și furnizorii lor implementează NIS2: autoevaluare, șabloane și instruire pentru conducere. <os>Open Source</os>, fără lock-in.",
     "productLine": "Conformitate NIS2 gratuită și informații pentru companiile reglementate și furnizorii lor.",
-    "regLine": "Directiva NIS2 (UE) 2022/2555 · CIR 2024/2690",
     "supplierDoor": "Ați primit un chestionar NIS2 de la un client? Mergeți la portalul furnizorilor.",
     "trust1": "Open Source, kein Lock-in",
     "trust2": "Găzduită în Germania, conformă cu GDPR",


### PR DESCRIPTION
`landing.regLine` carried "NIS2 Directive (EU) 2022/2555 · CIR 2024/2690". The hero stopped rendering that line in #166, so the key is now defined in all ten landing files and read by nothing. Left in place it sends translators after a string that cannot appear on any page.

**Not the same key as `supplierPortal.marketing.regLine`.** The supplier-portal page still renders its own citation line from that namespace, which keeps its own copy in all ten files and is untouched here. The only `t("regLine")` call left in the codebase resolves to it.

## Verification

- Repo-wide search: after this change, `regLine` appears only under `messages/supplierPortal/` plus the single call site in `app/[locale]/supplier-portal/page.tsx`.
- Checked programmatically across all ten locales that `landing.regLine` is gone, `supplierPortal.marketing.regLine` is intact, and `landing.supplierDoor` still present.
- `bun run typecheck` and `bun run lint:ci` clean.
- Rendered the landing page in de, ro, cs and pl: all 200, supplier-portal link present, and no `MISSING_MESSAGE` or errors in the dev log.

`scripts/i18n/validate.ts` could not be run: it fails on a missing `@formatjs/icu-messageformat-parser` module, which is pre-existing and unrelated to this change.