### PR TITLE
platform-admin: weekly insights panel on the Graphs tab

### DIFF
--- a/components/platform-admin/GraphsPanel.tsx
+++ b/components/platform-admin/GraphsPanel.tsx
@@ -29,6 +29,8 @@ import {
   signupFunnel,
   sizeBars,
 } from "./graphs/derive";
+import { InsightsCard } from "./graphs/InsightsCard";
+import { insightWindow, weeklyInsights } from "./graphs/insights";
 import { VIZ, VIZ_PALETTE_CSS } from "./graphs/palette";
 import {
   barsTable,
@@ -329,6 +331,13 @@ function GraphsView({ data }: { data: GrowthData }) {
     [data, today],
   );
 
+  // Fixed seven-day window, deliberately not scoped by the range selector.
+  const insights = useMemo(
+    () => weeklyInsights(data.users, data.companies, data.work, today),
+    [data, today],
+  );
+  const insightDays = insightWindow(today);
+
   const accountsNow = totals.accounts.get(frame.end) ?? 0;
   const ceoLessons = data.courseLessonCounts["nis2-ceo"];
   const supplierMedian = median(questionnairePercents(scoped.suppliers));
@@ -395,6 +404,8 @@ function GraphsView({ data }: { data: GrowthData }) {
   return (
     <div data-viz className="space-y-6">
       <style>{VIZ_PALETTE_CSS}</style>
+
+      <InsightsCard insights={insights} from={insightDays.from} to={insightDays.to} />
 
       {/* One filter row, scoping every card below it. */}
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border bg-muted/30 p-3">

--- a/components/platform-admin/graphs/InsightsCard.tsx
+++ b/components/platform-admin/graphs/InsightsCard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+/**
+ * The weekly read, at the top of the tab and above the range filter, because
+ * it reports on a fixed seven-day window and must not reshuffle while someone
+ * browses the charts underneath.
+ *
+ * Tone is carried by a written label, never by the stripe colour alone: two of
+ * the three status colours sit under 3:1 on a white card, and a reader who
+ * cannot separate orange from yellow still gets the meaning from the words.
+ */
+
+import type { Insight } from "./insights";
+
+const TONE = {
+  act: { label: "Act on this", color: "#ec835a" },
+  watch: { label: "Worth watching", color: "#fab219" },
+  good: { label: "Good news", color: "#0ca30c" },
+} as const satisfies Record<Insight["tone"], { label: string; color: string }>;
+
+export function InsightsCard({
+  insights,
+  from,
+  to,
+}: {
+  insights: Insight[];
+  from: string;
+  to: string;
+}) {
+  return (
+    <section className="rounded-lg border bg-card p-5">
+      <div className="mb-4">
+        <h3 className="text-base font-semibold">This week</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {from} to {to}. Up to three things worth acting on, ranked by how much they
+          matter rather than by how recent they are. Not affected by the range selector
+          below.
+        </p>
+      </div>
+
+      {insights.length === 0 ? (
+        <p className="py-4 text-sm text-muted-foreground">
+          Nothing crossed a threshold this week. That is a real answer, not an empty
+          state: no collapse in activity, no backlog growing, nothing overdue for a nudge.
+          The charts below still have the detail.
+        </p>
+      ) : (
+        <ol className="space-y-5">
+          {insights.map((insight) => {
+            const tone = TONE[insight.tone];
+            return (
+              <li
+                key={insight.id}
+                className="border-l-[3px] pl-4"
+                style={{ borderColor: tone.color }}
+              >
+                <p
+                  className="text-xs font-semibold uppercase tracking-wide"
+                  style={{ color: tone.color }}
+                >
+                  {tone.label}
+                </p>
+                <p className="mt-1 font-medium">{insight.headline}</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">{insight.detail}</p>
+                <p className="mt-1.5 text-sm">
+                  <span className="font-medium">Next:</span> {insight.action}
+                </p>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/components/platform-admin/graphs/insights.test.ts
+++ b/components/platform-admin/graphs/insights.test.ts
@@ -1,0 +1,241 @@
+/**
+ * The weekly panel is the one part of the Graphs tab that makes a judgement
+ * rather than plotting a number, so its thresholds are the thing worth pinning
+ * down: when a rule fires, when it stays quiet, and that the same facts always
+ * produce the same three findings in the same order.
+ */
+import { describe, expect, test } from "bun:test";
+import type { CompanyFact, DailyWorkRow, UserFact } from "@/lib/platform-admin/growth";
+import { MAX_INSIGHTS, weeklyInsights } from "./insights";
+import { addDays } from "./range";
+
+const TODAY = "2026-03-01";
+const ago = (days: number) => addDays(TODAY, -days);
+
+function user(overrides: Partial<UserFact> = {}): UserFact {
+  return {
+    signupDay: ago(90),
+    verified: true,
+    disposable: false,
+    locale: "de",
+    inOrg: true,
+    activatedDay: ago(89),
+    activeDays: [],
+    workEvents: 0,
+    complianceEvents: 0,
+    signOffs: 0,
+    coursesStarted: [],
+    coursesFinished: [],
+    ...overrides,
+  };
+}
+
+function company(overrides: Partial<CompanyFact> = {}): CompanyFact {
+  return {
+    createdDay: ago(90),
+    activatedDay: ago(89),
+    sector: "energy",
+    country: "DE",
+    entityType: "important",
+    plan: "free",
+    employeeCount: 120,
+    actsAsSupplier: false,
+    actsAsNis2Entity: true,
+    seats: 1,
+    compliancePct: 0,
+    questionnairePct: null,
+    ...overrides,
+  };
+}
+
+const run = (
+  users: UserFact[],
+  companies: CompanyFact[] = [],
+  work: DailyWorkRow[] = [],
+) => weeklyInsights(users, companies, work, TODAY);
+
+const ids = (users: UserFact[], companies?: CompanyFact[], work?: DailyWorkRow[]) =>
+  run(users, companies, work).map((i) => i.id);
+
+describe("weeklyInsights", () => {
+  test("a platform with nothing on it produces no findings", () => {
+    expect(run([])).toEqual([]);
+  });
+
+  test("a steady week produces no findings", () => {
+    // Active every week including this one, everyone activated, nothing stalled.
+    const steady = Array.from({ length: 6 }, () =>
+      user({
+        activeDays: [ago(1), ago(9), ago(16), ago(23), ago(30)],
+        workEvents: 5,
+        signOffs: 1,
+      }),
+    );
+    expect(ids(steady)).toEqual([]);
+  });
+
+  test("a week where nobody worked outranks everything else", () => {
+    const wasActive = Array.from({ length: 5 }, () =>
+      user({ activeDays: [ago(10), ago(17), ago(24), ago(31)], workEvents: 4 }),
+    );
+    const found = run(wasActive);
+    expect(found[0]?.id).toBe("activity-zero");
+    expect(found[0]?.tone).toBe("act");
+  });
+
+  test("the draft-shell backlog fires, and says whether it is still growing", () => {
+    const stuck = Array.from({ length: 8 }, () =>
+      user({ activatedDay: null, signupDay: ago(40) }),
+    );
+    const growing = [
+      ...stuck,
+      ...Array.from({ length: 3 }, () =>
+        user({ activatedDay: null, signupDay: ago(10) }),
+      ),
+    ];
+    expect(ids(stuck)).toContain("draft-shell-backlog");
+
+    const flat = run(stuck).find((i) => i.id === "draft-shell-backlog");
+    const rising = run(growing).find((i) => i.id === "draft-shell-backlog");
+    expect(flat?.detail).toContain("stopped growing");
+    expect(rising?.detail).toContain("still growing");
+    // Growth has to raise the ranking, or a chronic backlog never gets worse.
+    expect(rising?.severity ?? 0).toBeGreaterThan(flat?.severity ?? 0);
+  });
+
+  test("two stuck accounts are not worth anyone's week", () => {
+    const barely = Array.from({ length: 2 }, () =>
+      user({ activatedDay: null, signupDay: ago(40) }),
+    );
+    expect(ids(barely)).not.toContain("draft-shell-backlog");
+  });
+
+  test("people who worked and went quiet are surfaced", () => {
+    const stalled = Array.from({ length: 4 }, () =>
+      user({ activeDays: [ago(40), ago(30)], workEvents: 6 }),
+    );
+    expect(ids(stalled)).toContain("stalled-workers");
+  });
+
+  test("someone who signed a requirement off is not counted as stalled", () => {
+    const done = Array.from({ length: 4 }, () =>
+      user({ activeDays: [ago(40), ago(30)], workEvents: 6, signOffs: 2 }),
+    );
+    expect(ids(done)).not.toContain("stalled-workers");
+  });
+
+  test("course finishers who never used the platform are surfaced", () => {
+    const idle = Array.from({ length: 3 }, () =>
+      user({ coursesFinished: [{ courseId: "nis2-ceo", day: ago(30) }] }),
+    );
+    expect(ids(idle)).toContain("course-finishers-idle");
+  });
+
+  test("a course finisher counts as idle even though the lessons were work", () => {
+    // Regression: the rule first tested total work events, which a 47-lesson
+    // course guarantees, so it could never fire for the people it describes.
+    const finished = Array.from({ length: 3 }, () =>
+      user({
+        coursesFinished: [{ courseId: "nis2-ceo", day: ago(30) }],
+        workEvents: 47,
+        complianceEvents: 0,
+      }),
+    );
+    expect(ids(finished)).toContain("course-finishers-idle");
+
+    const alsoWorked = finished.map((u) => ({ ...u, complianceEvents: 12 }));
+    expect(ids(alsoWorked)).not.toContain("course-finishers-idle");
+  });
+
+  test("a supplier who signed up this week is not chased for being mid-form", () => {
+    const fresh = [
+      company({ actsAsSupplier: true, questionnairePct: 0, createdDay: ago(3) }),
+    ];
+    expect(ids([], fresh)).not.toContain("supplier-questionnaire-gap");
+
+    const overdue = [
+      company({ actsAsSupplier: true, questionnairePct: 0, createdDay: ago(30) }),
+    ];
+    expect(ids([], overdue)).toContain("supplier-questionnaire-gap");
+  });
+
+  test("a falling activation rate needs a cohort big enough to mean anything", () => {
+    // Four recent signups, none activated: a real collapse in ratio terms,
+    // but four people is noise and the rule must stay quiet.
+    const tiny = [
+      ...Array.from({ length: 4 }, () =>
+        user({ signupDay: ago(12), activatedDay: null }),
+      ),
+      ...Array.from({ length: 8 }, () =>
+        user({ signupDay: ago(30), activatedDay: ago(29) }),
+      ),
+    ];
+    expect(ids(tiny)).not.toContain("activation-rate-falling");
+
+    const enough = [
+      ...Array.from({ length: 10 }, () =>
+        user({ signupDay: ago(12), activatedDay: null }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        user({ signupDay: ago(30), activatedDay: ago(29) }),
+      ),
+    ];
+    expect(ids(enough)).toContain("activation-rate-falling");
+  });
+
+  test("good news gets said out loud", () => {
+    const surge = [
+      ...Array.from({ length: 9 }, () => user({ signupDay: ago(2) })),
+      ...Array.from({ length: 2 }, () => user({ signupDay: ago(15) })),
+    ];
+    const good = run(surge).find((i) => i.tone === "good");
+    expect(good?.id).toBe("growth-up");
+  });
+
+  test("never more than three, however much is wrong", () => {
+    const everything = [
+      ...Array.from({ length: 12 }, () =>
+        user({ activatedDay: null, signupDay: ago(40) }),
+      ),
+      ...Array.from({ length: 8 }, () => user({ activeDays: [ago(40)], workEvents: 3 })),
+      ...Array.from({ length: 6 }, () =>
+        user({ coursesFinished: [{ courseId: "nis2-ceo", day: ago(30) }] }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        user({ signupDay: ago(12), activatedDay: null }),
+      ),
+      ...Array.from({ length: 10 }, () =>
+        user({ signupDay: ago(30), activatedDay: ago(29) }),
+      ),
+    ];
+    const suppliers = Array.from({ length: 5 }, () =>
+      company({ actsAsSupplier: true, questionnairePct: 0, createdDay: ago(30) }),
+    );
+    expect(run(everything, suppliers).length).toBe(MAX_INSIGHTS);
+  });
+
+  test("the same facts always give the same findings in the same order", () => {
+    const facts = [
+      ...Array.from({ length: 9 }, () =>
+        user({ activatedDay: null, signupDay: ago(40) }),
+      ),
+      ...Array.from({ length: 5 }, () => user({ activeDays: [ago(40)], workEvents: 3 })),
+    ];
+    expect(ids(facts)).toEqual(ids(facts));
+  });
+
+  test("disposable signups never drive a finding", () => {
+    const bots = Array.from({ length: 30 }, () =>
+      user({ disposable: true, activatedDay: null, signupDay: ago(40) }),
+    );
+    expect(ids(bots)).toEqual([]);
+  });
+
+  test("work with no sign-off for a fortnight is flagged", () => {
+    const work: DailyWorkRow[] = [
+      { day: ago(3), completed: 6, signedOff: 0, evidence: 2 },
+      { day: ago(9), completed: 4, signedOff: 0, evidence: 0 },
+    ];
+    expect(ids([], [], work)).toContain("signoff-drought");
+  });
+});

--- a/components/platform-admin/graphs/insights.ts
+++ b/components/platform-admin/graphs/insights.ts
@@ -1,0 +1,391 @@
+/**
+ * The weekly read: up to three things worth doing something about.
+ *
+ * Rules, not a language model. The hard part of a panel like this is not the
+ * writing, it is deciding which of twenty metrics matters this week — and a
+ * model handed twenty numbers with no sense of what is normal here produces
+ * confident, unstable filler that reads differently every week from data that
+ * barely moved. A rule has a threshold you can argue with in review, gives the
+ * same answer twice, costs nothing, and works on a self-hosted instance with no
+ * API key. Every number below is computed, never phrased by anything.
+ *
+ * Deliberately **up to** three. A quiet week says so. Forcing three findings
+ * out of a week where nothing crossed a line is how a panel becomes wallpaper.
+ *
+ * Fixed weekly window, independent of the range selector: a weekly check wants
+ * a weekly answer, and findings that reshuffled while you browsed the charts
+ * would be unreadable. That is why the panel sits above the filter row.
+ */
+
+import type { CompanyFact, DailyWorkRow, UserFact } from "@/lib/platform-admin/growth";
+import { activePeople, percent } from "./derive";
+import { addDays } from "./range";
+
+export interface Insight {
+  /** Stable across weeks, so a repeat finding is recognisable. */
+  id: string;
+  /** 0-100, for ranking only. Never shown. */
+  severity: number;
+  tone: "act" | "watch" | "good";
+  /** What is true, in one line. */
+  headline: string;
+  /** The numbers behind it. */
+  detail: string;
+  /** What to do about it. */
+  action: string;
+}
+
+interface Window {
+  today: string;
+  weekStart: string;
+  /** The four whole weeks before this one, newest first. */
+  baselineWeeks: Array<{ from: string; to: string }>;
+}
+
+const mean = (values: number[]): number =>
+  values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length;
+
+const within = (day: string | null, from: string, to: string): boolean =>
+  day !== null && day >= from && day <= to;
+
+function buildWindow(today: string): Window {
+  const weekStart = addDays(today, -6);
+  return {
+    today,
+    weekStart,
+    baselineWeeks: [1, 2, 3, 4].map((i) => ({
+      from: addDays(weekStart, -7 * i),
+      to: addDays(today, -7 * i),
+    })),
+  };
+}
+
+interface Facts {
+  users: UserFact[];
+  companies: CompanyFact[];
+  work: DailyWorkRow[];
+  window: Window;
+}
+
+/** A rule returns null when nothing about it is worth a reader's attention. */
+type Rule = (facts: Facts) => Insight | null;
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Nobody did anything this week.
+ *
+ * Ranked highest when it is absolute, because a platform that went completely
+ * quiet is usually a broken deploy rather than a demand signal, and that is
+ * worth ten minutes before drawing any conclusion from the charts below.
+ */
+const activityCollapsed: Rule = ({ users, window: w }) => {
+  const now = activePeople(users, w.weekStart, w.today);
+  const baseline = mean(
+    w.baselineWeeks.map((week) => activePeople(users, week.from, week.to)),
+  );
+  if (baseline < 1) return null;
+
+  if (now === 0) {
+    return {
+      id: "activity-zero",
+      severity: 95,
+      tone: "act",
+      headline: "Nobody did any work in the platform this week",
+      detail: `${baseline.toFixed(1)} people a week were active over the previous four weeks. This week: none.`,
+      action:
+        "Check the deploy and sign-in before reading anything else on this page as a demand signal.",
+    };
+  }
+
+  const drop = (baseline - now) / baseline;
+  if (drop < 0.4) return null;
+  return {
+    id: "activity-down",
+    severity: Math.min(88, 45 + Math.round(drop * 50)),
+    tone: "act",
+    headline: "Far fewer people did any work this week",
+    detail: `${now} active this week against a four-week average of ${baseline.toFixed(1)}, down ${Math.round(drop * 100)} percent.`,
+    action:
+      "Open the Users tab and check whether the quiet accounts are recent signups who never got started, or regulars who stopped.",
+  };
+};
+
+/**
+ * Verified, given an organisation shell, never named it.
+ *
+ * The structural funnel gap: everyone who verifies gets a draft company
+ * automatically, so this counts people who arrived, got a workspace, and never
+ * described their organisation. Chronic rather than news, so the base severity
+ * is moderate and only growth this week pushes it up — otherwise it would win
+ * every week and the panel would stop being read.
+ */
+const draftShellBacklog: Rule = ({ users, window: w }) => {
+  const stuck = users.filter(
+    (u) =>
+      !u.disposable &&
+      u.verified &&
+      u.inOrg &&
+      u.activatedDay === null &&
+      u.signupDay <= addDays(w.today, -7),
+  );
+  if (stuck.length < 3) return null;
+
+  const addedThisWeek = users.filter(
+    (u) =>
+      !u.disposable &&
+      u.verified &&
+      u.inOrg &&
+      u.activatedDay === null &&
+      within(u.signupDay, addDays(w.today, -13), addDays(w.today, -7)),
+  ).length;
+
+  return {
+    id: "draft-shell-backlog",
+    severity: Math.min(75, 30 + stuck.length + addedThisWeek * 4),
+    tone: "act",
+    headline: `${stuck.length} verified accounts never named their organisation`,
+    detail:
+      addedThisWeek > 0
+        ? `${addedThisWeek} of them arrived in the week before last, so the backlog is still growing.`
+        : "The backlog stopped growing this week, but nobody worked it down either.",
+    action:
+      "The activation nudge on the Emails tab was built for exactly these people. Review the queue and send a batch.",
+  };
+};
+
+/**
+ * People who were working and stopped.
+ *
+ * Active at some point, silent for a fortnight, nothing signed off. This is the
+ * week-three abandonment shape, and it is the warmest list on the page: they
+ * already know what the product is and got far enough to use it.
+ */
+const stalledWorkers: Rule = ({ users, window: w }) => {
+  const stalled = users.filter((u) => {
+    if (u.disposable || u.workEvents === 0 || u.signOffs > 0) return false;
+    const last = u.activeDays[u.activeDays.length - 1];
+    if (last === undefined) return false;
+    return last < addDays(w.today, -13) && last >= addDays(w.today, -60);
+  });
+  if (stalled.length < 2) return null;
+
+  return {
+    id: "stalled-workers",
+    severity: Math.min(80, 35 + stalled.length * 3),
+    tone: "act",
+    headline: `${stalled.length} people started work and went quiet`,
+    detail:
+      "Each did something in the platform, nothing in the last two weeks, and has never signed a requirement off.",
+    action:
+      "Warmest list you have. Ask one of them what stopped them before writing any new copy.",
+  };
+};
+
+/**
+ * Finished a course, never touched the platform.
+ *
+ * The course is the wedge that brings people in; someone who completed every
+ * lesson and then did nothing is a person who already trusts us and has not
+ * been asked for the next step.
+ */
+const courseFinishersIdle: Rule = ({ users }) => {
+  // complianceEvents, not workEvents: finishing a 47-lesson course IS work
+  // events, so testing the total would mean this never fires for the exact
+  // people it is about.
+  const idle = users.filter(
+    (u) => !u.disposable && u.coursesFinished.length > 0 && u.complianceEvents === 0,
+  );
+  const finishers = users.filter(
+    (u) => !u.disposable && u.coursesFinished.length > 0,
+  ).length;
+  if (idle.length < 2) return null;
+
+  return {
+    id: "course-finishers-idle",
+    severity: Math.min(78, 30 + idle.length * 4),
+    tone: "act",
+    headline: `${idle.length} course finishers have never used the platform`,
+    detail: `${idle.length} of ${finishers} people who completed a course did no work afterwards (${percent(idle.length, finishers)}).`,
+    action:
+      "They sat through the whole course, so they are not cold. One mail offering the next concrete step.",
+  };
+};
+
+/**
+ * Suppliers sitting on an unfinished questionnaire.
+ *
+ * Only counts profiles older than a fortnight, so someone who signed up on
+ * Tuesday is not chased for being mid-form.
+ */
+const supplierQuestionnaireGap: Rule = ({ companies, window: w }) => {
+  const due = companies.filter(
+    (c) =>
+      c.actsAsSupplier &&
+      c.questionnairePct !== null &&
+      c.questionnairePct < 100 &&
+      c.createdDay <= addDays(w.today, -14),
+  );
+  if (due.length === 0) return null;
+  const untouched = due.filter((c) => c.questionnairePct === 0).length;
+
+  return {
+    id: "supplier-questionnaire-gap",
+    severity: Math.min(70, 25 + due.length * 5 + untouched * 5),
+    tone: untouched > 0 ? "act" : "watch",
+    headline: `${due.length} supplier profiles are still unfinished`,
+    detail:
+      untouched > 0
+        ? `${untouched} of them have answered nothing at all, a fortnight after the profile was created.`
+        : "All of them have started; none has finished the questions that apply to them.",
+    action:
+      "The Suppliers tab lists them by completeness. An unfinished profile is the thing their customer is waiting on.",
+  };
+};
+
+/**
+ * Work is happening but nothing is being signed off.
+ *
+ * Sign-off is where a completed requirement becomes evidence. Work without it
+ * produces no defensible record, so a fortnight of one without the other is
+ * worth knowing about.
+ */
+const signOffDrought: Rule = ({ work, window: w }) => {
+  const from = addDays(w.today, -13);
+  const recent = work.filter((row) => row.day >= from && row.day <= w.today);
+  const completed = recent.reduce((sum, row) => sum + row.completed, 0);
+  const signed = recent.reduce((sum, row) => sum + row.signedOff, 0);
+  if (completed < 5 || signed > 0) return null;
+
+  return {
+    id: "signoff-drought",
+    severity: 60,
+    tone: "watch",
+    headline: "Requirements are being completed but nothing is signed off",
+    detail: `${completed} requirements marked complete in the last fortnight, zero sign-offs.`,
+    action:
+      "Sign-off is what turns a completed requirement into evidence. Worth checking the step is reachable.",
+  };
+};
+
+/**
+ * Recent signups are converting worse than the ones before them.
+ *
+ * Compares a cohort that has had at least a week to activate against the four
+ * weeks before it. Guarded on cohort size, because at this volume a three-
+ * person week swings any rate wildly and would fire constantly.
+ */
+const activationRateFalling: Rule = ({ users, window: w }) => {
+  const recent = users.filter(
+    (u) =>
+      !u.disposable && within(u.signupDay, addDays(w.today, -20), addDays(w.today, -7)),
+  );
+  const before = users.filter(
+    (u) =>
+      !u.disposable && within(u.signupDay, addDays(w.today, -48), addDays(w.today, -21)),
+  );
+  if (recent.length < 5 || before.length < 5) return null;
+
+  const rateOf = (rows: UserFact[]) =>
+    rows.filter((u) => u.activatedDay !== null).length / rows.length;
+  const now = rateOf(recent);
+  const then = rateOf(before);
+  if (then === 0 || now >= then * 0.75) return null;
+
+  return {
+    id: "activation-rate-falling",
+    severity: Math.min(85, 40 + Math.round((1 - now / then) * 50)),
+    tone: "act",
+    headline: "The latest signups are converting worse than the batch before",
+    detail: `${Math.round(now * 100)} percent of the last ${recent.length} signups named an organisation, against ${Math.round(then * 100)} percent of the ${before.length} before them.`,
+    action:
+      "Same product, worse conversion, usually means the traffic changed. Check where the recent signups came from.",
+  };
+};
+
+/**
+ * Good news, so the panel is not purely a list of complaints. A week that is
+ * genuinely better than the last four deserves to be said out loud.
+ */
+const growthUp: Rule = ({ users, window: w }) => {
+  const countIn = (from: string, to: string) =>
+    users.filter((u) => !u.disposable && within(u.signupDay, from, to)).length;
+  const now = countIn(w.weekStart, w.today);
+  const baseline = mean(w.baselineWeeks.map((week) => countIn(week.from, week.to)));
+  if (now < 3 || baseline === 0 || now < baseline * 1.5) return null;
+
+  return {
+    id: "growth-up",
+    severity: 40,
+    tone: "good",
+    headline: "Signups were well up on the last four weeks",
+    detail: `${now} new accounts this week against a four-week average of ${baseline.toFixed(1)}.`,
+    action:
+      "Worth knowing what caused it while you can still remember. Check the Users tab for where they clustered.",
+  };
+};
+
+/**
+ * A week where somebody signed something off for the first time in a while is
+ * the single best signal the product is working. Cheap to detect, worth saying.
+ */
+const signOffsHappened: Rule = ({ work, window: w }) => {
+  const signedThisWeek = work
+    .filter((row) => row.day >= w.weekStart && row.day <= w.today)
+    .reduce((sum, row) => sum + row.signedOff, 0);
+  if (signedThisWeek < 1) return null;
+
+  const before = work
+    .filter((row) => row.day >= addDays(w.today, -34) && row.day < w.weekStart)
+    .reduce((sum, row) => sum + row.signedOff, 0);
+  if (before > 0) return null;
+
+  return {
+    id: "signoffs-resumed",
+    severity: 45,
+    tone: "good",
+    headline: "Someone signed off a requirement for the first time in a month",
+    detail: `${signedThisWeek} sign-off${signedThisWeek === 1 ? "" : "s"} this week, after four quiet weeks.`,
+    action:
+      "Find out who, and what they were working on. That is the shape of a customer.",
+  };
+};
+
+/**
+ * Order matters only for ties: two findings with the same severity always come
+ * out in the same order, so the panel does not reshuffle between refreshes.
+ */
+const RULES: Rule[] = [
+  activityCollapsed,
+  activationRateFalling,
+  stalledWorkers,
+  courseFinishersIdle,
+  draftShellBacklog,
+  supplierQuestionnaireGap,
+  signOffDrought,
+  signOffsHappened,
+  growthUp,
+];
+
+/** How many the panel will ever show. */
+export const MAX_INSIGHTS = 3;
+
+export function weeklyInsights(
+  users: UserFact[],
+  companies: CompanyFact[],
+  work: DailyWorkRow[],
+  today: string,
+): Insight[] {
+  const facts: Facts = { users, companies, work, window: buildWindow(today) };
+  return RULES.map((rule) => rule(facts))
+    .filter((insight): insight is Insight => insight !== null)
+    .sort((a, b) => b.severity - a.severity)
+    .slice(0, MAX_INSIGHTS);
+}
+
+/** The window the panel reports on, for the card's subtitle. */
+export function insightWindow(today: string): { from: string; to: string } {
+  return { from: addDays(today, -6), to: today };
+}

--- a/lib/platform-admin/growth.ts
+++ b/lib/platform-admin/growth.ts
@@ -77,6 +77,13 @@ export interface UserFact {
    * would read our own batch jobs as customers being busy.
    */
   workEvents: number;
+  /**
+   * The same count without lesson progress: requirement completions, sign-offs
+   * and evidence only. Someone who finished a 47-lesson course has 47 work
+   * events and may still have done nothing at all inside their ISMS, which is
+   * a different and more interesting fact.
+   */
+  complianceEvents: number;
   /** Requirements this person signed off, all time. */
   signOffs: number;
   /** Courses with at least one lesson touched. */
@@ -369,24 +376,34 @@ export async function loadGrowthData(db: Database): Promise<GrowthData> {
 
   interface UserWork {
     events: number;
+    complianceEvents: number;
     signOffs: number;
     days: Set<string>;
   }
   const workByUser = new Map<string, UserWork>();
   const activeByDay = new Map<string, { users: Set<string>; events: number }>();
 
+  /**
+   * Which kind of work a row is. Lesson progress and ISMS work are both work,
+   * but they answer different questions: "did this person come back" counts
+   * both, while "did the course turn into anything" has to count only the
+   * second, or every course finisher looks busy on the strength of the 47
+   * lessons they just clicked through.
+   */
   const recordWork = (
     row: { userId: string | null; day: string; events: number },
-    isSignOff: boolean,
+    kind: "lesson" | "compliance" | "sign-off",
   ) => {
     if (!row.userId) return;
     const forUser: UserWork = workByUser.get(row.userId) ?? {
       events: 0,
+      complianceEvents: 0,
       signOffs: 0,
       days: new Set(),
     };
     forUser.events += row.events;
-    if (isSignOff) forUser.signOffs += row.events;
+    if (kind !== "lesson") forUser.complianceEvents += row.events;
+    if (kind === "sign-off") forUser.signOffs += row.events;
     forUser.days.add(row.day);
     workByUser.set(row.userId, forUser);
 
@@ -396,10 +413,10 @@ export async function loadGrowthData(db: Database): Promise<GrowthData> {
     activeByDay.set(row.day, forDay);
   };
 
-  for (const r of lessonTouches) recordWork(r, false);
-  for (const r of signOffRows) recordWork(r, true);
-  for (const r of evidenceRows) recordWork(r, false);
-  for (const r of requirementRows) recordWork(r, false);
+  for (const r of lessonTouches) recordWork(r, "lesson");
+  for (const r of signOffRows) recordWork(r, "sign-off");
+  for (const r of evidenceRows) recordWork(r, "compliance");
+  for (const r of requirementRows) recordWork(r, "compliance");
 
   const startedByUser = new Map<string, Set<CourseId>>();
   for (const r of lessonTouches) {
@@ -428,6 +445,7 @@ export async function loadGrowthData(db: Database): Promise<GrowthData> {
       activatedDay: u.activatedDay,
       activeDays: work ? Array.from(work.days).sort() : [],
       workEvents: work?.events ?? 0,
+      complianceEvents: work?.complianceEvents ?? 0,
       signOffs: work?.signOffs ?? 0,
       coursesStarted: Array.from(startedByUser.get(u.id) ?? []),
       coursesFinished: finishedByUser.get(u.id) ?? [],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "biome check --write .",
     "lint:ci": "biome check --changed --since=$(git merge-base origin/main HEAD) --no-errors-on-unmatched",
     "typecheck": "tsc --noEmit",
-    "test:unit": "bun test lib server schema/",
+    "test:unit": "bun test lib server schema/ components/",
     "check:migrations": "bun scripts/check-migration-journals.ts",
     "check:migration-immutability": "bun scripts/check-migration-immutability.ts",
     "check:migration-safety": "bun scripts/check-migration-safety.ts",


### PR DESCRIPTION
Up to three findings at the top of the Graphs tab, each one a headline, the numbers behind it, and a next step.

## Why rules and not a model

The hard part of a weekly panel is not the writing, it is deciding which of twenty metrics matters *this* week. A model handed twenty numbers with no sense of what is normal here produces confident, unstable filler — three different "insights" each week from data that barely moved — and it would put invented numbers on a compliance product's admin page.

A rule has a threshold you can argue with in review, gives the same answer twice, costs nothing, and works on a self-hosted instance with no API key. Every number in the panel is computed; nothing is phrased by anything.

A model could reasonably rewrite the three findings into one paragraph later, with the numbers passed in and forbidden from inventing any. That bolts on top without rework, because the rules emit structured findings.

## Design

**Nine rules**, each computing its own severity. Acute findings (activity collapsed, activation rate falling) outrank chronic ones (the draft-shell backlog), so a standing problem cannot sit at the top every week until nobody reads the panel — though chronic rules do get a bump when they worsen. Two rules report good news, so the panel is not purely a list of complaints.

**Up to three, deliberately.** A quiet week says "nothing crossed a threshold", which is a real answer. Manufacturing three findings from a flat week is how a panel becomes wallpaper.

**Fixed seven-day window**, independent of the range selector, which is why it sits above the filter row: findings that reshuffled while you browsed the charts underneath would be unreadable.

**Guards against noise at low volume** — the activation-rate rule needs at least five signups on each side before it will speak, because at current volume a three-person week swings any rate wildly. Disposable signups never drive a finding.

Tone is carried by a written label ("Act on this" / "Worth watching" / "Good news"), never by the stripe colour alone: two of the three status colours sit under 3:1 on a white card.

## Also in here

`UserFact` gains `complianceEvents`, the work count without lesson progress. Someone who finished a 47-lesson course has 47 work events and may still have done nothing inside their ISMS, so "finished the course, never used the platform" could not be expressed against the total — the rule was dead on arrival. Found while building fixtures, covered by a regression test.

`test:unit` now covers `components/` as well. The Graphs tab put real pure logic there (bucketing, derivations, these rules) and none of it was reachable by CI. No component tests existed before, so nothing changes except that the 16 new ones run.

## Verification

Typecheck clean, biome clean, 395 unit tests pass (16 new). The thresholds were mutation-tested: loosening the draft-shell floor and the activation-rate cohort guard each made a test fail, so the suite has teeth.

Rendered on the local dev server against fixtures shaped to trip specific rules — the three that surfaced were the three with the highest severity, in the right order — and again with the fixtures removed, to check the quiet-week copy.