### PR TITLE
platform-admin: stop the insights panel repeating itself

### DIFF
--- a/components/platform-admin/graphs/insights.test.ts
+++ b/components/platform-admin/graphs/insights.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { CompanyFact, DailyWorkRow, UserFact } from "@/lib/platform-admin/growth";
-import { MAX_INSIGHTS, weeklyInsights } from "./insights";
+import { allInsights, MAX_INSIGHTS, weeklyInsights } from "./insights";
 import { addDays } from "./range";
 
 const TODAY = "2026-03-01";
@@ -83,24 +83,76 @@ describe("weeklyInsights", () => {
     expect(found[0]?.tone).toBe("act");
   });
 
-  test("the draft-shell backlog fires, and says whether it is still growing", () => {
+  test("the draft-shell backlog reports movement, not just a level", () => {
     const stuck = Array.from({ length: 8 }, () =>
       user({ activatedDay: null, signupDay: ago(40) }),
     );
+    // Three more crossed the seven-day line during the last week.
     const growing = [
       ...stuck,
-      ...Array.from({ length: 3 }, () =>
-        user({ activatedDay: null, signupDay: ago(10) }),
-      ),
+      ...Array.from({ length: 3 }, () => user({ activatedDay: null, signupDay: ago(8) })),
     ];
-    expect(ids(stuck)).toContain("draft-shell-backlog");
+    // Four of the eight were activated three days ago.
+    const shrinking = stuck.map((u, i) => (i < 4 ? { ...u, activatedDay: ago(3) } : u));
 
     const flat = run(stuck).find((i) => i.id === "draft-shell-backlog");
     const rising = run(growing).find((i) => i.id === "draft-shell-backlog");
-    expect(flat?.detail).toContain("stopped growing");
-    expect(rising?.detail).toContain("still growing");
-    // Growth has to raise the ranking, or a chronic backlog never gets worse.
+    const falling = run(shrinking).find((i) => i.id === "draft-shell-backlog");
+
+    expect(flat?.detail).toContain("Unchanged");
+    expect(rising?.detail).toContain("3 more than last week");
+    expect(falling?.detail).toContain("4 fewer than last week");
+
+    // A backlog that grew must outrank one that is flat, which must outrank one
+    // being worked down — otherwise acting on it never changes what you see.
     expect(rising?.severity ?? 0).toBeGreaterThan(flat?.severity ?? 0);
+    expect(flat?.severity ?? 0).toBeGreaterThan(falling?.severity ?? 0);
+    // And the advice changes once it is moving.
+    expect(falling?.action).toContain("It is moving");
+  });
+
+  test("at most one standing problem takes a slot", () => {
+    // Four chronic rules all firing at once, and nothing acute.
+    const everythingChronic = [
+      ...Array.from({ length: 40 }, () =>
+        user({ activatedDay: null, signupDay: ago(40) }),
+      ),
+      ...Array.from({ length: 20 }, () => user({ activeDays: [ago(40)], workEvents: 3 })),
+      ...Array.from({ length: 20 }, () =>
+        user({
+          coursesFinished: [{ courseId: "nis2-ceo", day: ago(30) }],
+          workEvents: 47,
+        }),
+      ),
+    ];
+    const suppliers = Array.from({ length: 6 }, () =>
+      company({ actsAsSupplier: true, questionnairePct: 0, createdDay: ago(30) }),
+    );
+    const found = run(everythingChronic, suppliers);
+    expect(found.filter((i) => i.kind === "chronic").length).toBe(1);
+    // Which one wins depends on the numbers, but it must be the most severe of
+    // them: capping the slot must never hide the worst standing problem.
+    const shown = found.find((i) => i.kind === "chronic");
+    const everyChronic = allInsights(everythingChronic, suppliers, [], TODAY).filter(
+      (i) => i.kind === "chronic",
+    );
+    expect(everyChronic.length).toBeGreaterThan(1);
+    expect(shown?.severity).toBe(Math.max(...everyChronic.map((i) => i.severity)));
+  });
+
+  test("a standing problem never crowds out something that just happened", () => {
+    const chronicPlusAcute = [
+      ...Array.from({ length: 60 }, () =>
+        user({ activatedDay: null, signupDay: ago(40) }),
+      ),
+      // Active every baseline week, silent this one.
+      ...Array.from({ length: 6 }, () =>
+        user({ activeDays: [ago(10), ago(17), ago(24), ago(31)], workEvents: 4 }),
+      ),
+    ];
+    const found = run(chronicPlusAcute);
+    expect(found[0]?.id).toBe("activity-zero");
+    expect(found.some((i) => i.kind === "acute")).toBe(true);
   });
 
   test("two stuck accounts are not worth anyone's week", () => {
@@ -211,7 +263,9 @@ describe("weeklyInsights", () => {
     const suppliers = Array.from({ length: 5 }, () =>
       company({ actsAsSupplier: true, questionnairePct: 0, createdDay: ago(30) }),
     );
-    expect(run(everything, suppliers).length).toBe(MAX_INSIGHTS);
+    const found = run(everything, suppliers);
+    expect(found.length).toBeLessThanOrEqual(MAX_INSIGHTS);
+    expect(found.filter((i) => i.kind === "chronic").length).toBeLessThanOrEqual(1);
   });
 
   test("the same facts always give the same findings in the same order", () => {

--- a/components/platform-admin/graphs/insights.ts
+++ b/components/platform-admin/graphs/insights.ts
@@ -27,6 +27,17 @@ export interface Insight {
   /** 0-100, for ranking only. Never shown. */
   severity: number;
   tone: "act" | "watch" | "good";
+  /**
+   * Whether this finding can change from one week to the next.
+   *
+   * "acute" describes something that happened in the window: activity
+   * collapsed, the conversion rate moved, somebody signed off for the first
+   * time in a month. "chronic" describes a standing population: people stuck
+   * on a draft shell, course finishers who never came back. Both are worth
+   * saying, but a panel that fills all three slots with chronic findings reads
+   * identically every Monday, which is the failure this field exists to stop.
+   */
+  kind: "acute" | "chronic";
   /** What is true, in one line. */
   headline: string;
   /** The numbers behind it. */
@@ -67,6 +78,65 @@ interface Facts {
   window: Window;
 }
 
+/**
+ * A chronic count and the same count a week ago, so the finding can report
+ * movement rather than a level that never changes.
+ *
+ * Rewound from the facts themselves, never from stored history: a person's
+ * signup day and activation day are both dates, so "was this account stuck
+ * last Monday" is answerable today. Only used where the rewind is exact. A
+ * rule whose inputs are current-only counters (the supplier questionnaire
+ * percentage, lifetime event totals) reports its level and says nothing about
+ * movement, because a guessed delta is worse than no delta.
+ */
+function movement(
+  matches: (asOf: string) => number,
+  today: string,
+): { now: number; change: number } {
+  const now = matches(today);
+  return { now, change: now - matches(addDays(today, -7)) };
+}
+
+/**
+ * Severity for a chronic finding: the size of the problem sets the base, and
+ * this week's movement shifts it within bounds.
+ *
+ * Symmetric on purpose. Rewarding growth without penalising shrinkage was the
+ * first version, and it meant a backlog being actively worked down scored the
+ * same as one nobody had touched — so acting on the finding changed nothing
+ * about what the panel said. The shift is bounded so a large problem recedes
+ * when it improves without dropping off the page after one good week.
+ */
+function chronicSeverity({
+  base,
+  now,
+  per,
+  change,
+  ceiling,
+}: {
+  base: number;
+  now: number;
+  /** How many people one severity point of "size" is worth. */
+  per: number;
+  change: number;
+  ceiling: number;
+}): number {
+  const level = base + Math.round(now / per);
+  const shift = Math.max(-10, Math.min(15, change * 2));
+  return Math.max(20, Math.min(ceiling, level + shift));
+}
+
+/** "six more than last week", "26 fewer than last week", or the flat case. */
+function movementPhrase(change: number, capitalised = false): string {
+  const phrase =
+    change > 0
+      ? `${change} more than last week`
+      : change < 0
+        ? `${Math.abs(change)} fewer than last week`
+        : "unchanged on last week";
+  return capitalised ? phrase.charAt(0).toUpperCase() + phrase.slice(1) : phrase;
+}
+
 /** A rule returns null when nothing about it is worth a reader's attention. */
 type Rule = (facts: Facts) => Insight | null;
 
@@ -92,6 +162,7 @@ const activityCollapsed: Rule = ({ users, window: w }) => {
     return {
       id: "activity-zero",
       severity: 95,
+      kind: "acute",
       tone: "act",
       headline: "Nobody did any work in the platform this week",
       detail: `${baseline.toFixed(1)} people a week were active over the previous four weeks. This week: none.`,
@@ -105,6 +176,7 @@ const activityCollapsed: Rule = ({ users, window: w }) => {
   return {
     id: "activity-down",
     severity: Math.min(88, 45 + Math.round(drop * 50)),
+    kind: "acute",
     tone: "act",
     headline: "Far fewer people did any work this week",
     detail: `${now} active this week against a four-week average of ${baseline.toFixed(1)}, down ${Math.round(drop * 100)} percent.`,
@@ -123,36 +195,35 @@ const activityCollapsed: Rule = ({ users, window: w }) => {
  * every week and the panel would stop being read.
  */
 const draftShellBacklog: Rule = ({ users, window: w }) => {
-  const stuck = users.filter(
-    (u) =>
-      !u.disposable &&
-      u.verified &&
-      u.inOrg &&
-      u.activatedDay === null &&
-      u.signupDay <= addDays(w.today, -7),
-  );
-  if (stuck.length < 3) return null;
+  // Rewindable exactly: an account was stuck on a given day if it existed a
+  // week before that day and had not been activated by it.
+  const stuckOn = (asOf: string) =>
+    users.filter(
+      (u) =>
+        !u.disposable &&
+        u.verified &&
+        u.inOrg &&
+        (u.activatedDay === null || u.activatedDay > asOf) &&
+        u.signupDay <= addDays(asOf, -7),
+    ).length;
 
-  const addedThisWeek = users.filter(
-    (u) =>
-      !u.disposable &&
-      u.verified &&
-      u.inOrg &&
-      u.activatedDay === null &&
-      within(u.signupDay, addDays(w.today, -13), addDays(w.today, -7)),
-  ).length;
+  const { now, change } = movement(stuckOn, w.today);
+  if (now < 3) return null;
 
   return {
     id: "draft-shell-backlog",
-    severity: Math.min(75, 30 + stuck.length + addedThisWeek * 4),
+    severity: chronicSeverity({ base: 30, now, per: 8, change, ceiling: 75 }),
+    kind: "chronic",
     tone: "act",
-    headline: `${stuck.length} verified accounts never named their organisation`,
+    headline: `${now} verified accounts never named their organisation`,
     detail:
-      addedThisWeek > 0
-        ? `${addedThisWeek} of them arrived in the week before last, so the backlog is still growing.`
-        : "The backlog stopped growing this week, but nobody worked it down either.",
+      change === 0
+        ? "Unchanged on last week: none arrived, none were worked down."
+        : `${movementPhrase(change)}.`,
     action:
-      "The activation nudge on the Emails tab was built for exactly these people. Review the queue and send a batch.",
+      change < 0
+        ? "It is moving. The activation nudge on the Emails tab is the lever; keep sending batches."
+        : "The activation nudge on the Emails tab was built for exactly these people. Review the queue and send a batch.",
   };
 };
 
@@ -164,21 +235,26 @@ const draftShellBacklog: Rule = ({ users, window: w }) => {
  * already know what the product is and got far enough to use it.
  */
 const stalledWorkers: Rule = ({ users, window: w }) => {
-  const stalled = users.filter((u) => {
-    if (u.disposable || u.workEvents === 0 || u.signOffs > 0) return false;
-    const last = u.activeDays[u.activeDays.length - 1];
-    if (last === undefined) return false;
-    return last < addDays(w.today, -13) && last >= addDays(w.today, -60);
-  });
-  if (stalled.length < 2) return null;
+  // Rewindable exactly: activity is a list of days, so "had this person been
+  // quiet a fortnight as of last Monday" is answerable from the same facts.
+  const stalledOn = (asOf: string) =>
+    users.filter((u) => {
+      if (u.disposable || u.workEvents === 0 || u.signOffs > 0) return false;
+      const lastByThen = u.activeDays.filter((day) => day <= asOf).at(-1);
+      if (lastByThen === undefined) return false;
+      return lastByThen < addDays(asOf, -13) && lastByThen >= addDays(asOf, -60);
+    }).length;
+
+  const { now, change } = movement(stalledOn, w.today);
+  if (now < 2) return null;
 
   return {
     id: "stalled-workers",
-    severity: Math.min(80, 35 + stalled.length * 3),
+    severity: chronicSeverity({ base: 35, now, per: 3, change, ceiling: 80 }),
+    kind: "chronic",
     tone: "act",
-    headline: `${stalled.length} people started work and went quiet`,
-    detail:
-      "Each did something in the platform, nothing in the last two weeks, and has never signed a requirement off.",
+    headline: `${now} people started work and went quiet`,
+    detail: `Each did something, nothing in the last two weeks, and has never signed a requirement off. ${movementPhrase(change, true)}.`,
     action:
       "Warmest list you have. Ask one of them what stopped them before writing any new copy.",
   };
@@ -205,7 +281,12 @@ const courseFinishersIdle: Rule = ({ users }) => {
 
   return {
     id: "course-finishers-idle",
-    severity: Math.min(78, 30 + idle.length * 4),
+    // Ceiling below the rewindable rules on purpose: complianceEvents is a
+    // lifetime counter, so this finding can never report movement and can
+    // never show progress. It is a standing backlog item, and a backlog item
+    // must not outrank a problem that visibly grew this week.
+    severity: Math.min(55, 25 + idle.length * 2),
+    kind: "chronic",
     tone: "act",
     headline: `${idle.length} course finishers have never used the platform`,
     detail: `${idle.length} of ${finishers} people who completed a course did no work afterwards (${percent(idle.length, finishers)}).`,
@@ -233,7 +314,9 @@ const supplierQuestionnaireGap: Rule = ({ companies, window: w }) => {
 
   return {
     id: "supplier-questionnaire-gap",
-    severity: Math.min(70, 25 + due.length * 5 + untouched * 5),
+    // Same ceiling reasoning: the questionnaire percentage is current-only.
+    severity: Math.min(50, 20 + due.length * 4 + untouched * 4),
+    kind: "chronic",
     tone: untouched > 0 ? "act" : "watch",
     headline: `${due.length} supplier profiles are still unfinished`,
     detail:
@@ -261,7 +344,8 @@ const signOffDrought: Rule = ({ work, window: w }) => {
 
   return {
     id: "signoff-drought",
-    severity: 60,
+    severity: 50,
+    kind: "chronic",
     tone: "watch",
     headline: "Requirements are being completed but nothing is signed off",
     detail: `${completed} requirements marked complete in the last fortnight, zero sign-offs.`,
@@ -297,6 +381,7 @@ const activationRateFalling: Rule = ({ users, window: w }) => {
   return {
     id: "activation-rate-falling",
     severity: Math.min(85, 40 + Math.round((1 - now / then) * 50)),
+    kind: "acute",
     tone: "act",
     headline: "The latest signups are converting worse than the batch before",
     detail: `${Math.round(now * 100)} percent of the last ${recent.length} signups named an organisation, against ${Math.round(then * 100)} percent of the ${before.length} before them.`,
@@ -319,6 +404,7 @@ const growthUp: Rule = ({ users, window: w }) => {
   return {
     id: "growth-up",
     severity: 40,
+    kind: "acute",
     tone: "good",
     headline: "Signups were well up on the last four weeks",
     detail: `${now} new accounts this week against a four-week average of ${baseline.toFixed(1)}.`,
@@ -345,6 +431,7 @@ const signOffsHappened: Rule = ({ work, window: w }) => {
   return {
     id: "signoffs-resumed",
     severity: 45,
+    kind: "acute",
     tone: "good",
     headline: "Someone signed off a requirement for the first time in a month",
     detail: `${signedThisWeek} sign-off${signedThisWeek === 1 ? "" : "s"} this week, after four quiet weeks.`,
@@ -372,7 +459,28 @@ const RULES: Rule[] = [
 /** How many the panel will ever show. */
 export const MAX_INSIGHTS = 3;
 
-export function weeklyInsights(
+/**
+ * At most one standing problem on the panel at a time.
+ *
+ * Against real numbers every chronic rule fires at once and they are all
+ * large, so ranking on severity alone filled all three slots with the same
+ * findings every week: 224 accounts on a draft shell, 42 idle course
+ * finishers, N stalled workers, none of which changes between Mondays. Two of
+ * those slots said nothing the third had not. Capping chronic findings keeps
+ * room for whatever actually happened this week, and the one that does appear
+ * is the most severe, so nothing important is hidden — it is one line down the
+ * page instead of three lines of the same news.
+ */
+const MAX_CHRONIC = 1;
+
+/**
+ * Every rule that fired, most severe first, before the panel's caps.
+ *
+ * Separate from the choosing below because they are different jobs: one asks
+ * what is true, the other decides what is worth three lines of someone's
+ * Monday. Exported so the caps can be tested against the full set.
+ */
+export function allInsights(
   users: UserFact[],
   companies: CompanyFact[],
   work: DailyWorkRow[],
@@ -381,8 +489,28 @@ export function weeklyInsights(
   const facts: Facts = { users, companies, work, window: buildWindow(today) };
   return RULES.map((rule) => rule(facts))
     .filter((insight): insight is Insight => insight !== null)
-    .sort((a, b) => b.severity - a.severity)
-    .slice(0, MAX_INSIGHTS);
+    .sort((a, b) => b.severity - a.severity);
+}
+
+export function weeklyInsights(
+  users: UserFact[],
+  companies: CompanyFact[],
+  work: DailyWorkRow[],
+  today: string,
+): Insight[] {
+  const found = allInsights(users, companies, work, today);
+
+  const chosen: Insight[] = [];
+  let chronic = 0;
+  for (const insight of found) {
+    if (chosen.length === MAX_INSIGHTS) break;
+    if (insight.kind === "chronic") {
+      if (chronic === MAX_CHRONIC) continue;
+      chronic += 1;
+    }
+    chosen.push(insight);
+  }
+  return chosen;
 }
 
 /** The window the panel reports on, for the card's subtitle. */


### PR DESCRIPTION
I could not read production, so I built a dataset with production's **shape** from the figures in the notebook (335 registered / 118 activated orgs at 17.08, 203 course starts / 42 completions at 04.09) and ran the rules against it. The panel as shipped repeats itself.

**Before**, a typical week:

```
[80] stalled-workers          15 people started work and went quiet
[78] course-finishers-idle    42 course finishers have never used the platform
[75] draft-shell-backlog      224 verified accounts never named their organisation
```

All three chronic. All three identical next Monday, and the Monday after. Even in a week where activity collapsed to zero, two of the three slots were still those same lines.

**After**:

```
typical week   [73] draft-shell-backlog · [65] activity-down
dead week      [95] activity-zero       · [73] draft-shell-backlog
```

## Three changes

**At most one standing problem per panel.** Findings are tagged `acute` (something happened in the window) or `chronic` (a standing population), and only one chronic takes a slot. The one shown is the most severe, so nothing is hidden — it is one line rather than three lines of the same news — and the rest of the panel stays free for whatever actually changed.

**Chronic findings report movement.** The draft-shell backlog and the stalled-worker count are rewound seven days from the same facts and reported as a delta: "6 more than last week", "28 fewer than last week". No stored history: signup day and activation day are both dates, so last Monday's number is answerable today. Done only where the rewind is exact — rules whose inputs are current-only counters keep reporting a level and say nothing about movement, because a guessed delta is worse than none.

**Severity is symmetric.** The first version rewarded growth but did not penalise shrinkage, so a backlog being actively worked down scored the same as one nobody had touched — acting on a finding changed nothing about what the panel said. Now:

| Week | Severity | Detail | Advice |
|---|---|---|---|
| 6 arrived | 75 | "6 more than last week" | Review the queue and send a batch |
| nothing moved | 58 | "Unchanged on last week" | Review the queue and send a batch |
| 30 activated after a nudge batch | 55 | "28 fewer than last week" | **"It is moving."** Keep sending batches |

That is the point of the whole panel: send the batch, and next Monday it tells you it worked.

Unmeasurable findings also get lower ceilings than rewindable ones. `course-finishers-idle` sat at a flat 78 and permanently owned the chronic slot while a 224-person backlog was never seen. A finding that can never show progress is a backlog item, not weekly news.

## Also

Rule evaluation is split from selection (`allInsights` / `weeklyInsights`) — different jobs, and the caps can now be tested against the full set rather than against a hard-coded winner.

## Verification

Typecheck clean, biome clean, 397 unit tests pass (18 in this file, up from 16). New tests cover the chronic cap, that a standing problem never crowds out something acute, and that rising outranks flat outranks falling.

Checked by running the rules and reading their output, not by re-rendering: `InsightsCard` is untouched and the only visual difference is a shorter list, which was already verified at three items and at zero.

The thresholds are still estimates against a modelled dataset. First real production week is the thing that will confirm or move them.