### PR TITLE
platform-admin: Graphs tab, supplier questionnaire completeness

### DIFF
--- a/components/platform-admin/GraphsPanel.tsx
+++ b/components/platform-admin/GraphsPanel.tsx
@@ -1,0 +1,726 @@
+"use client";
+
+/**
+ * Graphs — where the platform is, over whatever window you pick.
+ *
+ * One fetch, all-time, and every chart below is folded out of it on the
+ * client, so the range buttons are instant and no two cards can disagree
+ * about the same number. The range row at the top scopes everything under it.
+ */
+
+import { useMemo, useState } from "react";
+import { type RouterOutputs, trpc } from "@/lib/trpc/client";
+import {
+  activationLagBars,
+  activationLags,
+  activePeople,
+  cohortMatrix,
+  countryBars,
+  courseFunnel,
+  firstWorkLagBars,
+  localeBars,
+  median,
+  percent,
+  progressBars,
+  questionnaireBars,
+  questionnairePercents,
+  seatBars,
+  sectorBars,
+  signupFunnel,
+  sizeBars,
+} from "./graphs/derive";
+import { VIZ, VIZ_PALETTE_CSS } from "./graphs/palette";
+import {
+  barsTable,
+  CategoryBars,
+  ChartCard,
+  CohortHeatmap,
+  cohortTable,
+  type SeriesSpec,
+  StatTile,
+  TrendColumns,
+  TrendLines,
+  trendTable,
+} from "./graphs/primitives";
+import {
+  bucketSeries,
+  eachDay,
+  type GranularityChoice,
+  parseDay,
+  RANGES,
+  type RangeKey,
+  resolveWindow,
+  todayUtc,
+} from "./graphs/range";
+
+type GrowthData = RouterOutputs["platformAdmin"]["growth"];
+
+/** How a bucket is named in headings and table columns. */
+const PERIOD_NAME = { day: "Day", week: "Week", month: "Month" } as const;
+
+const MONTH_LABEL = new Intl.DateTimeFormat("en-GB", {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+const monthName = (month: string) => MONTH_LABEL.format(parseDay(`${month}-01`));
+
+function bump(map: Map<string, number>, day: string): void {
+  map.set(day, (map.get(day) ?? 0) + 1);
+}
+
+/** Cumulative totals for every day from `from` to `to`, inclusive. */
+function runningTotals(
+  increments: Map<string, number>,
+  from: string,
+  to: string,
+): Map<string, number> {
+  const totals = new Map<string, number>();
+  let carried = 0;
+  for (const day of eachDay(from, to)) {
+    carried += increments.get(day) ?? 0;
+    totals.set(day, carried);
+  }
+  return totals;
+}
+
+const inWindow = (day: string | null, from: string, to: string): boolean =>
+  day !== null && day >= from && day <= to;
+
+export function GraphsPanel() {
+  const query = trpc.platformAdmin.growth.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+    staleTime: 60_000,
+  });
+
+  if (query.isPending) {
+    return (
+      <p className="py-16 text-center text-sm text-muted-foreground">
+        Reading the platform&rsquo;s history...
+      </p>
+    );
+  }
+  if (query.isError) {
+    return (
+      <p className="py-16 text-center text-sm text-destructive">
+        Could not load the numbers: {query.error.message}
+      </p>
+    );
+  }
+  return <GraphsView data={query.data} />;
+}
+
+function GraphsView({ data }: { data: GrowthData }) {
+  const [rangeKey, setRangeKey] = useState<RangeKey>("all");
+  const [granularity, setGranularity] = useState<GranularityChoice>("auto");
+
+  const today = todayUtc();
+
+  const earliest = useMemo(() => {
+    const days = [
+      ...data.users.map((u) => u.signupDay),
+      ...data.companies.map((c) => c.createdDay),
+      ...data.leads.map((l) => l.day),
+    ];
+    return days.length === 0 ? today : days.reduce((a, b) => (a < b ? a : b));
+  }, [data, today]);
+
+  const frame = useMemo(
+    () => resolveWindow(rangeKey, granularity, earliest, today),
+    [rangeKey, granularity, earliest, today],
+  );
+  const g = frame.granularity;
+  const period = PERIOD_NAME[g];
+  const days = useMemo(() => eachDay(frame.start, frame.end), [frame.start, frame.end]);
+
+  // ── All-time day maps, built once ────────────────────────────────────────
+
+  const marks = useMemo(() => {
+    const signups = new Map<string, number>();
+    const verified = new Map<string, number>();
+    const activatedUsers = new Map<string, number>();
+    for (const u of data.users) {
+      bump(signups, u.signupDay);
+      if (u.verified) bump(verified, u.signupDay);
+      if (u.activatedDay !== null) bump(activatedUsers, u.activatedDay);
+    }
+    const orgsCreated = new Map<string, number>();
+    const orgsActivated = new Map<string, number>();
+    for (const c of data.companies) {
+      bump(orgsCreated, c.createdDay);
+      if (c.activatedDay !== null) bump(orgsActivated, c.activatedDay);
+    }
+    return { signups, verified, activatedUsers, orgsCreated, orgsActivated };
+  }, [data]);
+
+  const totals = useMemo(
+    () => ({
+      accounts: runningTotals(marks.signups, earliest, today),
+      activated: runningTotals(marks.activatedUsers, earliest, today),
+      orgsCreated: runningTotals(marks.orgsCreated, earliest, today),
+      orgsActivated: runningTotals(marks.orgsActivated, earliest, today),
+    }),
+    [marks, earliest, today],
+  );
+
+  const byDay = useMemo(
+    () => ({
+      lessons: new Map(data.lessons.map((r) => [r.day, r])),
+      work: new Map(data.work.map((r) => [r.day, r])),
+      activity: new Map(data.activity.map((r) => [r.day, r])),
+      leads: new Map(data.leads.map((r) => [r.day, r])),
+      emails: new Map(data.emails.map((r) => [r.day, r])),
+    }),
+    [data],
+  );
+
+  // ── Series ───────────────────────────────────────────────────────────────
+
+  const trends = useMemo(
+    () => ({
+      accounts: bucketSeries(
+        days,
+        g,
+        (day) => ({
+          accounts: totals.accounts.get(day) ?? 0,
+          activated: totals.activated.get(day) ?? 0,
+        }),
+        "last",
+      ),
+      signups: bucketSeries(
+        days,
+        g,
+        (day) => {
+          const all = marks.signups.get(day) ?? 0;
+          const ok = marks.verified.get(day) ?? 0;
+          return { verified: ok, unverified: all - ok };
+        },
+        "sum",
+      ),
+      orgs: bucketSeries(
+        days,
+        g,
+        (day) => ({
+          created: totals.orgsCreated.get(day) ?? 0,
+          named: totals.orgsActivated.get(day) ?? 0,
+        }),
+        "last",
+      ),
+      newOrgs: bucketSeries(
+        days,
+        g,
+        (day) => ({
+          created: marks.orgsCreated.get(day) ?? 0,
+          named: marks.orgsActivated.get(day) ?? 0,
+        }),
+        "sum",
+      ),
+      activity: bucketSeries(
+        days,
+        g,
+        (day) => ({ people: byDay.activity.get(day)?.users ?? 0 }),
+        "sum",
+      ),
+      work: bucketSeries(
+        days,
+        g,
+        (day) => {
+          const row = byDay.work.get(day);
+          return {
+            completed: row?.completed ?? 0,
+            signedOff: row?.signedOff ?? 0,
+            evidence: row?.evidence ?? 0,
+          };
+        },
+        "sum",
+      ),
+      lessons: bucketSeries(
+        days,
+        g,
+        (day) => {
+          const row = byDay.lessons.get(day);
+          return { ceo: row?.ceo ?? 0, cra: row?.cra ?? 0, tabletop: row?.tabletop ?? 0 };
+        },
+        "sum",
+      ),
+      leads: bucketSeries(
+        days,
+        g,
+        (day) => {
+          const row = byDay.leads.get(day);
+          return {
+            entity: row?.entity ?? 0,
+            supplier: row?.supplier ?? 0,
+            both: row?.both ?? 0,
+            unknown: row?.unknown ?? 0,
+          };
+        },
+        "sum",
+      ),
+      emails: bucketSeries(
+        days,
+        g,
+        (day) => ({ sent: byDay.emails.get(day)?.sent ?? 0 }),
+        "sum",
+      ),
+    }),
+    [days, g, totals, marks, byDay],
+  );
+
+  // ── Range-scoped facts ───────────────────────────────────────────────────
+
+  const scoped = useMemo(() => {
+    const newUsers = data.users.filter((u) =>
+      inWindow(u.signupDay, frame.start, frame.end),
+    );
+    const namedOrgs = data.companies.filter((c) =>
+      inWindow(c.activatedDay, frame.start, frame.end),
+    );
+    // Suppliers are scoped by when the company row appeared, not by when it
+    // was activated: a supplier-only signup never runs the entity activation
+    // flow, so activatedDay is null for them and scoping on it would show an
+    // empty supplier chart.
+    const suppliers = data.companies.filter(
+      (c) => c.actsAsSupplier && inWindow(c.createdDay, frame.start, frame.end),
+    );
+    return {
+      newUsers,
+      namedOrgs,
+      suppliers,
+      verified: newUsers.filter((u) => u.verified).length,
+      activated: newUsers.filter((u) => u.activatedDay !== null).length,
+      medianActivationDays: median(activationLags(newUsers)),
+      finishers: data.users.filter((u) =>
+        u.coursesFinished.some((c) => inWindow(c.day, frame.start, frame.end)),
+      ).length,
+      active: activePeople(data.users, frame.start, frame.end),
+      previous: {
+        newUsers: data.users.filter((u) =>
+          inWindow(u.signupDay, frame.previousStart, frame.previousEnd),
+        ).length,
+        namedOrgs: data.companies.filter((c) =>
+          inWindow(c.activatedDay, frame.previousStart, frame.previousEnd),
+        ).length,
+        active: activePeople(data.users, frame.previousStart, frame.previousEnd),
+      },
+    };
+  }, [data, frame]);
+
+  const bars = useMemo(
+    () => ({
+      signupFunnel: signupFunnel(scoped.newUsers),
+      ceoFunnel: courseFunnel(scoped.newUsers, "nis2-ceo"),
+      activationLag: activationLagBars(scoped.newUsers),
+      firstWorkLag: firstWorkLagBars(scoped.newUsers),
+      locale: localeBars(scoped.newUsers),
+      sector: sectorBars(scoped.namedOrgs),
+      size: sizeBars(scoped.namedOrgs),
+      country: countryBars(scoped.namedOrgs),
+      seats: seatBars(scoped.namedOrgs),
+      progress: progressBars(scoped.namedOrgs),
+      questionnaire: questionnaireBars(scoped.suppliers),
+    }),
+    [scoped],
+  );
+
+  const cohorts = useMemo(
+    () => cohortMatrix(data.users, today.slice(0, 7)),
+    [data, today],
+  );
+
+  const accountsNow = totals.accounts.get(frame.end) ?? 0;
+  const ceoLessons = data.courseLessonCounts["nis2-ceo"];
+  const supplierMedian = median(questionnairePercents(scoped.suppliers));
+
+  /**
+   * All time has no previous period worth naming: the window before the first
+   * signup is empty by definition, so the delta would always be the whole
+   * number again. Show it only when the comparison means something.
+   */
+  const deltaFor = (current: number, before: number) =>
+    rangeKey === "all"
+      ? undefined
+      : { amount: current - before, period: "the previous period" };
+
+  const series = {
+    accounts: [
+      { key: "accounts", label: "All accounts", color: VIZ.slot1 },
+      { key: "activated", label: "In a named organisation", color: VIZ.slot2 },
+    ],
+    signups: [
+      { key: "verified", label: "Verified", color: VIZ.slot1 },
+      { key: "unverified", label: "Never verified", color: VIZ.slot2 },
+    ],
+    // Two labellings of the same two keys. On the running total, `created`
+    // counts every organisation row that exists, named or not, so calling it
+    // "draft shells" would be a lie: the drafts are the GAP between the lines.
+    // On the per-period chart the same key really is "created this period".
+    orgsTotal: [
+      { key: "created", label: "All organisations", color: VIZ.slot2 },
+      { key: "named", label: "Named", color: VIZ.slot1 },
+    ],
+    orgsNew: [
+      { key: "created", label: "Created", color: VIZ.slot2 },
+      { key: "named", label: "Named", color: VIZ.slot1 },
+    ],
+    activity: [{ key: "people", label: "People", color: VIZ.slot1 }],
+    work: [
+      { key: "completed", label: "Requirements completed", color: VIZ.slot1 },
+      { key: "signedOff", label: "Sign-offs", color: VIZ.slot2 },
+      { key: "evidence", label: "Evidence uploaded", color: VIZ.slot3 },
+    ],
+    lessons: [
+      { key: "ceo", label: `CEO course (${ceoLessons})`, color: VIZ.slot1 },
+      {
+        key: "cra",
+        label: `CRA and SBOM (${data.courseLessonCounts["cra-sbom"]})`,
+        color: VIZ.slot2,
+      },
+      {
+        key: "tabletop",
+        label: `Tabletop (${data.courseLessonCounts["nis2-tabletop"]})`,
+        color: VIZ.slot3,
+      },
+    ],
+    leads: [
+      { key: "entity", label: "Regulated entity", color: VIZ.slot1 },
+      { key: "supplier", label: "Supplier", color: VIZ.slot2 },
+      { key: "both", label: "Both", color: VIZ.slot3 },
+      { key: "unknown", label: "Not declared", color: VIZ.slot4 },
+    ],
+    emails: [{ key: "sent", label: "Sent", color: VIZ.slot1 }],
+  } satisfies Record<string, SeriesSpec[]>;
+
+  return (
+    <div data-viz className="space-y-6">
+      <style>{VIZ_PALETTE_CSS}</style>
+
+      {/* One filter row, scoping every card below it. */}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border bg-muted/30 p-3">
+        <FilterGroup
+          legend="Range"
+          options={RANGES.map((r) => ({ key: r.key, label: r.label }))}
+          value={rangeKey}
+          onChange={setRangeKey}
+        />
+        <FilterGroup
+          legend="Bucket"
+          options={[
+            { key: "auto" as const, label: `Auto (${period.toLowerCase()})` },
+            { key: "day" as const, label: "Day" },
+            { key: "week" as const, label: "Week" },
+            { key: "month" as const, label: "Month" },
+          ]}
+          value={granularity}
+          onChange={setGranularity}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 lg:grid-cols-8">
+        <StatTile label="Accounts" value={accountsNow} sub={`total on ${frame.end}`} />
+        <StatTile
+          label="New accounts"
+          value={scoped.newUsers.length}
+          delta={deltaFor(scoped.newUsers.length, scoped.previous.newUsers)}
+        />
+        <StatTile
+          label="Verified"
+          value={scoped.verified}
+          sub={`${percent(scoped.verified, scoped.newUsers.length)} of new accounts`}
+        />
+        <StatTile
+          label="Orgs named"
+          value={scoped.namedOrgs.length}
+          delta={deltaFor(scoped.namedOrgs.length, scoped.previous.namedOrgs)}
+        />
+        <StatTile
+          label="Activation rate"
+          value={percent(scoped.activated, scoped.newUsers.length)}
+          sub="of accounts opened in range"
+        />
+        <StatTile
+          label="People doing work"
+          value={scoped.active}
+          delta={deltaFor(scoped.active, scoped.previous.active)}
+        />
+        <StatTile
+          label="Days to naming"
+          value={scoped.medianActivationDays ?? "no data"}
+          sub="median, accounts in range"
+        />
+        <StatTile
+          label="Course finishers"
+          value={scoped.finishers}
+          sub="any course, finished in range"
+        />
+      </div>
+
+      <SectionHeading
+        title="Growth"
+        blurb="How many people and organisations there are, and how fast that is changing."
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Accounts over time"
+          subtitle="Running total of every account ever created"
+          note="The second line counts accounts whose organisation has been named. Verification and naming are read as they stand today, not as they stood on the day plotted."
+          table={trendTable(trends.accounts, series.accounts, period)}
+        >
+          <TrendLines data={trends.accounts} series={series.accounts} />
+        </ChartCard>
+
+        <ChartCard
+          title={`New accounts per ${period.toLowerCase()}`}
+          subtitle="Signups, split by whether the address was ever verified"
+          note="An address that was never verified cannot sign in with a password, so the verified half is the usable intake."
+          table={trendTable(trends.signups, series.signups, period)}
+        >
+          <TrendColumns data={trends.signups} series={series.signups} />
+        </ChartCard>
+
+        <ChartCard
+          title="Organisations over time"
+          subtitle="Running total of every organisation row against the ones that got named"
+          note="Every verified account gets a draft shell automatically, so the gap between the lines is the funnel gap: people who arrived and never described their organisation."
+          table={trendTable(trends.orgs, series.orgsTotal, period)}
+        >
+          <TrendLines data={trends.orgs} series={series.orgsTotal} />
+        </ChartCard>
+
+        <ChartCard
+          title={`Organisations created and named per ${period.toLowerCase()}`}
+          subtitle="Side by side, because an org is often named long after it appears"
+          note="Grouped rather than stacked: the same organisation can appear in one bar and, weeks later, in the other."
+          table={trendTable(trends.newOrgs, series.orgsNew, period)}
+        >
+          <TrendColumns data={trends.newOrgs} series={series.orgsNew} stacked={false} />
+        </ChartCard>
+
+        <ChartCard
+          title={`Applicability checks per ${period.toLowerCase()}`}
+          subtitle="Leads from the public scope check, by the intent they declared"
+          note="Top of the funnel. These are addresses left on the applicability tool, not accounts."
+          table={trendTable(trends.leads, series.leads, period)}
+        >
+          <TrendColumns data={trends.leads} series={series.leads} />
+        </ChartCard>
+      </div>
+
+      <SectionHeading
+        title="Engagement"
+        blurb="What people do once they are in. Work means lesson progress, requirement completions, sign-offs and evidence uploads. Crons and outbound mail are deliberately not counted, or our own batch jobs would read as customers being busy."
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title={`People doing work per ${period.toLowerCase()}`}
+          subtitle="Distinct people with at least one recorded action that day"
+          note="Summed over the days in a bucket, so one person active on three days of a week counts three times here. The range tile above counts each person once."
+          table={trendTable(trends.activity, series.activity, period)}
+        >
+          <TrendLines data={trends.activity} series={series.activity} />
+        </ChartCard>
+
+        <ChartCard
+          title={`Compliance work per ${period.toLowerCase()}`}
+          subtitle="Requirements completed, sign-offs recorded, evidence uploaded"
+          note="All frameworks, not NIS 2 alone: a policy written for ISO 27001 is still work someone did here."
+          table={trendTable(trends.work, series.work, period)}
+        >
+          <TrendColumns data={trends.work} series={series.work} />
+        </ChartCard>
+
+        <ChartCard
+          title={`Lessons completed per ${period.toLowerCase()}`}
+          subtitle="Individual lessons across the three courses"
+          table={trendTable(trends.lessons, series.lessons, period)}
+        >
+          <TrendColumns data={trends.lessons} series={series.lessons} />
+        </ChartCard>
+
+        <ChartCard
+          title={`Email sent per ${period.toLowerCase()}`}
+          subtitle="Everything the notification table records as delivered"
+          note="Same scope as the Emails tab: digests, reminders, course follow-ups, lifecycle nudges, newsletter and test sends. Invites and welcome mail are not logged there."
+          table={trendTable(trends.emails, series.emails, period)}
+        >
+          <TrendColumns data={trends.emails} series={series.emails} />
+        </ChartCard>
+      </div>
+
+      <SectionHeading
+        title="Conversion"
+        blurb="Where people stop. Each funnel stage filters the one above it, so a rate always means what it says."
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Signup to signed-off work"
+          subtitle={`Accounts opened between ${frame.start} and ${frame.end}`}
+          note="Accounts opened near the end of the range have had less time to get anywhere, so a short range flatters the top and starves the bottom."
+          table={barsTable(bars.signupFunnel, "Stage")}
+        >
+          <CategoryBars bars={bars.signupFunnel} />
+        </ChartCard>
+
+        <ChartCard
+          title="The CEO course"
+          subtitle="NIS 2 for CEOs, for accounts opened in range"
+          note={`Finished means every one of the ${ceoLessons} lessons in the current course definition, the same test the certificate uses.`}
+          table={barsTable(bars.ceoFunnel, "Stage")}
+        >
+          <CategoryBars bars={bars.ceoFunnel} />
+        </ChartCard>
+
+        <ChartCard
+          title="How long until they name the organisation"
+          subtitle="Days from opening the account to activating it"
+          note="Counts only the accounts that got there. Everyone still sitting on a draft shell is absent by construction."
+          table={barsTable(bars.activationLag, "Delay")}
+        >
+          <CategoryBars bars={bars.activationLag} />
+        </ChartCard>
+
+        <ChartCard
+          title="How long until the first piece of work"
+          subtitle="Days from opening the account to the first recorded action"
+          note="Time to first value. Same caveat: only people who ever did anything appear."
+          table={barsTable(bars.firstWorkLag, "Delay")}
+        >
+          <CategoryBars bars={bars.firstWorkLag} />
+        </ChartCard>
+      </div>
+
+      <ChartCard
+        title="Do they come back"
+        subtitle="Signup month against the months that cohort did work in, all time"
+        note="Month zero is the signup month itself, which is why it is never 100 percent: plenty of people open an account and never touch anything. Dashed cells are months that have not happened yet. Not scoped by the range above, because a cohort grid needs whole months."
+        table={cohortTable(cohorts, monthName)}
+      >
+        <CohortHeatmap rows={cohorts} monthLabel={monthName} />
+      </ChartCard>
+
+      <SectionHeading
+        title="Who signed up"
+        blurb="Named organisations only. Draft shells carry placeholder details, so counting them would drown every real answer."
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Sector"
+          subtitle="Organisations named in range"
+          table={barsTable(bars.sector, "Sector")}
+        >
+          <CategoryBars bars={bars.sector} />
+        </ChartCard>
+
+        <ChartCard
+          title="Company size"
+          subtitle="Staff numbers as the organisation stated them"
+          note="Bands sit on the statutory lines: 50 and 250 employees are where the NIS 2 size-cap rule changes the answer, and 50 to 249 is also who we sell to."
+          table={barsTable(bars.size, "Employees")}
+        >
+          <CategoryBars bars={bars.size} />
+        </ChartCard>
+
+        <ChartCard
+          title="Country"
+          subtitle="From the organisation's registered address"
+          table={barsTable(bars.country, "Country")}
+        >
+          <CategoryBars bars={bars.country} />
+        </ChartCard>
+
+        <ChartCard
+          title="Interface language"
+          subtitle="Accounts opened in range, by the language they read the platform in"
+          note="Also the language their email goes out in. Accounts predating the column never set one."
+          table={barsTable(bars.locale, "Language")}
+        >
+          <CategoryBars bars={bars.locale} />
+        </ChartCard>
+
+        <ChartCard
+          title="People per organisation"
+          subtitle="Seats attached to each organisation named in range"
+          note="One seat means nobody was ever invited. A second seat is the first sign this is being used as a team tool rather than looked at once."
+          table={barsTable(bars.seats, "Seats")}
+        >
+          <CategoryBars bars={bars.seats} />
+        </ChartCard>
+
+        <ChartCard
+          title="NIS 2 progress per organisation"
+          subtitle="Where each named organisation stands on its 49 requirements"
+          note="Read from the stored compliance percentage on the NIS 2 assessment. An organisation with no assessment counts as nothing yet."
+          table={barsTable(bars.progress, "Progress")}
+        >
+          <CategoryBars bars={bars.progress} />
+        </ChartCard>
+
+        <ChartCard
+          title="Supplier questionnaire"
+          subtitle={`How far through it the ${scoped.suppliers.length} supplier${
+            scoped.suppliers.length === 1 ? "" : "s"
+          } created in range have got${supplierMedian === null ? "" : `, median ${supplierMedian}%`}`}
+          note="Counts only the questions that apply to each supplier: service-type blocks they did not tick are left out of their denominator, and a no counts as answered. Scoped by when the company row appeared, because a supplier-only signup never runs the entity activation flow."
+          table={barsTable(bars.questionnaire, "Answered")}
+        >
+          <CategoryBars bars={bars.questionnaire} />
+        </ChartCard>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chrome
+// ---------------------------------------------------------------------------
+
+function SectionHeading({ title, blurb }: { title: string; blurb: string }) {
+  return (
+    <div className="pt-2">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      <p className="mt-1 max-w-3xl text-xs text-muted-foreground">{blurb}</p>
+    </div>
+  );
+}
+
+function FilterGroup<T extends string>({
+  legend,
+  options,
+  value,
+  onChange,
+}: {
+  legend: string;
+  options: ReadonlyArray<{ key: T; label: string }>;
+  value: T;
+  onChange: (next: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs font-medium text-muted-foreground">{legend}</span>
+      <div className="flex flex-wrap gap-1">
+        {options.map((option) => (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => onChange(option.key)}
+            aria-pressed={value === option.key}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+              value === option.key
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/platform-admin/PlatformAdminPage.tsx
+++ b/components/platform-admin/PlatformAdminPage.tsx
@@ -4,6 +4,7 @@ import {
   Activity,
   BadgeCheck,
   Building2,
+  ChartLine,
   FlaskConical,
   GraduationCap,
   Loader2,
@@ -15,7 +16,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { type RouterInputs, trpc } from "@/lib/trpc/client";
+import { type RouterInputs, type RouterOutputs, trpc } from "@/lib/trpc/client";
 
 type CourseId = RouterInputs["platformAdmin"]["trainingMarkCourseComplete"]["courseId"];
 
@@ -25,6 +26,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link, useRouter } from "@/i18n/navigation";
 import { DevPanel } from "./DevPanel";
 import { EraseUserButton, ErasuresPanel } from "./GdprErasure";
+import { GraphsPanel } from "./GraphsPanel";
+import { median } from "./graphs/derive";
 
 // ---------------------------------------------------------------------------
 // Types (inferred from tRPC, kept flat for props)
@@ -110,13 +113,12 @@ const COURSES = {
   tabletop: { id: "nis2-tabletop", total: 8 },
 } as const;
 
-interface SupplierRow {
-  companyId: string;
-  companyName: string;
-  sector: string;
-  createdAt: Date;
-  customerCount: number;
-}
+/**
+ * Taken from the procedure rather than restated: the questionnaire score is a
+ * nested shape derived from the portal's own field lists, and a hand-written
+ * copy here would drift the first time a question was added.
+ */
+type SupplierRow = RouterOutputs["platformAdmin"]["supplierActivity"][number];
 
 interface EmailRow {
   id: string;
@@ -218,6 +220,7 @@ function planBadge(plan: string | null) {
 }
 
 type Tab =
+  | "graphs"
   | "users"
   | "companies"
   | "compliance"
@@ -311,6 +314,12 @@ export function PlatformAdminPage({
       {/* Tabs */}
       <div className="flex flex-wrap gap-1 rounded-lg border bg-muted/50 p-1">
         {[
+          {
+            key: "graphs" as const,
+            label: "Graphs",
+            icon: ChartLine,
+            count: undefined as number | undefined,
+          },
           { key: "users" as const, label: "Users", icon: Users, count: users.length },
           {
             key: "companies" as const,
@@ -375,6 +384,7 @@ export function PlatformAdminPage({
       </div>
 
       {/* Tab content */}
+      {tab === "graphs" && <GraphsPanel />}
       {tab === "users" && <UsersTable users={users} />}
       {tab === "companies" && <CompaniesTable companies={companies} />}
       {tab === "compliance" && <ComplianceTable rows={complianceActivity} />}
@@ -878,7 +888,16 @@ function scopeLabel(scope: string): string {
   return scope;
 }
 
-function StatCard({ label, value, sub }: { label: string; value: number; sub?: string }) {
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  /** A string when the figure is a rate or a dash, not a count. */
+  value: number | string;
+  sub?: string;
+}) {
   return (
     <Card>
       <CardContent className="p-4">
@@ -1287,43 +1306,111 @@ function MarkCourseCompleteButton({
 // ---------------------------------------------------------------------------
 
 function SuppliersTable({ rows }: { rows: SupplierRow[] }) {
+  const percentages = rows.map((r) => r.questionnaire.percent);
+  const finished = percentages.filter((p) => p === 100).length;
+  const untouched = percentages.filter((p) => p === 0).length;
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Supplier Portal Companies</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b text-left text-muted-foreground">
-                <th className="pb-2 pr-4 font-medium">Company</th>
-                <th className="pb-2 pr-4 font-medium">Sector</th>
-                <th className="pb-2 pr-4 font-medium">Customers</th>
-                <th className="pb-2 font-medium">Joined</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r) => (
-                <tr key={r.companyId} className="border-b border-border/50 last:border-0">
-                  <td className="py-2 pr-4 font-medium">{r.companyName}</td>
-                  <td className="py-2 pr-4 text-muted-foreground">{r.sector}</td>
-                  <td className="py-2 pr-4">{r.customerCount}</td>
-                  <td className="py-2 text-muted-foreground">{timeAgo(r.createdAt)}</td>
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="Suppliers" value={rows.length} sub="portal profiles created" />
+        <StatCard
+          label="Median answered"
+          value={rows.length === 0 ? "—" : `${median(percentages) ?? 0}%`}
+          sub="of the questions that apply to them"
+        />
+        <StatCard
+          label="Fully answered"
+          value={finished}
+          sub={rows.length > 0 ? `of ${rows.length}` : undefined}
+        />
+        <StatCard
+          label="Nothing filled in"
+          value={untouched}
+          sub="profile exists, no answers"
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Supplier Portal Companies</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="mb-3 text-xs text-muted-foreground">
+            The questionnaire bar counts only the questions that apply to each supplier:
+            the service-type blocks they did not tick (SaaS, on-prem, professional
+            services, managed services) are left out of their denominator, so a SaaS-only
+            supplier can still reach 100 percent. A &ldquo;no&rdquo; counts as answered.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-muted-foreground">
+                  <th className="pb-2 pr-4 font-medium">Company</th>
+                  <th className="pb-2 pr-4 font-medium">Sector</th>
+                  <th className="pb-2 pr-4 font-medium">Questionnaire</th>
+                  <th className="pb-2 pr-4 font-medium">Customers</th>
+                  <th className="pb-2 pr-4 font-medium">Last saved</th>
+                  <th className="pb-2 font-medium">Joined</th>
                 </tr>
-              ))}
-              {rows.length === 0 && (
-                <tr>
-                  <td colSpan={4} className="py-8 text-center text-muted-foreground">
-                    No supplier portal companies yet
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </CardContent>
-    </Card>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr
+                    key={r.companyId}
+                    className="border-b border-border/50 last:border-0"
+                  >
+                    <td className="py-2 pr-4 font-medium">{r.companyName}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">{r.sector}</td>
+                    <td className="py-2 pr-4">
+                      <QuestionnaireCell score={r.questionnaire} />
+                    </td>
+                    <td className="py-2 pr-4">{r.customerCount}</td>
+                    <td className="py-2 pr-4 text-muted-foreground">
+                      {r.practicesLastSavedAt ? timeAgo(r.practicesLastSavedAt) : "—"}
+                    </td>
+                    <td className="py-2 text-muted-foreground">{timeAgo(r.createdAt)}</td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-8 text-center text-muted-foreground">
+                      No supplier portal companies yet
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+/** Progress bar plus the raw ratio, with the per-page split on hover. */
+function QuestionnaireCell({ score }: { score: SupplierRow["questionnaire"] }) {
+  const breakdown = [
+    `Profile ${score.profile.answered}/${score.profile.applicable}`,
+    `Practices ${score.practices.answered}/${score.practices.applicable}`,
+    score.serviceType.applicable === 0
+      ? "Service type: no service type ticked"
+      : `Service type ${score.serviceType.answered}/${score.serviceType.applicable}`,
+  ].join(" · ");
+
+  return (
+    <div className="flex items-center gap-2" title={breakdown}>
+      <div className="h-1.5 w-20 rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          className="h-1.5 rounded-full bg-green-500"
+          style={{ width: `${score.percent}%` }}
+        />
+      </div>
+      <span className="tabular-nums text-xs text-muted-foreground">
+        {score.answered}/{score.applicable}
+      </span>
+      <span className="tabular-nums text-xs">{score.percent}%</span>
+    </div>
   );
 }
 

--- a/components/platform-admin/graphs/derive.ts
+++ b/components/platform-admin/graphs/derive.ts
@@ -1,0 +1,385 @@
+/**
+ * Derivations for the Graphs tab.
+ *
+ * Every number on the tab is folded out of the same two fact lists the server
+ * returns, so two cards can never disagree about the same quantity. All pure:
+ * given the same facts and the same window they return the same rows.
+ */
+
+import type { CompanyFact, CourseId, UserFact } from "@/lib/platform-admin/growth";
+
+/** One bar: a label, its value, and an optional second line under it. */
+export interface Bar {
+  label: string;
+  value: number;
+  /** Shown under the label — a conversion rate, a share, a caveat. */
+  hint?: string;
+  /** Drawn in the accent rather than the neutral track colour. */
+  emphasis?: boolean;
+}
+
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const lower = sorted[mid - 1];
+  const upper = sorted[mid];
+  if (sorted.length % 2 === 1) return upper ?? null;
+  return lower === undefined || upper === undefined ? null : (lower + upper) / 2;
+}
+
+export function percent(part: number, whole: number): string {
+  if (whole <= 0) return "—";
+  if (part === 0) return "0%";
+  const share = part / whole;
+  return `${(share * 100).toFixed(share >= 0.1 ? 0 : 1)}%`;
+}
+
+/** Whole days between two calendar days; negative if `to` precedes `from`. */
+export function dayGap(from: string, to: string): number {
+  const ms = Date.parse(`${to}T12:00:00Z`) - Date.parse(`${from}T12:00:00Z`);
+  return Math.round(ms / 86_400_000);
+}
+
+/** Calendar months between two "YYYY-MM" keys. */
+export function monthGap(from: string, to: string): number {
+  const [fy, fm] = from.split("-").map(Number);
+  const [ty, tm] = to.split("-").map(Number);
+  if (!fy || !fm || !ty || !tm) return 0;
+  return (ty - fy) * 12 + (tm - fm);
+}
+
+// ---------------------------------------------------------------------------
+// Banding
+// ---------------------------------------------------------------------------
+
+/**
+ * Company-size bands on the statutory lines rather than round numbers: 50 and
+ * 250 employees are where NIS 2's size-cap rule changes the answer, and 50-249
+ * is also who we sell to, which is why that band is the emphasised one.
+ */
+const SIZE_BANDS = ["Under 50", "50 to 249", "250 or more", "Not stated"] as const;
+
+function sizeBand(employeeCount: number | null): (typeof SIZE_BANDS)[number] {
+  if (employeeCount === null) return "Not stated";
+  if (employeeCount < 50) return "Under 50";
+  if (employeeCount < 250) return "50 to 249";
+  return "250 or more";
+}
+
+const LAG_BANDS = [
+  "Same day",
+  "1 to 3 days",
+  "4 to 7 days",
+  "8 to 30 days",
+  "Over 30 days",
+] as const;
+
+function lagBand(days: number): (typeof LAG_BANDS)[number] {
+  if (days <= 0) return "Same day";
+  if (days <= 3) return "1 to 3 days";
+  if (days <= 7) return "4 to 7 days";
+  if (days <= 30) return "8 to 30 days";
+  return "Over 30 days";
+}
+
+const SEAT_BANDS = ["1 person", "2 people", "3 to 5", "6 to 10", "11 or more"] as const;
+
+function seatBand(seats: number): (typeof SEAT_BANDS)[number] {
+  if (seats <= 1) return "1 person";
+  if (seats === 2) return "2 people";
+  if (seats <= 5) return "3 to 5";
+  if (seats <= 10) return "6 to 10";
+  return "11 or more";
+}
+
+const PROGRESS_BANDS = [
+  "Nothing yet",
+  "1 to 24%",
+  "25 to 49%",
+  "50 to 74%",
+  "75 to 99%",
+  "All 49 done",
+] as const;
+
+function progressBand(pct: number): (typeof PROGRESS_BANDS)[number] {
+  if (pct <= 0) return "Nothing yet";
+  if (pct < 25) return "1 to 24%";
+  if (pct < 50) return "25 to 49%";
+  if (pct < 75) return "50 to 74%";
+  if (pct < 100) return "75 to 99%";
+  return "All 49 done";
+}
+
+/** Count occurrences into a fixed, ordered band list. Empty bands stay. */
+function tally<T extends string>(values: T[], bands: readonly T[], total: number): Bar[] {
+  const counts = new Map<T, number>(bands.map((b) => [b, 0]));
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return bands.map((band) => ({
+    label: band,
+    value: counts.get(band) ?? 0,
+    hint: percent(counts.get(band) ?? 0, total),
+  }));
+}
+
+/**
+ * Free-text categories (sector, country, language): biggest first, with
+ * everything past `top` folded into one row rather than given its own hue.
+ */
+function rank(values: Array<string | null>, top: number, unknown: string): Bar[] {
+  const counts = new Map<string, number>();
+  for (const raw of values) {
+    const label = raw && raw.trim() !== "" ? raw : unknown;
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  const total = values.length;
+  const sorted = Array.from(counts, ([label, value]) => ({ label, value })).sort(
+    (a, b) => b.value - a.value || a.label.localeCompare(b.label),
+  );
+  const head = sorted.slice(0, top);
+  const tail = sorted.slice(top);
+  const rows = [...head];
+  if (tail.length > 0) {
+    rows.push({
+      label: `Other (${tail.length})`,
+      value: tail.reduce((sum, r) => sum + r.value, 0),
+    });
+  }
+  return rows.map((r) => ({ ...r, hint: percent(r.value, total) }));
+}
+
+// ---------------------------------------------------------------------------
+// Funnels
+// ---------------------------------------------------------------------------
+
+/**
+ * Signup to signed-off work, as strictly nested sets: every stage filters the
+ * one above it, so the bars can only ever shrink and a conversion rate always
+ * means what it says.
+ *
+ * Disposable-address signups are dropped before stage one. They are recorded
+ * deliberately (so bot traffic is visible) but can never verify, so leaving
+ * them in would understate every rate below.
+ */
+export function signupFunnel(users: UserFact[]): Bar[] {
+  const real = users.filter((u) => !u.disposable);
+  const verified = real.filter((u) => u.verified);
+  const activated = verified.filter((u) => u.activatedDay !== null);
+  const worked = activated.filter((u) => u.workEvents > 0);
+  const signed = worked.filter((u) => u.signOffs > 0);
+
+  const stages: Array<{ label: string; rows: UserFact[] }> = [
+    { label: "Signed up", rows: real },
+    { label: "Verified their address", rows: verified },
+    { label: "Named their organisation", rows: activated },
+    { label: "Did any work in it", rows: worked },
+    { label: "Signed off a requirement", rows: signed },
+  ];
+
+  const excluded = users.length - real.length;
+  return stages.map((stage, i) => {
+    const previous = stages[i - 1];
+    return {
+      label: stage.label,
+      value: stage.rows.length,
+      hint:
+        previous === undefined
+          ? excluded > 0
+            ? `${excluded} disposable-address signups excluded`
+            : "every signup in range"
+          : `${percent(stage.rows.length, previous.rows.length)} of the step above`,
+    };
+  });
+}
+
+/** The same shape for one course: signed up, opened it, finished every lesson. */
+export function courseFunnel(users: UserFact[], courseId: CourseId): Bar[] {
+  const real = users.filter((u) => !u.disposable);
+  const started = real.filter((u) => u.coursesStarted.includes(courseId));
+  const finished = started.filter((u) =>
+    u.coursesFinished.some((c) => c.courseId === courseId),
+  );
+  const stages = [
+    { label: "Signed up", rows: real },
+    { label: "Opened a lesson", rows: started },
+    { label: "Finished every lesson", rows: finished },
+  ];
+  return stages.map((stage, i) => {
+    const previous = stages[i - 1];
+    return {
+      label: stage.label,
+      value: stage.rows.length,
+      hint:
+        previous === undefined
+          ? "all signups in range"
+          : `${percent(stage.rows.length, previous.rows.length)} of the step above`,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Distributions
+// ---------------------------------------------------------------------------
+
+export function sectorBars(companies: CompanyFact[]): Bar[] {
+  return rank(
+    companies.map((c) => c.sector),
+    9,
+    "Not stated",
+  );
+}
+
+export function countryBars(companies: CompanyFact[]): Bar[] {
+  return rank(
+    companies.map((c) => c.country?.toUpperCase() ?? null),
+    7,
+    "Not stated",
+  );
+}
+
+export function localeBars(users: UserFact[]): Bar[] {
+  return rank(
+    users.map((u) => (u.locale === "unknown" ? null : u.locale.toUpperCase())),
+    7,
+    "Never set",
+  );
+}
+
+export function sizeBars(companies: CompanyFact[]): Bar[] {
+  return tally(
+    companies.map((c) => sizeBand(c.employeeCount)),
+    SIZE_BANDS,
+    companies.length,
+  ).map((bar) => ({ ...bar, emphasis: bar.label === "50 to 249" }));
+}
+
+export function seatBars(companies: CompanyFact[]): Bar[] {
+  return tally(
+    companies.map((c) => seatBand(c.seats)),
+    SEAT_BANDS,
+    companies.length,
+  );
+}
+
+export function progressBars(companies: CompanyFact[]): Bar[] {
+  return tally(
+    companies.map((c) => progressBand(c.compliancePct)),
+    PROGRESS_BANDS,
+    companies.length,
+  );
+}
+
+const QUESTIONNAIRE_BANDS = [
+  "Nothing yet",
+  "1 to 24%",
+  "25 to 49%",
+  "50 to 74%",
+  "75 to 99%",
+  "Everything answered",
+] as const;
+
+function questionnaireBand(pct: number): (typeof QUESTIONNAIRE_BANDS)[number] {
+  if (pct <= 0) return "Nothing yet";
+  if (pct < 25) return "1 to 24%";
+  if (pct < 50) return "25 to 49%";
+  if (pct < 75) return "50 to 74%";
+  if (pct < 100) return "75 to 99%";
+  return "Everything answered";
+}
+
+/**
+ * How far through the supplier questionnaire each supplier has got. Companies
+ * that are not suppliers are absent rather than zero: they were never asked.
+ */
+export function questionnaireBars(companies: CompanyFact[]): Bar[] {
+  const suppliers = companies.flatMap((c) =>
+    c.questionnairePct === null ? [] : [questionnaireBand(c.questionnairePct)],
+  );
+  return tally(suppliers, QUESTIONNAIRE_BANDS, suppliers.length);
+}
+
+/** Answered percentages, suppliers only — the input to a median. */
+export function questionnairePercents(companies: CompanyFact[]): number[] {
+  return companies.flatMap((c) =>
+    c.questionnairePct === null ? [] : [c.questionnairePct],
+  );
+}
+
+export function activationLagBars(users: UserFact[]): Bar[] {
+  const lags = activationLags(users);
+  return tally(lags.map(lagBand), LAG_BANDS, lags.length);
+}
+
+export function firstWorkLagBars(users: UserFact[]): Bar[] {
+  const lags = firstWorkLags(users);
+  return tally(lags.map(lagBand), LAG_BANDS, lags.length);
+}
+
+/** Days from signup to the org being named, for everyone who got there. */
+export function activationLags(users: UserFact[]): number[] {
+  return users.flatMap((u) =>
+    u.activatedDay === null ? [] : [Math.max(0, dayGap(u.signupDay, u.activatedDay))],
+  );
+}
+
+/** Days from signup to the first recorded piece of work. */
+export function firstWorkLags(users: UserFact[]): number[] {
+  return users.flatMap((u) => {
+    const first = u.activeDays[0];
+    return first === undefined ? [] : [Math.max(0, dayGap(u.signupDay, first))];
+  });
+}
+
+/** Distinct people with at least one work event inside the window. */
+export function activePeople(users: UserFact[], start: string, end: string): number {
+  return users.filter((u) => u.activeDays.some((day) => day >= start && day <= end))
+    .length;
+}
+
+// ---------------------------------------------------------------------------
+// Cohorts
+// ---------------------------------------------------------------------------
+
+export interface CohortRow {
+  /** "YYYY-MM". */
+  cohort: string;
+  size: number;
+  /**
+   * People from this cohort with recorded work in month N after signup.
+   * `null` for months that have not happened yet, so an unfinished month
+   * reads as blank rather than as a month where nobody came back.
+   */
+  retained: Array<number | null>;
+}
+
+/**
+ * Monthly signup cohorts against the months they did work in.
+ *
+ * Month 0 is the signup month itself, which is why it is never 100%: plenty of
+ * people sign up and never touch anything. That gap is the point of the chart.
+ */
+export function cohortMatrix(
+  users: UserFact[],
+  currentMonth: string,
+  maxOffset = 6,
+): CohortRow[] {
+  const byCohort = new Map<string, UserFact[]>();
+  for (const u of users) {
+    if (u.disposable) continue;
+    const cohort = u.signupDay.slice(0, 7);
+    byCohort.set(cohort, [...(byCohort.get(cohort) ?? []), u]);
+  }
+
+  return Array.from(byCohort.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([cohort, members]) => {
+      const elapsed = monthGap(cohort, currentMonth);
+      const retained = Array.from({ length: maxOffset + 1 }, (_, offset) => {
+        if (offset > elapsed) return null;
+        return members.filter((m) =>
+          m.activeDays.some((day) => monthGap(cohort, day.slice(0, 7)) === offset),
+        ).length;
+      });
+      return { cohort, size: members.length, retained };
+    });
+}

--- a/components/platform-admin/graphs/palette.ts
+++ b/components/platform-admin/graphs/palette.ts
@@ -1,0 +1,86 @@
+/**
+ * Chart palette for the Graphs tab.
+ *
+ * Four categorical slots in a fixed order (blue, orange, aqua, yellow) plus a
+ * five-step single-hue blue ramp for the one place a magnitude is coloured (the
+ * cohort heatmap). Colour follows the series, never its rank, so filtering the
+ * range never repaints a chart.
+ *
+ * Both columns are selected, not flipped: the dark values are the same four
+ * hues re-stepped for the dark card. Validated against this app's card
+ * surfaces (#ffffff light, #171717 dark) — lightness band, chroma floor,
+ * colour-vision-deficiency separation and normal-vision separation all pass in
+ * both modes (worst adjacent pair: yellow/aqua, CVD dE 9.1 light and 8.4 dark).
+ * On white, aqua (2.82:1) and yellow (2.17:1) fall under 3:1, which is why
+ * every card here prints its numbers as text and carries a table view: colour
+ * is never the only way to read a value.
+ */
+
+/**
+ * Injected once by the panel. A style element rather than a token in
+ * theme.css: these four slots exist for this tab and nothing else renders
+ * against them, so they should not enter the app-wide token surface.
+ */
+export const VIZ_PALETTE_CSS = `
+[data-viz] {
+  --viz-1: #2a78d6;
+  --viz-2: #eb6834;
+  --viz-3: #1baf7a;
+  --viz-4: #eda100;
+  --viz-track: #edecea;
+  --viz-muted: #c3c2b7;
+  --viz-heat-0: #f5f5f3;
+  --viz-heat-1: #cde2fb;
+  --viz-heat-2: #9ec5f4;
+  --viz-heat-3: #5598e7;
+  --viz-heat-4: #256abf;
+  --viz-heat-5: #184f95;
+}
+.dark [data-viz] {
+  --viz-1: #3987e5;
+  --viz-2: #d95926;
+  --viz-3: #199e70;
+  --viz-4: #c98500;
+  --viz-track: #262625;
+  --viz-muted: #55554f;
+  --viz-heat-0: #202020;
+  --viz-heat-1: #16304f;
+  --viz-heat-2: #184f95;
+  --viz-heat-3: #2a78d6;
+  --viz-heat-4: #5598e7;
+  --viz-heat-5: #9ec5f4;
+}
+`;
+
+/** The four categorical slots, addressed by their fixed position. */
+export const VIZ = {
+  slot1: "var(--viz-1)",
+  slot2: "var(--viz-2)",
+  slot3: "var(--viz-3)",
+  slot4: "var(--viz-4)",
+} as const;
+
+export type VizSlot = keyof typeof VIZ;
+
+/**
+ * Heat step for a 0-1 magnitude. Step 0 is the near-surface tint that means
+ * "nothing here", so an empty cohort cell recedes instead of reading as data.
+ */
+export function heatColor(fraction: number): string {
+  if (fraction <= 0) return "var(--viz-heat-0)";
+  if (fraction < 0.2) return "var(--viz-heat-1)";
+  if (fraction < 0.4) return "var(--viz-heat-2)";
+  if (fraction < 0.6) return "var(--viz-heat-3)";
+  if (fraction < 0.8) return "var(--viz-heat-4)";
+  return "var(--viz-heat-5)";
+}
+
+/**
+ * Ink for a label sitting inside a heat cell: white once the fill is dark
+ * enough that body ink stops clearing contrast. The light ramp darkens with
+ * magnitude and the dark ramp lightens with it, so the flip happens at
+ * opposite ends and each mode names its own.
+ */
+export function heatInk(fraction: number): string {
+  return fraction >= 0.6 ? "text-white dark:text-neutral-900" : "text-foreground";
+}

--- a/components/platform-admin/graphs/primitives.tsx
+++ b/components/platform-admin/graphs/primitives.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+/**
+ * The pieces every card on the Graphs tab is built from.
+ *
+ * Two rules hold across all of them. Values are always printed as text, never
+ * only as a length or a shade, so nothing on the tab is readable by colour
+ * alone. And every card carries a table view, because three of the four light
+ * mode series colours sit under 3:1 against a white card.
+ */
+
+import { Table2 } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+} from "@/components/ui/chart";
+import { type Bar as BarDatum, percent } from "./derive";
+import { heatColor, heatInk } from "./palette";
+
+// ---------------------------------------------------------------------------
+// Card shell
+// ---------------------------------------------------------------------------
+
+export interface TableSpec {
+  columns: string[];
+  rows: Array<Array<string | number>>;
+}
+
+export function ChartCard({
+  title,
+  subtitle,
+  note,
+  table,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  /** What the number means or what it leaves out. Sits under the chart. */
+  note?: string;
+  table: TableSpec;
+  children: ReactNode;
+}) {
+  const [view, setView] = useState<"chart" | "table">("chart");
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div>
+          <CardTitle className="text-base">{title}</CardTitle>
+          {subtitle && <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>}
+        </div>
+        <button
+          type="button"
+          onClick={() => setView(view === "chart" ? "table" : "chart")}
+          className="flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-pressed={view === "table"}
+        >
+          <Table2 className="h-3.5 w-3.5" />
+          {view === "chart" ? "Table" : "Chart"}
+        </button>
+      </CardHeader>
+      <CardContent>
+        {view === "chart" ? children : <DataTable table={table} />}
+        {note && <p className="mt-3 text-xs text-muted-foreground">{note}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DataTable({ table }: { table: TableSpec }) {
+  return (
+    <div className="max-h-[320px] overflow-auto">
+      <table className="w-full text-sm">
+        <thead className="sticky top-0 bg-card">
+          <tr className="border-b text-left text-muted-foreground">
+            {table.columns.map((column, i) => (
+              <th
+                key={column}
+                className={`pb-2 pr-4 font-medium ${i === 0 ? "" : "text-right"}`}
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row) => (
+            <tr key={String(row[0])} className="border-b border-border/50 last:border-0">
+              {table.columns.map((column, i) => (
+                <td
+                  key={column}
+                  className={`py-1.5 pr-4 ${
+                    i === 0 ? "" : "text-right tabular-nums text-muted-foreground"
+                  }`}
+                >
+                  {row[i]}
+                </td>
+              ))}
+            </tr>
+          ))}
+          {table.rows.length === 0 && (
+            <tr>
+              <td
+                colSpan={table.columns.length}
+                className="py-8 text-center text-muted-foreground"
+              >
+                Nothing in this range
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat tiles
+// ---------------------------------------------------------------------------
+
+export function StatTile({
+  label,
+  value,
+  sub,
+  delta,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  /** Signed change against the previous window of the same length. */
+  delta?: { amount: number; period: string };
+}) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p className="text-sm text-muted-foreground">{label}</p>
+        <p className="text-2xl font-semibold">{value}</p>
+        {delta && (
+          <p
+            className={`text-xs ${
+              delta.amount > 0
+                ? "text-[#006300] dark:text-[#0ca30c]"
+                : delta.amount < 0
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+            }`}
+          >
+            {delta.amount > 0 ? "+" : ""}
+            {delta.amount} vs {delta.period}
+          </p>
+        )}
+        {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Horizontal bars — funnels, distributions, histograms
+// ---------------------------------------------------------------------------
+
+/**
+ * One series, one colour. Where a single band is the one worth looking at
+ * (the size band we sell to), that band keeps the accent and the rest go
+ * neutral, rather than every bar getting a hue of its own.
+ */
+export function CategoryBars({
+  bars,
+  accent = "var(--viz-1)",
+}: {
+  bars: BarDatum[];
+  accent?: string;
+}) {
+  const max = Math.max(1, ...bars.map((b) => b.value));
+  const emphasised = bars.some((b) => b.emphasis);
+
+  return (
+    <div className="space-y-2.5">
+      {bars.map((bar) => (
+        <div
+          key={bar.label}
+          className="grid grid-cols-[minmax(8rem,16rem)_1fr_3.5rem] items-center gap-3 rounded-sm py-0.5 transition-colors hover:bg-muted/50"
+        >
+          <div className="min-w-0">
+            <p className="truncate text-sm" title={bar.label}>
+              {bar.label}
+            </p>
+            {/* The hint wraps rather than truncates: it carries the
+                conversion rate or the caveat, which is the half of the row
+                a reader cannot reconstruct from the bar. */}
+            {bar.hint && <p className="text-xs text-muted-foreground">{bar.hint}</p>}
+          </div>
+          <div
+            className="h-2.5 w-full rounded-r-[4px]"
+            style={{ background: "var(--viz-track)" }}
+          >
+            <div
+              className="h-2.5 rounded-r-[4px]"
+              style={{
+                width: `${Math.max(bar.value > 0 ? 1.5 : 0, (bar.value / max) * 100)}%`,
+                background: emphasised && !bar.emphasis ? "var(--viz-muted)" : accent,
+              }}
+            />
+          </div>
+          <span className="text-right text-sm tabular-nums">
+            {bar.value.toLocaleString("en-GB")}
+          </span>
+        </div>
+      ))}
+      {bars.length === 0 && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Nothing in this range
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function barsTable(bars: BarDatum[], categoryHeading: string): TableSpec {
+  const total = bars.reduce((sum, b) => sum + b.value, 0);
+  return {
+    columns: [categoryHeading, "Count", "Share"],
+    rows: bars.map((b) => [b.label, b.value, percent(b.value, total)]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Time series
+// ---------------------------------------------------------------------------
+
+export interface SeriesSpec {
+  key: string;
+  label: string;
+  color: string;
+}
+
+export type TrendRow = { bucket: string; label: string; title: string } & Record<
+  string,
+  string | number
+>;
+
+function configOf(series: SeriesSpec[]): ChartConfig {
+  return Object.fromEntries(
+    series.map((s) => [s.key, { label: s.label, color: s.color }]),
+  );
+}
+
+/**
+ * An all-zero window gets a sentence instead of an empty plot. A blank pair of
+ * axes reads as "this broke"; the sentence says "nothing happened", which is
+ * a finding rather than a failure.
+ */
+function hasValues(data: TrendRow[], series: SeriesSpec[]): boolean {
+  return data.some((row) =>
+    series.some((s) => {
+      const value = row[s.key];
+      return typeof value === "number" && value > 0;
+    }),
+  );
+}
+
+function NothingHere() {
+  return (
+    <div className="flex h-[240px] items-center justify-center text-sm text-muted-foreground">
+      Nothing recorded in this range
+    </div>
+  );
+}
+
+/**
+ * What recharts hands a tooltip element. Written out rather than imported
+ * because recharts types `content` as a bare ReactElement, so an element whose
+ * own props are all optional is the only shape that type-checks here.
+ */
+interface TooltipItem {
+  dataKey?: string | number;
+  value?: string | number;
+  payload?: { title?: string };
+}
+
+/**
+ * One tooltip, every series at that x. The value leads and the series name
+ * follows it, because by the time someone is hovering they already know which
+ * line they are on and want the number. Series identity rides a short stroke
+ * in the series colour, never coloured text.
+ */
+function TrendTooltip({
+  active,
+  payload,
+  series,
+}: {
+  active?: boolean;
+  payload?: ReadonlyArray<TooltipItem>;
+  series: SeriesSpec[];
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const title = payload[0]?.payload?.title ?? "";
+
+  return (
+    <div className="grid min-w-[9rem] gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      {title && <p className="font-medium">{title}</p>}
+      {series.map((s) => {
+        const item = payload.find((p) => p.dataKey === s.key);
+        if (item === undefined) return null;
+        return (
+          <div key={s.key} className="flex items-center gap-2">
+            <span
+              className="h-0.5 w-3 shrink-0 rounded-full"
+              style={{ background: s.color }}
+            />
+            <span className="font-semibold tabular-nums">{item.value ?? 0}</span>
+            <span className="truncate text-muted-foreground">{s.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function TrendLines({ data, series }: { data: TrendRow[]; series: SeriesSpec[] }) {
+  if (!hasValues(data, series)) return <NothingHere />;
+  return (
+    <ChartContainer config={configOf(series)} className="aspect-auto h-[240px] w-full">
+      <LineChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={28}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          allowDecimals={false}
+          tickMargin={4}
+        />
+        <ChartTooltip content={<TrendTooltip series={series} />} />
+        {series.length > 1 && <ChartLegend content={<ChartLegendContent />} />}
+        {series.map((s) => (
+          <Line
+            key={s.key}
+            dataKey={s.key}
+            type="monotone"
+            stroke={`var(--color-${s.key})`}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            dot={false}
+            activeDot={{ r: 4, strokeWidth: 2, stroke: "var(--color-card)" }}
+          />
+        ))}
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+export function TrendColumns({
+  data,
+  series,
+  stacked = true,
+}: {
+  data: TrendRow[];
+  series: SeriesSpec[];
+  /** Stack when the parts add up to a meaningful whole; group when they do not. */
+  stacked?: boolean;
+}) {
+  if (!hasValues(data, series)) return <NothingHere />;
+  return (
+    <ChartContainer config={configOf(series)} className="aspect-auto h-[240px] w-full">
+      <BarChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={28}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          allowDecimals={false}
+          tickMargin={4}
+        />
+        <ChartTooltip content={<TrendTooltip series={series} />} />
+        {series.length > 1 && <ChartLegend content={<ChartLegendContent />} />}
+        {series.map((s, i) => (
+          <Bar
+            key={s.key}
+            dataKey={s.key}
+            stackId={stacked ? "a" : undefined}
+            fill={`var(--color-${s.key})`}
+            maxBarSize={24}
+            // The gap between touching marks is the card colour showing
+            // through, not a border drawn round each segment.
+            stroke="var(--color-card)"
+            strokeWidth={stacked && series.length > 1 ? 2 : 0}
+            radius={!stacked || i === series.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+          />
+        ))}
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+export function trendTable(
+  data: TrendRow[],
+  series: SeriesSpec[],
+  periodHeading: string,
+): TableSpec {
+  return {
+    columns: [periodHeading, ...series.map((s) => s.label)],
+    rows: data.map((row) => [
+      row.title,
+      ...series.map((s) => {
+        const value = row[s.key];
+        return typeof value === "number" ? value : 0;
+      }),
+    ]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cohort heatmap
+// ---------------------------------------------------------------------------
+
+/** Month-offset columns, keyed by their heading so no key is an array index. */
+function offsetColumns(
+  rows: Array<{ retained: Array<number | null> }>,
+): Array<{ heading: string; offset: number }> {
+  const width = rows[0]?.retained.length ?? 0;
+  return Array.from({ length: width }, (_, offset) => ({
+    heading: offset === 0 ? "Month 0" : `+${offset}`,
+    offset,
+  }));
+}
+
+export function CohortHeatmap({
+  rows,
+  monthLabel,
+}: {
+  rows: Array<{ cohort: string; size: number; retained: Array<number | null> }>;
+  monthLabel: (cohort: string) => string;
+}) {
+  const columns = offsetColumns(rows);
+
+  if (rows.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        No cohorts in this range
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      {/* Not w-full: the offset columns are fixed width, so stretching the
+          table would dump all the slack into the cohort-name column and push
+          the grid off to the right. */}
+      <table className="min-w-[520px] text-sm">
+        <thead>
+          <tr className="text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Signed up</th>
+            <th className="pb-2 pr-4 text-right font-medium">People</th>
+            {columns.map((column) => (
+              <th
+                key={column.heading}
+                className="w-16 px-1 pb-2 text-center font-medium tabular-nums"
+              >
+                {column.heading}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.cohort}>
+              <td className="py-1 pr-4 whitespace-nowrap">{monthLabel(row.cohort)}</td>
+              <td className="py-1 pr-4 text-right tabular-nums text-muted-foreground">
+                {row.size}
+              </td>
+              {columns.map((column) => {
+                const count = row.retained[column.offset] ?? null;
+                const fraction = count === null || row.size === 0 ? 0 : count / row.size;
+                return (
+                  <td key={column.heading} className="w-16 p-0.5">
+                    {count === null ? (
+                      <div className="h-8 rounded-sm border border-dashed border-border/60" />
+                    ) : (
+                      <div
+                        className={`flex h-8 items-center justify-center rounded-sm text-xs tabular-nums ${heatInk(fraction)}`}
+                        style={{ background: heatColor(fraction) }}
+                        title={`${count} of ${row.size} active (${percent(count, row.size)})`}
+                      >
+                        {count === 0 ? "" : `${Math.round(fraction * 100)}%`}
+                      </div>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function cohortTable(
+  rows: Array<{ cohort: string; size: number; retained: Array<number | null> }>,
+  monthLabel: (cohort: string) => string,
+): TableSpec {
+  const columns = offsetColumns(rows);
+  return {
+    columns: ["Signed up", "People", ...columns.map((c) => c.heading)],
+    rows: rows.map((row) => [
+      monthLabel(row.cohort),
+      row.size,
+      ...columns.map((c) => row.retained[c.offset] ?? "—"),
+    ]),
+  };
+}

--- a/components/platform-admin/graphs/range.ts
+++ b/components/platform-admin/graphs/range.ts
@@ -1,0 +1,171 @@
+/**
+ * Range and bucket arithmetic for the Graphs tab.
+ *
+ * Days are "YYYY-MM-DD" strings throughout — the same UTC calendar days the
+ * server grouped by. Nothing here builds a Date from a bare day string and
+ * reads local components off it, because that shifts the day for every viewer
+ * west of UTC; parsing pins midday UTC and every format call names UTC.
+ */
+
+export const RANGES = [
+  { key: "7d", label: "7 days", days: 7 },
+  { key: "30d", label: "1 month", days: 30 },
+  { key: "60d", label: "2 months", days: 60 },
+  { key: "90d", label: "3 months", days: 90 },
+  { key: "180d", label: "6 months", days: 180 },
+  { key: "365d", label: "12 months", days: 365 },
+  { key: "all", label: "All time", days: null },
+] as const;
+
+export type RangeKey = (typeof RANGES)[number]["key"];
+export type Granularity = "day" | "week" | "month";
+/** "auto" resolves from the range width; the rest are the operator's override. */
+export type GranularityChoice = Granularity | "auto";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Midday UTC, so no viewer's timezone can push the date onto its neighbour. */
+export function parseDay(day: string): Date {
+  return new Date(`${day}T12:00:00Z`);
+}
+
+export function toDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function addDays(day: string, delta: number): string {
+  return toDay(new Date(parseDay(day).getTime() + delta * DAY_MS));
+}
+
+/** Whole days between two calendar days, end exclusive of nothing. */
+export function daysBetween(from: string, to: string): number {
+  return Math.round((parseDay(to).getTime() - parseDay(from).getTime()) / DAY_MS);
+}
+
+/** Today as a UTC calendar day — the same clock the server grouped by. */
+export function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Every day from `from` to `to` inclusive, oldest first. */
+export function eachDay(from: string, to: string): string[] {
+  const span = daysBetween(from, to);
+  if (span < 0) return [];
+  return Array.from({ length: span + 1 }, (_, i) => addDays(from, i));
+}
+
+/**
+ * Bucket width that keeps a chart readable: roughly 7 to 60 marks on screen.
+ * Overridable, because "show me the daily shape of the last year" is a real
+ * question even when it renders 365 thin columns.
+ */
+export function resolveGranularity(
+  choice: GranularityChoice,
+  spanDays: number,
+): Granularity {
+  if (choice !== "auto") return choice;
+  if (spanDays <= 60) return "day";
+  if (spanDays <= 300) return "week";
+  return "month";
+}
+
+/** The bucket a day belongs to. Weeks start Monday. */
+export function bucketOf(day: string, granularity: Granularity): string {
+  if (granularity === "day") return day;
+  if (granularity === "month") return day.slice(0, 7);
+  const date = parseDay(day);
+  const weekday = (date.getUTCDay() + 6) % 7;
+  return addDays(day, -weekday);
+}
+
+const DAY_LABEL = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+});
+const MONTH_LABEL = new Intl.DateTimeFormat("en-GB", {
+  month: "short",
+  year: "2-digit",
+  timeZone: "UTC",
+});
+
+export function bucketLabel(bucket: string, granularity: Granularity): string {
+  if (granularity === "month") return MONTH_LABEL.format(parseDay(`${bucket}-01`));
+  return DAY_LABEL.format(parseDay(bucket));
+}
+
+/** Long form for tooltips and table rows, where there is room to be exact. */
+export function bucketTitle(bucket: string, granularity: Granularity): string {
+  if (granularity === "month") return MONTH_LABEL.format(parseDay(`${bucket}-01`));
+  if (granularity === "day") return DAY_LABEL.format(parseDay(bucket));
+  return `week of ${DAY_LABEL.format(parseDay(bucket))}`;
+}
+
+export interface RangeWindow {
+  /** First day plotted. */
+  start: string;
+  /** Last day plotted, always today. */
+  end: string;
+  granularity: Granularity;
+  /** The equally long window immediately before `start`, for period deltas. */
+  previousStart: string;
+  previousEnd: string;
+}
+
+export function resolveWindow(
+  rangeKey: RangeKey,
+  granularityChoice: GranularityChoice,
+  earliestDay: string,
+  today: string,
+): RangeWindow {
+  const range = RANGES.find((r) => r.key === rangeKey) ?? RANGES[RANGES.length - 1];
+  // A fixed range always plots its full width, even where that reaches back
+  // before the first signup: leading zeroes say "we did not exist yet", which
+  // is the truth, and clamping would quietly shrink the window a delta is
+  // measured against.
+  const start = range.days === null ? earliestDay : addDays(today, -(range.days - 1));
+  const span = daysBetween(start, today) + 1;
+  return {
+    start,
+    end: today,
+    granularity: resolveGranularity(granularityChoice, span),
+    previousStart: addDays(start, -span),
+    previousEnd: addDays(start, -1),
+  };
+}
+
+/**
+ * Roll a dense daily series up into buckets.
+ *
+ * `mode` decides what a bucket means. "sum" totals the days in it (new
+ * accounts this week). "last" takes the final day's value (a running total is
+ * already cumulative, so summing it would square the curve).
+ */
+export function bucketSeries<T extends Record<string, number>>(
+  days: string[],
+  granularity: Granularity,
+  sample: (day: string) => T,
+  mode: "sum" | "last",
+): Array<T & { bucket: string; label: string; title: string }> {
+  const buckets: Array<{ bucket: string; value: Record<string, number> }> = [];
+
+  for (const day of days) {
+    const bucket = bucketOf(day, granularity);
+    const value = sample(day);
+    const open = buckets[buckets.length - 1];
+    if (!open || open.bucket !== bucket) {
+      buckets.push({ bucket, value: { ...value } });
+      continue;
+    }
+    for (const [key, incoming] of Object.entries(value)) {
+      open.value[key] = mode === "sum" ? (open.value[key] ?? 0) + incoming : incoming;
+    }
+  }
+
+  return buckets.map(({ bucket, value }) => ({
+    ...(value as T),
+    bucket,
+    label: bucketLabel(bucket, granularity),
+    title: bucketTitle(bucket, granularity),
+  }));
+}

--- a/lib/forms/supplier-portal-sections.ts
+++ b/lib/forms/supplier-portal-sections.ts
@@ -88,6 +88,60 @@ export const SECURITY_PRACTICES_PAGE_FIELDS = [
   "aiSbomUrl",
 ] as const;
 
+const SAAS_FIELDS = [
+  "saasHostingRegion",
+  "saasEncryptionAtRest",
+  "saasEncryptionInTransit",
+  "saasMfaEnforced",
+  "saasRtoHours",
+] as const;
+
+const ON_PREM_FIELDS = [
+  "onPremSbomProvided",
+  "onPremSignedReleases",
+  "onPremVulnerabilityDisclosurePolicy",
+  "onPremPatchSlaCriticalHours",
+] as const;
+
+const PRO_SERVICES_FIELDS = [
+  "proServicesBackgroundCheckScope",
+  "proServicesNdaInPlace",
+  "proServicesCustomerPremisesPolicy",
+] as const;
+
+const MANAGED_SERVICES_FIELDS = [
+  "managedPrivilegedAccessMgmt",
+  "managedSessionRecording",
+  "managedOnCall24x7",
+] as const;
+
+/**
+ * Each service-type block with the toggle that turns it on.
+ *
+ * The mapping used to live only in the comments below ("rendered when
+ * isSaas"). Anything that measures how much of the questionnaire a supplier
+ * answered needs it as data — a supplier who ships no on-prem software should
+ * not be scored against four on-prem questions — and a second, hand-kept copy
+ * would drift the first time a field moved between blocks.
+ */
+export const SERVICE_TYPE_BLOCKS = [
+  { gate: "isSaas", fields: SAAS_FIELDS },
+  { gate: "isOnPrem", fields: ON_PREM_FIELDS },
+  { gate: "isProfessionalServices", fields: PRO_SERVICES_FIELDS },
+  { gate: "isManagedService", fields: MANAGED_SERVICES_FIELDS },
+] as const;
+
+/**
+ * Fields on the practices page that only apply once another answer switches
+ * them on. Same reason as the service-type gates: the form shows them to
+ * everyone, but demanding a subprocessor list from a supplier who has no
+ * subprocessors would be measuring the wrong thing.
+ */
+export const GATED_PRACTICE_FIELDS = {
+  subprocessorList: "hasSubprocessors",
+  aiSbomUrl: "providesSbomForAi",
+} as const;
+
 /**
  * Service-type page — renders the four service-type-conditional sections
  * (SaaS, On-prem, Professional services, Managed services). Every field
@@ -98,23 +152,8 @@ export const SECURITY_PRACTICES_PAGE_FIELDS = [
  * on identity / contact + the toggle pickers.
  */
 export const SERVICE_TYPE_PAGE_FIELDS = [
-  // SaaS technical (rendered when isSaas)
-  "saasHostingRegion",
-  "saasEncryptionAtRest",
-  "saasEncryptionInTransit",
-  "saasMfaEnforced",
-  "saasRtoHours",
-  // On-prem technical (rendered when isOnPrem)
-  "onPremSbomProvided",
-  "onPremSignedReleases",
-  "onPremVulnerabilityDisclosurePolicy",
-  "onPremPatchSlaCriticalHours",
-  // Professional services (rendered when isProfessionalServices)
-  "proServicesBackgroundCheckScope",
-  "proServicesNdaInPlace",
-  "proServicesCustomerPremisesPolicy",
-  // Managed services (rendered when isManagedService)
-  "managedPrivilegedAccessMgmt",
-  "managedSessionRecording",
-  "managedOnCall24x7",
+  ...SAAS_FIELDS,
+  ...ON_PREM_FIELDS,
+  ...PRO_SERVICES_FIELDS,
+  ...MANAGED_SERVICES_FIELDS,
 ] as const;

--- a/lib/platform-admin/growth.ts
+++ b/lib/platform-admin/growth.ts
@@ -1,0 +1,519 @@
+/**
+ * Platform growth analytics — the data behind the Graphs tab.
+ *
+ * Two shapes come back:
+ *
+ *  - **Fact rows**, one per user and one per company, carrying only what a
+ *    chart needs (calendar days, flags, counts — no names, no addresses).
+ *    Every signup curve, funnel, cohort and distribution on the tab is folded
+ *    out of these on the client, so one range filter scopes all of them and
+ *    two cards can never disagree about the same number.
+ *  - **Daily series** for the things that are not per-user facts (lessons
+ *    completed, requirement work, leads, mail), pre-grouped in SQL.
+ *
+ * Both are all-time. The client picks the range and the bucket size, so
+ * switching "last 30 days" to "all time" is instant and never refetches.
+ *
+ * Every day is a UTC calendar day rendered by `to_char` on a bare timestamp
+ * column. Those columns store UTC wall time, so this groups by UTC day with no
+ * timezone math, and shipping strings rather than Date objects stops the
+ * client re-interpreting them in the viewer's zone.
+ */
+
+import { and, eq, inArray, isNotNull, type SQLWrapper, sql } from "drizzle-orm";
+import type { Database } from "@/lib/db";
+import {
+  questionnaireColumns,
+  questionnaireCompleteness,
+} from "@/lib/supplier-portal/completeness";
+import { COURSE_IDS, loadCourse } from "@/lib/training/course-loader";
+import {
+  company,
+  companyRequirementStatus,
+  evidence,
+  lead,
+  notification,
+  signOffHistory,
+  trainingLessonProgress,
+  user,
+} from "@/schema";
+
+export type CourseId = (typeof COURSE_IDS)[number];
+
+/** The UTC calendar day a bare timestamp column falls on. */
+const dayOf = (column: SQLWrapper) => sql<string>`to_char(${column}, 'YYYY-MM-DD')`;
+/** Same, for a nullable column — a NULL timestamp gives a NULL day. */
+const nullableDayOf = (column: SQLWrapper) =>
+  sql<string | null>`to_char(${column}, 'YYYY-MM-DD')`;
+
+// ---------------------------------------------------------------------------
+// Returned shapes
+// ---------------------------------------------------------------------------
+
+export interface UserFact {
+  /** UTC day the account was created. */
+  signupDay: string;
+  /** Has proved control of the address (signup OTP or Google). */
+  verified: boolean;
+  /** Signed up from a domain on the disposable-address blocklist. */
+  disposable: boolean;
+  /** Stored UI language, or "unknown" for accounts predating the column. */
+  locale: string;
+  /** Attached to a company row, activated or still a draft shell. */
+  inOrg: boolean;
+  /** Day their org was activated; null while it is still a draft shell. */
+  activatedDay: string | null;
+  /**
+   * Every day carrying at least one work event, oldest first. Days rather than
+   * months because the client needs both: the first entry is time-to-first-
+   * value, a range slice is "active people this week", and the months they
+   * fall in are the cohort grid. Short for almost everyone.
+   */
+  activeDays: string[];
+  /**
+   * Recorded work events, all time: lesson progress, requirement completions,
+   * sign-offs and evidence uploads. Deliberately not the audit log, which
+   * records crons, outbound mail and admin actions, so a count built on it
+   * would read our own batch jobs as customers being busy.
+   */
+  workEvents: number;
+  /** Requirements this person signed off, all time. */
+  signOffs: number;
+  /** Courses with at least one lesson touched. */
+  coursesStarted: CourseId[];
+  /** Courses finished, with the day the last lesson was completed. */
+  coursesFinished: Array<{ courseId: CourseId; day: string }>;
+}
+
+export interface CompanyFact {
+  createdDay: string;
+  /** Null means a draft shell: provisioned at signup, never named. */
+  activatedDay: string | null;
+  sector: string;
+  /** ISO 3166-1 alpha-2, or null when the org never filled it in. */
+  country: string | null;
+  entityType: string;
+  plan: string;
+  employeeCount: number | null;
+  actsAsSupplier: boolean;
+  actsAsNis2Entity: boolean;
+  /** Accounts attached to this org. */
+  seats: number;
+  /** NIS 2 compliance percentage, 0-100. Zero for orgs with no assessment. */
+  compliancePct: number;
+  /**
+   * Share of the supplier questionnaire answered, 0-100, counting only the
+   * questions that apply to them. Null for companies that are not suppliers,
+   * so they never land in the supplier distribution as a zero.
+   */
+  questionnairePct: number | null;
+}
+
+export interface DailyCourseRow {
+  day: string;
+  ceo: number;
+  cra: number;
+  tabletop: number;
+}
+
+export interface DailyWorkRow {
+  day: string;
+  /** Requirements marked complete that day. */
+  completed: number;
+  /** Requirement sign-offs recorded that day. */
+  signedOff: number;
+  /** Evidence files uploaded that day. */
+  evidence: number;
+}
+
+export interface DailyActivityRow {
+  day: string;
+  /** Distinct people with at least one work event that day. */
+  users: number;
+  /** Work events that day. */
+  events: number;
+}
+
+export interface DailyLeadRow {
+  day: string;
+  total: number;
+  entity: number;
+  supplier: number;
+  both: number;
+  unknown: number;
+}
+
+export interface DailyEmailRow {
+  day: string;
+  sent: number;
+}
+
+export interface GrowthData {
+  users: UserFact[];
+  companies: CompanyFact[];
+  /** Lessons completed per day, split by course. */
+  lessons: DailyCourseRow[];
+  /** Compliance work recorded per day. */
+  work: DailyWorkRow[];
+  /** Distinct active people and their event count per day. */
+  activity: DailyActivityRow[];
+  /** Applicability-check leads per day, split by declared intent. */
+  leads: DailyLeadRow[];
+  /** Outbound email per day, same scope as the Emails tab. */
+  emails: DailyEmailRow[];
+  /** Lesson count per course, so "x of y" can never drift from the course. */
+  courseLessonCounts: Record<CourseId, number>;
+}
+
+/** Which DailyCourseRow column a course id writes to. */
+const COURSE_COLUMN = {
+  "nis2-ceo": "ceo",
+  "cra-sbom": "cra",
+  "nis2-tabletop": "tabletop",
+} as const satisfies Record<CourseId, keyof Omit<DailyCourseRow, "day">>;
+
+const asCourseId = (value: string): CourseId | null =>
+  COURSE_IDS.find((id) => id === value) ?? null;
+
+// ---------------------------------------------------------------------------
+// The query
+// ---------------------------------------------------------------------------
+
+export async function loadGrowthData(db: Database): Promise<GrowthData> {
+  const courses = await Promise.all(
+    COURSE_IDS.map(async (courseId) => ({
+      courseId,
+      lessonIds: (await loadCourse(courseId)).modules.flatMap((m) => m.lessonIds),
+    })),
+  );
+
+  const [
+    userRows,
+    companyRows,
+    lessonTouches,
+    lessonCompletions,
+    signOffRows,
+    evidenceRows,
+    requirementRows,
+    leadRows,
+    emailRows,
+    courseFinishRows,
+  ] = await Promise.all([
+    db
+      .select({
+        id: user.id,
+        signupDay: dayOf(user.createdAt),
+        verified: sql<boolean>`${user.emailVerifiedAt} IS NOT NULL`,
+        disposable: user.isDisposableEmail,
+        locale: user.locale,
+        companyId: user.companyId,
+        activatedDay: nullableDayOf(company.activatedAt),
+      })
+      .from(user)
+      .leftJoin(company, eq(user.companyId, company.id)),
+
+    db
+      .select({
+        ...questionnaireColumns(),
+        createdDay: dayOf(company.createdAt),
+        activatedDay: nullableDayOf(company.activatedAt),
+        sector: company.sector,
+        country: company.country,
+        entityType: company.entityType,
+        plan: company.plan,
+        employeeCount: company.employeeCount,
+        actsAsSupplier: company.actsAsSupplier,
+        actsAsNis2Entity: company.actsAsNis2Entity,
+        // "company"."id" is written out rather than interpolated as
+        // ${company.id}: Drizzle only qualifies a column with its table when
+        // the outer query has a join, and this one selects from `company`
+        // alone, so the interpolation would render as a bare "id" that binds
+        // to the SUBQUERY's table. Same trap the Companies tab hit.
+        seats: sql<number>`(SELECT count(*)::int FROM "user" u WHERE u.company_id = "company"."id")`,
+        compliancePct: sql<number>`COALESCE(
+          (SELECT ca.compliance_percentage::float8
+             FROM company_assessment ca
+             JOIN compliance_framework cf ON cf.id = ca.framework_id
+            WHERE ca.company_id = "company"."id" AND cf.code = 'nis2'
+            LIMIT 1),
+          0
+        )`,
+      })
+      .from(company),
+
+    // Engagement, keyed on updatedAt: opening a lesson and failing its quiz is
+    // still someone doing the course. Completion is counted separately below.
+    db
+      .select({
+        userId: trainingLessonProgress.userId,
+        courseId: trainingLessonProgress.courseId,
+        day: dayOf(trainingLessonProgress.updatedAt),
+        events: sql<number>`count(*)::int`,
+      })
+      .from(trainingLessonProgress)
+      .groupBy(
+        trainingLessonProgress.userId,
+        trainingLessonProgress.courseId,
+        dayOf(trainingLessonProgress.updatedAt),
+      ),
+
+    db
+      .select({
+        courseId: trainingLessonProgress.courseId,
+        day: dayOf(trainingLessonProgress.completedAt),
+        completed: sql<number>`count(*)::int`,
+      })
+      .from(trainingLessonProgress)
+      .where(
+        and(
+          eq(trainingLessonProgress.completed, true),
+          isNotNull(trainingLessonProgress.completedAt),
+        ),
+      )
+      .groupBy(
+        trainingLessonProgress.courseId,
+        dayOf(trainingLessonProgress.completedAt),
+      ),
+
+    db
+      .select({
+        userId: signOffHistory.signedOffBy,
+        day: dayOf(signOffHistory.createdAt),
+        events: sql<number>`count(*)::int`,
+      })
+      .from(signOffHistory)
+      .groupBy(signOffHistory.signedOffBy, dayOf(signOffHistory.createdAt)),
+
+    db
+      .select({
+        userId: evidence.uploadedBy,
+        day: dayOf(evidence.uploadedAt),
+        events: sql<number>`count(*)::int`,
+      })
+      .from(evidence)
+      .where(isNotNull(evidence.uploadedBy))
+      .groupBy(evidence.uploadedBy, dayOf(evidence.uploadedAt)),
+
+    db
+      .select({
+        userId: companyRequirementStatus.completedBy,
+        day: dayOf(companyRequirementStatus.completedAt),
+        events: sql<number>`count(*)::int`,
+      })
+      .from(companyRequirementStatus)
+      .where(
+        and(
+          isNotNull(companyRequirementStatus.completedBy),
+          isNotNull(companyRequirementStatus.completedAt),
+        ),
+      )
+      .groupBy(
+        companyRequirementStatus.completedBy,
+        dayOf(companyRequirementStatus.completedAt),
+      ),
+
+    db
+      .select({
+        day: dayOf(lead.createdAt),
+        intent: lead.intent,
+        total: sql<number>`count(*)::int`,
+      })
+      .from(lead)
+      .groupBy(dayOf(lead.createdAt), lead.intent),
+
+    db
+      .select({
+        day: dayOf(notification.sentAt),
+        sent: sql<number>`count(*)::int`,
+      })
+      .from(notification)
+      .where(
+        and(
+          eq(notification.channel, "email"),
+          eq(notification.status, "sent"),
+          isNotNull(notification.sentAt),
+        ),
+      )
+      .groupBy(dayOf(notification.sentAt)),
+
+    // Finished = every lesson of the CURRENT course definition completed, the
+    // same test certificate eligibility uses, so progress on a since-removed
+    // lesson cannot inflate the count. The day is the last completion;
+    // COALESCE to updatedAt covers rows completed before completedAt was
+    // stamped, which keeps this set identical to the overview KPI's.
+    Promise.all(
+      courses.map(async ({ courseId, lessonIds }) => {
+        const rows = await db
+          .select({
+            userId: trainingLessonProgress.userId,
+            day: sql<string>`to_char(COALESCE(max(${trainingLessonProgress.completedAt}), max(${trainingLessonProgress.updatedAt})), 'YYYY-MM-DD')`,
+          })
+          .from(trainingLessonProgress)
+          .where(
+            and(
+              eq(trainingLessonProgress.courseId, courseId),
+              eq(trainingLessonProgress.completed, true),
+              inArray(trainingLessonProgress.lessonId, lessonIds),
+            ),
+          )
+          .groupBy(trainingLessonProgress.userId)
+          .having(
+            sql`count(distinct ${trainingLessonProgress.lessonId}) = ${lessonIds.length}`,
+          );
+        return rows.map((r) => ({ courseId, userId: r.userId, day: r.day }));
+      }),
+    ),
+  ]);
+
+  // ── Per-user work, folded from the four sources ───────────────────────────
+
+  interface UserWork {
+    events: number;
+    signOffs: number;
+    days: Set<string>;
+  }
+  const workByUser = new Map<string, UserWork>();
+  const activeByDay = new Map<string, { users: Set<string>; events: number }>();
+
+  const recordWork = (
+    row: { userId: string | null; day: string; events: number },
+    isSignOff: boolean,
+  ) => {
+    if (!row.userId) return;
+    const forUser: UserWork = workByUser.get(row.userId) ?? {
+      events: 0,
+      signOffs: 0,
+      days: new Set(),
+    };
+    forUser.events += row.events;
+    if (isSignOff) forUser.signOffs += row.events;
+    forUser.days.add(row.day);
+    workByUser.set(row.userId, forUser);
+
+    const forDay = activeByDay.get(row.day) ?? { users: new Set<string>(), events: 0 };
+    forDay.users.add(row.userId);
+    forDay.events += row.events;
+    activeByDay.set(row.day, forDay);
+  };
+
+  for (const r of lessonTouches) recordWork(r, false);
+  for (const r of signOffRows) recordWork(r, true);
+  for (const r of evidenceRows) recordWork(r, false);
+  for (const r of requirementRows) recordWork(r, false);
+
+  const startedByUser = new Map<string, Set<CourseId>>();
+  for (const r of lessonTouches) {
+    const courseId = asCourseId(r.courseId);
+    if (!courseId) continue;
+    const started = startedByUser.get(r.userId) ?? new Set<CourseId>();
+    started.add(courseId);
+    startedByUser.set(r.userId, started);
+  }
+
+  const finishedByUser = new Map<string, Array<{ courseId: CourseId; day: string }>>();
+  for (const row of courseFinishRows.flat()) {
+    const finished = finishedByUser.get(row.userId) ?? [];
+    finished.push({ courseId: row.courseId, day: row.day });
+    finishedByUser.set(row.userId, finished);
+  }
+
+  const users: UserFact[] = userRows.map((u) => {
+    const work = workByUser.get(u.id);
+    return {
+      signupDay: u.signupDay,
+      verified: u.verified,
+      disposable: u.disposable,
+      locale: u.locale ?? "unknown",
+      inOrg: u.companyId !== null,
+      activatedDay: u.activatedDay,
+      activeDays: work ? Array.from(work.days).sort() : [],
+      workEvents: work?.events ?? 0,
+      signOffs: work?.signOffs ?? 0,
+      coursesStarted: Array.from(startedByUser.get(u.id) ?? []),
+      coursesFinished: finishedByUser.get(u.id) ?? [],
+    };
+  });
+
+  // ── Daily series ──────────────────────────────────────────────────────────
+
+  const lessonsByDay = new Map<string, DailyCourseRow>();
+  for (const r of lessonCompletions) {
+    const courseId = asCourseId(r.courseId);
+    if (!courseId) continue;
+    const row = lessonsByDay.get(r.day) ?? { day: r.day, ceo: 0, cra: 0, tabletop: 0 };
+    row[COURSE_COLUMN[courseId]] += r.completed;
+    lessonsByDay.set(r.day, row);
+  }
+
+  const workByDay = new Map<string, DailyWorkRow>();
+  const addWork = (
+    day: string,
+    key: "completed" | "signedOff" | "evidence",
+    n: number,
+  ) => {
+    const row = workByDay.get(day) ?? { day, completed: 0, signedOff: 0, evidence: 0 };
+    row[key] += n;
+    workByDay.set(day, row);
+  };
+  for (const r of requirementRows) addWork(r.day, "completed", r.events);
+  for (const r of signOffRows) addWork(r.day, "signedOff", r.events);
+  for (const r of evidenceRows) addWork(r.day, "evidence", r.events);
+
+  const leadsByDay = new Map<string, DailyLeadRow>();
+  for (const r of leadRows) {
+    const row = leadsByDay.get(r.day) ?? {
+      day: r.day,
+      total: 0,
+      entity: 0,
+      supplier: 0,
+      both: 0,
+      unknown: 0,
+    };
+    row.total += r.total;
+    row[r.intent] += r.total;
+    leadsByDay.set(r.day, row);
+  }
+
+  const byDay = <T extends { day: string }>(rows: Iterable<T>): T[] =>
+    Array.from(rows).sort((a, b) => a.day.localeCompare(b.day));
+
+  return {
+    users,
+    // Scored from the whole row, not from a rest-spread of "everything that
+    // was not named above". `country` is both a questionnaire field and a
+    // column this query selects for the country chart, so destructuring it out
+    // deleted it from the answers and scored every supplier one field short —
+    // which showed up as the Graphs tab and the Suppliers tab reporting
+    // different medians for the same five suppliers.
+    companies: companyRows.map((row) => ({
+      createdDay: row.createdDay,
+      activatedDay: row.activatedDay,
+      sector: row.sector,
+      country: row.country,
+      entityType: row.entityType,
+      plan: row.plan,
+      employeeCount: row.employeeCount,
+      actsAsSupplier: row.actsAsSupplier,
+      actsAsNis2Entity: row.actsAsNis2Entity,
+      seats: row.seats,
+      compliancePct: Number(row.compliancePct),
+      questionnairePct: row.actsAsSupplier
+        ? questionnaireCompleteness(row).percent
+        : null,
+    })),
+    lessons: byDay(lessonsByDay.values()),
+    work: byDay(workByDay.values()),
+    activity: byDay(
+      Array.from(activeByDay, ([day, v]) => ({
+        day,
+        users: v.users.size,
+        events: v.events,
+      })),
+    ),
+    leads: byDay(leadsByDay.values()),
+    emails: byDay(emailRows.map((r) => ({ day: r.day, sent: r.sent }))),
+    courseLessonCounts: Object.fromEntries(
+      courses.map(({ courseId, lessonIds }) => [courseId, lessonIds.length]),
+    ) as Record<CourseId, number>,
+  };
+}

--- a/lib/supplier-portal/completeness.test.ts
+++ b/lib/supplier-portal/completeness.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The questionnaire score is the number a platform admin uses to decide who
+ * still owes us answers, and it is read in two places (the Suppliers tab and
+ * the Graphs tab) that have to agree. The cases below are the ones that make
+ * it mean something rather than just counting non-null columns.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  PROFILE_PAGE_FIELDS,
+  SECURITY_PRACTICES_PAGE_FIELDS,
+} from "@/lib/forms/supplier-portal-sections";
+import { questionnaireCompleteness } from "./completeness";
+
+/** Practices minus the two that only apply once another answer turns them on. */
+const UNGATED_PRACTICES = SECURITY_PRACTICES_PAGE_FIELDS.length - 2;
+const BASELINE = PROFILE_PAGE_FIELDS.length + UNGATED_PRACTICES;
+
+describe("questionnaireCompleteness", () => {
+  test("an untouched supplier has answered nothing, and is asked only the baseline", () => {
+    const score = questionnaireCompleteness({});
+    expect(score.answered).toBe(0);
+    expect(score.applicable).toBe(BASELINE);
+    expect(score.percent).toBe(0);
+    expect(score.serviceType.applicable).toBe(0);
+  });
+
+  test("`false` is an answer, so an honest no does not score as a blank", () => {
+    expect(questionnaireCompleteness({ hasIsms: false }).answered).toBe(1);
+    expect(questionnaireCompleteness({ hasIsms: true }).answered).toBe(1);
+  });
+
+  test("a blank or whitespace-only string is not an answer", () => {
+    expect(questionnaireCompleteness({ legalName: "" }).answered).toBe(0);
+    expect(questionnaireCompleteness({ legalName: "   " }).answered).toBe(0);
+    expect(questionnaireCompleteness({ legalName: "Acme GmbH" }).answered).toBe(1);
+  });
+
+  test("ticking a service type adds that block to the denominator", () => {
+    const saas = questionnaireCompleteness({ isSaas: true });
+    // isSaas is itself a profile field, so ticking it also answers one.
+    expect(saas.answered).toBe(1);
+    expect(saas.serviceType.applicable).toBe(5);
+    expect(saas.applicable).toBe(BASELINE + 5);
+  });
+
+  test("a supplier who ticks no service type is never asked those questions", () => {
+    const filled = questionnaireCompleteness({ saasHostingRegion: "eu-central-1" });
+    expect(filled.serviceType.applicable).toBe(0);
+    // The answer is ignored rather than counted: they were never asked.
+    expect(filled.answered).toBe(0);
+  });
+
+  test("the subprocessor list only applies once they say they have subprocessors", () => {
+    const without = questionnaireCompleteness({ hasSubprocessors: false });
+    const with_ = questionnaireCompleteness({ hasSubprocessors: true });
+    expect(without.applicable).toBe(BASELINE);
+    expect(with_.applicable).toBe(BASELINE + 1);
+  });
+
+  test("columns that are not questionnaire fields do not change the score", () => {
+    // Regression: both callers pass a whole company row, which carries
+    // billing, role flags and FKs alongside the answers. Scoring is defined
+    // by the field lists, never by "every key present on the object".
+    const bare = questionnaireCompleteness({ legalName: "Acme GmbH" });
+    const noisy = questionnaireCompleteness({
+      legalName: "Acme GmbH",
+      id: "0d1b1a4e-0000-4000-8000-000000000000",
+      plan: "free",
+      stripeCustomerId: "cus_123",
+      seats: 4,
+    } as Parameters<typeof questionnaireCompleteness>[0]);
+    expect(noisy).toEqual(bare);
+  });
+
+  test("percent is answered over applicable, not over every question that exists", () => {
+    const answers = Object.fromEntries(
+      PROFILE_PAGE_FIELDS.map((field) => [field, "answered"]),
+    );
+    const score = questionnaireCompleteness(answers);
+    expect(score.profile.answered).toBe(PROFILE_PAGE_FIELDS.length);
+    expect(score.percent).toBe(
+      Math.round((PROFILE_PAGE_FIELDS.length / score.applicable) * 100),
+    );
+  });
+});

--- a/lib/supplier-portal/completeness.ts
+++ b/lib/supplier-portal/completeness.ts
@@ -1,0 +1,119 @@
+/**
+ * How much of the supplier questionnaire a company has actually answered.
+ *
+ * The fields come from the same three page constants the portal renders
+ * against (`lib/forms/supplier-portal-sections.ts`), so a question added to a
+ * page is scored the moment it ships and there is no second list to maintain.
+ *
+ * Two rules make the number mean something:
+ *
+ *  - **`false` is an answer.** "No, we hold no ISO 27001 certificate" is a
+ *    filled-in field. Treating it as blank would score an honest supplier
+ *    below a silent one.
+ *  - **The denominator is what applies to them.** A SaaS-only supplier is not
+ *    asked about on-prem patch SLAs, so those four fields are not counted
+ *    against them. Without this nobody could ever reach 100 percent and the
+ *    number would say nothing about who still owes us answers.
+ */
+
+import {
+  GATED_PRACTICE_FIELDS,
+  PROFILE_PAGE_FIELDS,
+  SECURITY_PRACTICES_PAGE_FIELDS,
+  SERVICE_TYPE_BLOCKS,
+  SERVICE_TYPE_PAGE_FIELDS,
+} from "@/lib/forms/supplier-portal-sections";
+import { company } from "@/schema";
+
+/** Every column the questionnaire covers, across all three pages. */
+export const QUESTIONNAIRE_FIELDS = [
+  ...PROFILE_PAGE_FIELDS,
+  ...SECURITY_PRACTICES_PAGE_FIELDS,
+  ...SERVICE_TYPE_PAGE_FIELDS,
+] as const;
+
+export type QuestionnaireField = (typeof QUESTIONNAIRE_FIELDS)[number];
+
+/** A company row carrying (at least) the questionnaire columns. */
+export type QuestionnaireAnswers = Partial<Record<QuestionnaireField, unknown>>;
+
+export interface SectionScore {
+  answered: number;
+  applicable: number;
+}
+
+export interface QuestionnaireCompleteness {
+  answered: number;
+  /** Fields that apply to this supplier, given the service types they ticked. */
+  applicable: number;
+  /** 0-100, rounded. */
+  percent: number;
+  profile: SectionScore;
+  practices: SectionScore;
+  /** Zero-applicable when the supplier has ticked no service type. */
+  serviceType: SectionScore;
+}
+
+/**
+ * The questionnaire columns as a Drizzle projection, so a `.select()` picks
+ * up a new question without anyone editing the query.
+ */
+export function questionnaireColumns(): {
+  [K in QuestionnaireField]: (typeof company)[K];
+} {
+  return Object.fromEntries(
+    QUESTIONNAIRE_FIELDS.map((field) => [field, company[field]]),
+  ) as { [K in QuestionnaireField]: (typeof company)[K] };
+}
+
+/** A blank string is not an answer; `false` and `0` are. */
+function isAnswered(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  return true;
+}
+
+function scoreOf(
+  row: QuestionnaireAnswers,
+  fields: readonly QuestionnaireField[],
+): SectionScore {
+  return {
+    applicable: fields.length,
+    answered: fields.filter((field) => isAnswered(row[field])).length,
+  };
+}
+
+function gateOf(field: QuestionnaireField): string | undefined {
+  return field in GATED_PRACTICE_FIELDS
+    ? GATED_PRACTICE_FIELDS[field as keyof typeof GATED_PRACTICE_FIELDS]
+    : undefined;
+}
+
+export function questionnaireCompleteness(
+  row: QuestionnaireAnswers,
+): QuestionnaireCompleteness {
+  const practiceFields = SECURITY_PRACTICES_PAGE_FIELDS.filter((field) => {
+    const gate = gateOf(field);
+    return gate === undefined || row[gate as QuestionnaireField] === true;
+  });
+
+  const serviceFields = SERVICE_TYPE_BLOCKS.flatMap((block) =>
+    row[block.gate] === true ? [...block.fields] : [],
+  );
+
+  const profile = scoreOf(row, PROFILE_PAGE_FIELDS);
+  const practices = scoreOf(row, practiceFields);
+  const serviceType = scoreOf(row, serviceFields);
+
+  const answered = profile.answered + practices.answered + serviceType.answered;
+  const applicable = profile.applicable + practices.applicable + serviceType.applicable;
+
+  return {
+    answered,
+    applicable,
+    percent: applicable === 0 ? 0 : Math.round((answered / applicable) * 100),
+    profile,
+    practices,
+    serviceType,
+  };
+}

--- a/server/trpc/routers/platform-admin.ts
+++ b/server/trpc/routers/platform-admin.ts
@@ -39,7 +39,12 @@ import { resolveEmailLocale } from "@/lib/mail/locale";
 import { isSuppressedSendId, sendMail } from "@/lib/mail/send";
 import { dailyDigestEmail, weeklyManagementDigestEmail } from "@/lib/mail/templates";
 import { HINT_COLUMN, HINTS, resolveHints } from "@/lib/onboarding/hints";
+import { loadGrowthData } from "@/lib/platform-admin/growth";
 import { rateLimit } from "@/lib/rate-limit";
+import {
+  questionnaireColumns,
+  questionnaireCompleteness,
+} from "@/lib/supplier-portal/completeness";
 import { COURSE_IDS, loadCourse } from "@/lib/training/course-loader";
 import {
   auditLog,
@@ -285,6 +290,17 @@ export const platformAdminRouter = router({
         .returning({ id: trainingLessonProgress.id });
       return { courseId: input.courseId, removed: deleted.length };
     }),
+
+  /**
+   * Everything the Graphs tab plots: per-user and per-company fact rows plus
+   * the daily series that are not per-user facts. All-time, unfiltered — the
+   * range selector lives on the client, so one fetch answers every range.
+   *
+   * Fetched lazily by the tab rather than on every platform-admin page load:
+   * it is the heaviest read on the page and eight of the nine tabs never
+   * need it.
+   */
+  growth: platformAdminProcedure.query(({ ctx }) => loadGrowthData(ctx.db)),
 
   overview: platformAdminProcedure.query(async ({ ctx }) => {
     const thirtyDaysAgo = new Date();
@@ -1228,25 +1244,52 @@ export const platformAdminRouter = router({
       return { email: target.email, scopesCleared: removed.length };
     }),
 
-  /** Supplier portal activity — companies acting as suppliers */
+  /**
+   * Supplier portal activity — companies acting as suppliers, with how much
+   * of the questionnaire each has answered.
+   *
+   * The questionnaire columns are projected from the page field lists rather
+   * than named here, so a question added to the portal is scored without
+   * anyone touching this query.
+   */
   supplierActivity: platformAdminProcedure.query(async ({ ctx }) => {
-    // Companies that act as suppliers and their relationship count
     const rows = await ctx.db
       .select({
+        ...questionnaireColumns(),
         companyId: company.id,
         companyName: company.name,
         sector: company.sector,
         createdAt: company.createdAt,
+        practicesLastSavedAt: company.practicesLastSavedAt,
+        // "company"."id" written out rather than interpolated as ${company.id}.
+        // Drizzle only qualifies a column with its table when the outer query
+        // joins, and this one selects from `company` alone, so the
+        // interpolation rendered a bare "id" that bound to the SUBQUERY's own
+        // table: `supplier.supplier_company_id = supplier.id`, false for every
+        // row. This column read 0 for every supplier. Same trap as the
+        // Companies tab (see platformAdmin.companies).
         customerCount: sql<number>`(
           SELECT count(*)::int FROM supplier
-          WHERE supplier.supplier_company_id = ${company.id}
+          WHERE supplier.supplier_company_id = "company"."id"
         )`,
       })
       .from(company)
       .where(eq(company.actsAsSupplier, true))
       .orderBy(desc(company.createdAt));
 
-    return rows;
+    // Scored from the whole row rather than a rest-spread: a column that is
+    // both a questionnaire field and named here would silently drop out of
+    // the answers and score every supplier short (it happened with `country`
+    // in the growth query).
+    return rows.map((row) => ({
+      companyId: row.companyId,
+      companyName: row.companyName,
+      sector: row.sector,
+      createdAt: row.createdAt,
+      practicesLastSavedAt: row.practicesLastSavedAt,
+      customerCount: row.customerCount,
+      questionnaire: questionnaireCompleteness(row),
+    }));
   }),
 
   gapAssessmentCreateForCompany: platformAdminProcedure


### PR DESCRIPTION
## Graphs tab

A range row (7 days to all time, plus a day/week/month bucket override) scoping twenty charts across four sections:

- **Growth** — accounts and organisations over time, new signups split by whether the address was ever verified, applicability-check leads by declared intent.
- **Engagement** — active people, compliance work (completions / sign-offs / evidence), lessons per course, mail volume.
- **Conversion** — a strictly nested signup funnel, the CEO-course funnel, time-to-activation and time-to-first-work histograms, a monthly cohort grid.
- **Who signed up** — sector, company size, country, interface language, seats per org, NIS 2 progress, supplier questionnaire completeness.

One all-time fetch; the client re-buckets, so switching range never refetches and two cards cannot disagree about the same quantity.

Three decisions worth reviewing:

- **"Work" is not the audit log.** That table records crons, outbound mail and admin actions, so an active-user count built on it would read our own batch jobs as customers being busy. It is lesson progress, requirement completions, sign-offs and evidence uploads.
- **Disposable signups are excluded from the funnels** and counted separately. They can never verify, so leaving them in understates every rate below.
- **Distributions use named orgs only.** Draft shells carry a placeholder sector, which would otherwise drown the real answer.

Every card carries a table view and prints its values as text: three of the four light-mode series colours sit under 3:1 against a white card, so colour is never the only way to read a value. The palette was validated against the app's real card surfaces in both themes (lightness band, chroma floor, colour-vision separation, normal-vision separation all pass).

## Supplier questionnaire completeness

The Suppliers tab gains a completeness column (bar, `answered/applicable`, percent, per-page split on hover), a last-saved column, and a four-tile summary. The Graphs tab gains the matching distribution.

Scored from the portal's own page field lists, so a question added to the portal is counted the day it ships. Two rules make the number mean something:

- **`false` is an answer.** "No, we hold no ISO 27001 certificate" is a filled-in field; scoring it as blank would rank an honest supplier below a silent one.
- **The denominator is what applies to them.** A SaaS-only supplier is not asked about on-prem patch SLAs, so those four questions do not count against them — otherwise nobody could reach 100% and the number would say nothing.

That required promoting the gate mapping out of the comments into `SERVICE_TYPE_BLOCKS`. `SERVICE_TYPE_PAGE_FIELDS` is now derived from it and is content-identical (verified field-by-field, same order).

## Two bugs fixed

**`supplierActivity.customerCount` read 0 for every supplier.** The correlated subquery interpolated `${company.id}` on a join-less select, so Drizzle rendered a bare `"id"` that bound to the subquery's own table — `supplier.supplier_company_id = supplier.id`, false for every row. The same trap is already documented in `platformAdmin.companies`. Confirmed against a live database (bare `id` → 0, qualified → 1).

**The Suppliers tab and the Graphs tab disagreed about the median (57% vs 55%).** Scoring read a rest-spread of "everything not named above", so `country` — both a questionnaire field and a column separately selected for the country chart — dropped out of the answers and scored every supplier one field short. Both call sites now score the whole row. Covered by a regression test.

## Scope

No schema changes, no migrations. Both new procedures sit on `platformAdminProcedure`. The growth payload carries no names, emails or ids — calendar days, flags and counts only.

## Verification

Typecheck clean, biome clean, 379 unit tests pass (8 new, covering the scoring rules). Rendered against a production build with ~250 synthetic accounts over 10 months and five fixture suppliers at deliberately different fill levels; the denominators shift correctly as service-type gates are ticked. Fixtures removed afterwards.

Known scaling boundary: the growth payload is one row per user. Fine at current volume; wants server-side aggregation somewhere north of a few thousand.